### PR TITLE
feat: implement M1 policy engine and M2 audit logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = []
+dependencies = [
+    "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -37,6 +39,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "ruff>=0.8",
     "mypy>=1.13",
+    "types-PyYAML>=6.0",
 ]
 
 [project.urls]

--- a/src/agentguard/__init__.py
+++ b/src/agentguard/__init__.py
@@ -1,3 +1,12 @@
 """AgentGuard -- Safety and audit framework for autonomous AI agents."""
 
+from agentguard.audit.log import AuditLog
+from agentguard.policies.guard import Guard
+
 __version__ = "0.1.0"
+
+__all__ = [
+    "AuditLog",
+    "Guard",
+    "__version__",
+]

--- a/src/agentguard/audit/__init__.py
+++ b/src/agentguard/audit/__init__.py
@@ -1,1 +1,9 @@
 """Audit logging for agent actions and decisions."""
+
+from agentguard.audit.log import AuditLog
+from agentguard.audit.models import AuditEntry
+
+__all__ = [
+    "AuditEntry",
+    "AuditLog",
+]

--- a/src/agentguard/audit/log.py
+++ b/src/agentguard/audit/log.py
@@ -1,0 +1,196 @@
+"""Hash-chained audit log with JSONL backend and query API.
+
+Provides the AuditLog class that records agent actions in a
+tamper-evident, append-only log with hash chaining.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentguard.audit.models import AuditEntry
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class AuditLog:
+    """Hash-chained, append-only audit log.
+
+    Records agent actions with automatic hash chaining for
+    tamper detection. Supports JSONL file persistence and
+    querying by action, actor, result, and time range.
+
+    Usage::
+
+        log = AuditLog("agent-session-001")
+        log.record(
+            action="file_write", actor="agent",
+            target="main.py", result="allowed",
+        )
+        log.save("audit.jsonl")
+        assert log.verify()
+    """
+
+    def __init__(self, session_id: str) -> None:
+        """Initialize an audit log.
+
+        Args:
+            session_id: Identifier for this agent session.
+        """
+        self._session_id = session_id
+        self._entries: list[AuditEntry] = []
+
+    @property
+    def session_id(self) -> str:
+        """Return the session identifier."""
+        return self._session_id
+
+    @property
+    def entries(self) -> list[AuditEntry]:
+        """Return a copy of the entries list."""
+        return list(self._entries)
+
+    def record(
+        self,
+        action: str,
+        actor: str,
+        target: str,
+        result: str,
+        metadata: dict[str, str] | None = None,
+    ) -> AuditEntry:
+        """Record a new audit entry.
+
+        The entry is automatically chained to the previous entry's hash.
+
+        Args:
+            action: Type of action (e.g. "shell_command").
+            actor: Agent identifier.
+            target: What the action targeted.
+            result: Outcome ("allowed", "denied", etc.).
+            metadata: Optional additional data.
+
+        Returns:
+            The newly created AuditEntry.
+        """
+        previous_hash = self._entries[-1].entry_hash if self._entries else None
+        entry = AuditEntry(
+            action=action,
+            actor=actor,
+            target=target,
+            result=result,
+            previous_hash=previous_hash,
+            metadata=metadata,
+        )
+        self._entries.append(entry)
+        return entry
+
+    def save(self, path: str | Path) -> None:
+        """Save the audit log to a JSONL file.
+
+        Each entry is written as a single JSON line.
+
+        Args:
+            path: File path to write to.
+        """
+        file_path = Path(path)
+        with file_path.open("w", encoding="utf-8") as f:
+            for entry in self._entries:
+                line = json.dumps(entry.to_dict(), ensure_ascii=True)
+                f.write(line + "\n")
+
+    @classmethod
+    def load(cls, path: str | Path, session_id: str) -> AuditLog:
+        """Load an audit log from a JSONL file.
+
+        Args:
+            path: File path to read from.
+            session_id: Session identifier for the loaded log.
+
+        Returns:
+            An AuditLog populated with entries from the file.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        file_path = Path(path)
+        if not file_path.exists():
+            msg = f"Audit log file not found: {file_path}"
+            raise FileNotFoundError(msg)
+
+        log = cls(session_id=session_id)
+        with file_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                entry = AuditEntry.from_dict(data)
+                log._entries.append(entry)
+        return log
+
+    def verify(self) -> bool:
+        """Verify the integrity of the hash chain.
+
+        Checks that:
+        1. Each entry's hash matches its content.
+        2. Each entry's previous_hash matches the prior entry's hash.
+
+        Returns:
+            True if the chain is intact, False if tampered.
+        """
+        for i, entry in enumerate(self._entries):
+            # Verify the entry hash matches the content
+            expected_hash = entry._compute_hash()
+            if entry.entry_hash != expected_hash:
+                return False
+
+            # Verify the chain link
+            if i == 0:
+                if entry.previous_hash is not None:
+                    return False
+            else:
+                if entry.previous_hash != self._entries[i - 1].entry_hash:
+                    return False
+
+        return True
+
+    def query(
+        self,
+        action: str | None = None,
+        actor: str | None = None,
+        result: str | None = None,
+        after: datetime | None = None,
+        before: datetime | None = None,
+    ) -> list[AuditEntry]:
+        """Query audit entries with optional filters.
+
+        All filters are AND-combined. Entries must match ALL specified
+        criteria.
+
+        Args:
+            action: Filter by action type.
+            actor: Filter by actor identifier.
+            result: Filter by result string.
+            after: Only entries after this timestamp.
+            before: Only entries before this timestamp.
+
+        Returns:
+            List of matching AuditEntry objects.
+        """
+        results: list[AuditEntry] = []
+        for entry in self._entries:
+            if action is not None and entry.action != action:
+                continue
+            if actor is not None and entry.actor != actor:
+                continue
+            if result is not None and entry.result != result:
+                continue
+            if after is not None and entry.timestamp <= after:
+                continue
+            if before is not None and entry.timestamp >= before:
+                continue
+            results.append(entry)
+        return results

--- a/src/agentguard/audit/models.py
+++ b/src/agentguard/audit/models.py
@@ -1,0 +1,101 @@
+"""Audit entry data model.
+
+AuditEntry represents a single logged event in the audit trail.
+Each entry is hashed for integrity verification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass
+class AuditEntry:
+    """A single entry in the audit log.
+
+    Each entry records an agent action with its context and result.
+    The entry_hash provides integrity verification; when chained with
+    previous_hash, entries form a tamper-evident log.
+
+    Attributes:
+        action: The type of action (e.g. "shell_command", "file_write").
+        actor: Identifier of the agent that performed the action.
+        target: What the action targeted (command, file path, URL, etc.).
+        result: Outcome of the action ("allowed", "denied", "error", etc.).
+        timestamp: When the action occurred (UTC).
+        previous_hash: Hash of the preceding entry (None for first entry).
+        metadata: Additional key-value data for the entry.
+        entry_hash: SHA-256 hash of this entry's content.
+    """
+
+    action: str
+    actor: str
+    target: str
+    result: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    previous_hash: str | None = None
+    metadata: dict[str, str] | None = None
+    entry_hash: str = field(default="", init=True)
+
+    def __post_init__(self) -> None:
+        """Compute the entry hash if not already set."""
+        if not self.entry_hash:
+            self.entry_hash = self._compute_hash()
+
+    def _compute_hash(self) -> str:
+        """Compute SHA-256 hash of entry content."""
+        content = {
+            "action": self.action,
+            "actor": self.actor,
+            "target": self.target,
+            "result": self.result,
+            "timestamp": self.timestamp.isoformat(),
+            "previous_hash": self.previous_hash,
+            "metadata": self.metadata,
+        }
+        raw = json.dumps(content, sort_keys=True, ensure_ascii=True)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary (for JSON output).
+
+        Returns:
+            Dictionary representation of this entry.
+        """
+        d: dict[str, Any] = {
+            "action": self.action,
+            "actor": self.actor,
+            "target": self.target,
+            "result": self.result,
+            "timestamp": self.timestamp.isoformat(),
+            "previous_hash": self.previous_hash,
+            "entry_hash": self.entry_hash,
+        }
+        if self.metadata is not None:
+            d["metadata"] = self.metadata
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AuditEntry:
+        """Deserialize from a dictionary.
+
+        Args:
+            data: Dictionary with entry fields.
+
+        Returns:
+            An AuditEntry instance.
+        """
+        return cls(
+            action=data["action"],
+            actor=data["actor"],
+            target=data["target"],
+            result=data["result"],
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+            previous_hash=data.get("previous_hash"),
+            metadata=data.get("metadata"),
+            entry_hash=data.get("entry_hash", ""),
+        )

--- a/src/agentguard/policies/__init__.py
+++ b/src/agentguard/policies/__init__.py
@@ -1,1 +1,20 @@
 """Policy engine for defining and enforcing agent behavior rules."""
+
+from agentguard.policies.builtins import list_builtins, load_all_builtins, load_builtin
+from agentguard.policies.guard import Guard
+from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
+from agentguard.policies.models import Action, Decision, Policy, Rule, Severity
+
+__all__ = [
+    "Action",
+    "Decision",
+    "Guard",
+    "Policy",
+    "Rule",
+    "Severity",
+    "list_builtins",
+    "load_all_builtins",
+    "load_builtin",
+    "load_policy_from_string",
+    "load_policy_from_yaml",
+]

--- a/src/agentguard/policies/builtin_policies/no-data-deletion.yaml
+++ b/src/agentguard/policies/builtin_policies/no-data-deletion.yaml
@@ -1,0 +1,17 @@
+name: no-data-deletion
+description: Prevent destructive data operations (file deletion, database drops)
+rules:
+  - action: shell_command
+    description: Block recursive file deletion
+    deny:
+      - pattern: 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f'
+      - pattern: 'rm\s+-[a-zA-Z]*f[a-zA-Z]*r'
+      - pattern: 'rm\s+--force'
+    severity: critical
+  - action: shell_command
+    description: Block destructive database operations
+    deny:
+      - pattern: 'DROP\s+(DATABASE|TABLE|SCHEMA)'
+      - pattern: 'TRUNCATE\s+TABLE'
+      - pattern: 'DELETE\s+FROM\s+\S+\s*$'
+    severity: critical

--- a/src/agentguard/policies/builtin_policies/no-force-push.yaml
+++ b/src/agentguard/policies/builtin_policies/no-force-push.yaml
@@ -1,0 +1,11 @@
+name: no-force-push
+description: Prevent destructive git operations that rewrite history
+rules:
+  - action: shell_command
+    description: Block force push, hard reset, and branch deletion
+    deny:
+      - pattern: 'git push\s+.*--force'
+      - pattern: 'git push\s+-f\b'
+      - pattern: 'git reset\s+--hard'
+      - pattern: 'git branch\s+-D\b'
+    severity: critical

--- a/src/agentguard/policies/builtin_policies/no-secret-exposure.yaml
+++ b/src/agentguard/policies/builtin_policies/no-secret-exposure.yaml
@@ -1,0 +1,22 @@
+name: no-secret-exposure
+description: Prevent writing secrets, credentials, or API keys to files
+rules:
+  - action: file_write
+    description: Block writing to known secret file paths
+    deny:
+      - pattern: '\.env$'
+      - pattern: '\.env\.'
+      - pattern: 'credentials'
+      - pattern: '\.pem$'
+      - pattern: '\.key$'
+      - pattern: 'id_rsa'
+    severity: critical
+  - action: file_write
+    description: Block writing content containing API keys or tokens
+    deny:
+      - pattern: 'API_KEY\s*='
+      - pattern: 'SECRET_KEY\s*='
+      - pattern: 'AWS_SECRET_ACCESS_KEY'
+      - pattern: 'PRIVATE_KEY'
+      - pattern: 'sk-[a-zA-Z0-9]{20,}'
+    severity: high

--- a/src/agentguard/policies/builtins.py
+++ b/src/agentguard/policies/builtins.py
@@ -1,0 +1,57 @@
+"""Built-in policy loader.
+
+Provides access to AgentGuard's bundled policy definitions:
+- no-force-push: Prevent destructive git operations
+- no-secret-exposure: Prevent writing secrets/credentials
+- no-data-deletion: Prevent destructive data operations
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentguard.policies.loader import load_policy_from_yaml
+
+if TYPE_CHECKING:
+    from agentguard.policies.models import Policy
+
+_BUILTIN_DIR = Path(__file__).parent / "builtin_policies"
+
+
+def list_builtins() -> list[str]:
+    """List the names of all available built-in policies.
+
+    Returns:
+        Sorted list of built-in policy names.
+    """
+    return sorted(p.stem for p in _BUILTIN_DIR.glob("*.yaml"))
+
+
+def load_builtin(name: str) -> Policy:
+    """Load a built-in policy by name.
+
+    Args:
+        name: The name of the built-in policy (e.g. "no-force-push").
+
+    Returns:
+        The loaded Policy object.
+
+    Raises:
+        ValueError: If no built-in policy with that name exists.
+    """
+    path = _BUILTIN_DIR / f"{name}.yaml"
+    if not path.exists():
+        available = ", ".join(list_builtins())
+        msg = f"No built-in policy named '{name}'. Available: {available}"
+        raise ValueError(msg)
+    return load_policy_from_yaml(path)
+
+
+def load_all_builtins() -> list[Policy]:
+    """Load all built-in policies.
+
+    Returns:
+        List of all built-in Policy objects.
+    """
+    return [load_builtin(name) for name in list_builtins()]

--- a/src/agentguard/policies/guard.py
+++ b/src/agentguard/policies/guard.py
@@ -1,0 +1,100 @@
+"""Guard: the central policy enforcement point.
+
+The Guard class loads and manages policies, and evaluates agent actions
+against all loaded policies. It's the main public API for AgentGuard's
+policy engine.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
+from agentguard.policies.models import Action, Decision, Policy
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class Guard:
+    """Central policy enforcement point.
+
+    A Guard manages a collection of policies and checks agent actions
+    against all of them. The first policy that denies an action wins.
+
+    Usage::
+
+        guard = Guard()
+        guard.add_policy(my_policy)
+        result = guard.check("shell_command", command="rm -rf /")
+        if result.denied:
+            print(result.reason)
+    """
+
+    def __init__(self, policies: list[Policy] | None = None) -> None:
+        """Initialize a Guard.
+
+        Args:
+            policies: Optional list of policies to start with.
+        """
+        self._policies: list[Policy] = list(policies) if policies else []
+
+    @property
+    def policies(self) -> list[Policy]:
+        """Return the list of loaded policies."""
+        return self._policies
+
+    def add_policy(self, policy: Policy) -> Guard:
+        """Add a policy to the guard.
+
+        Args:
+            policy: The policy to add.
+
+        Returns:
+            Self, for method chaining.
+        """
+        self._policies.append(policy)
+        return self
+
+    def load_policy_string(self, yaml_str: str) -> Guard:
+        """Load a policy from a YAML string and add it.
+
+        Args:
+            yaml_str: YAML-formatted policy definition.
+
+        Returns:
+            Self, for method chaining.
+        """
+        policy = load_policy_from_string(yaml_str)
+        self._policies.append(policy)
+        return self
+
+    def load_policy_file(self, path: str | Path) -> Guard:
+        """Load a policy from a YAML file and add it.
+
+        Args:
+            path: Path to the YAML policy file.
+
+        Returns:
+            Self, for method chaining.
+        """
+        policy = load_policy_from_yaml(path)
+        self._policies.append(policy)
+        return self
+
+    def check(self, action_kind: str, **params: str) -> Decision:
+        """Check an action against all loaded policies.
+
+        Args:
+            action_kind: The type of action (e.g. "shell_command").
+            **params: Key-value parameters for the action.
+
+        Returns:
+            A Decision indicating whether the action is allowed or denied.
+        """
+        action = Action(kind=action_kind, params=params)
+        for policy in self._policies:
+            decision = policy.evaluate(action)
+            if decision.denied:
+                return decision
+        return Decision(allowed=True)

--- a/src/agentguard/policies/loader.py
+++ b/src/agentguard/policies/loader.py
@@ -1,0 +1,134 @@
+"""YAML policy loader and validator.
+
+Parses YAML policy definitions into Policy objects. Validates structure,
+required fields, regex patterns, and severity values.
+
+Zero external dependencies — uses Python's built-in yaml support via
+the standard library. (PyYAML is a dependency, but it's ubiquitous.)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agentguard.policies.models import Policy, Rule, Severity
+
+
+def load_policy_from_string(yaml_str: str) -> Policy:
+    """Parse a YAML string into a Policy object.
+
+    Args:
+        yaml_str: YAML-formatted policy definition.
+
+    Returns:
+        A validated Policy object.
+
+    Raises:
+        ValueError: If the YAML is missing required fields or has
+            invalid values.
+    """
+    data = yaml.safe_load(yaml_str)
+    if not isinstance(data, dict):
+        msg = "Policy YAML must be a mapping"
+        raise ValueError(msg)
+    return _parse_policy(data)
+
+
+def load_policy_from_yaml(path: str | Path) -> Policy:
+    """Load a policy from a YAML file.
+
+    Args:
+        path: Path to the YAML file (str or Path).
+
+    Returns:
+        A validated Policy object.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the YAML is missing required fields or has
+            invalid values.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        msg = f"Policy file not found: {file_path}"
+        raise FileNotFoundError(msg)
+    text = file_path.read_text(encoding="utf-8")
+    return load_policy_from_string(text)
+
+
+def _parse_policy(data: dict[str, Any]) -> Policy:
+    """Parse and validate a policy dict."""
+    if "name" not in data:
+        msg = "Policy must have a 'name' field"
+        raise ValueError(msg)
+
+    if "rules" not in data or not data["rules"]:
+        msg = "Policy must have a non-empty 'rules' field"
+        raise ValueError(msg)
+
+    rules = [_parse_rule(r) for r in data["rules"]]
+    return Policy(
+        name=data["name"],
+        description=data.get("description"),
+        rules=rules,
+    )
+
+
+def _parse_rule(data: Any) -> Rule:
+    """Parse and validate a single rule dict."""
+    if not isinstance(data, dict):
+        msg = "Each rule must be a mapping"
+        raise ValueError(msg)
+
+    if "action" not in data:
+        msg = "Each rule must have an 'action' field"
+        raise ValueError(msg)
+
+    if "deny" not in data or not data["deny"]:
+        msg = "Each rule must have a non-empty 'deny' field"
+        raise ValueError(msg)
+
+    if "severity" not in data:
+        msg = "Each rule must have a 'severity' field"
+        raise ValueError(msg)
+
+    severity = _parse_severity(data["severity"])
+    patterns = [_parse_pattern(p) for p in data["deny"]]
+
+    return Rule(
+        action_kind=data["action"],
+        deny_patterns=patterns,
+        severity=severity,
+        description=data.get("description"),
+    )
+
+
+def _parse_severity(value: str) -> Severity:
+    """Parse a severity string into a Severity enum."""
+    try:
+        return Severity(value)
+    except ValueError:
+        valid = ", ".join(s.value for s in Severity)
+        msg = f"Invalid severity '{value}'. Valid values: {valid}"
+        raise ValueError(msg) from None
+
+
+def _parse_pattern(data: Any) -> re.Pattern[str]:
+    """Parse a deny pattern entry into a compiled regex."""
+    if not isinstance(data, dict):
+        msg = "Each deny entry must be a mapping with a 'pattern' key"
+        raise ValueError(msg)
+
+    if "pattern" not in data:
+        msg = "Each deny entry must have a 'pattern' key"
+        raise ValueError(msg)
+
+    try:
+        return re.compile(data["pattern"])
+    except re.error as e:
+        msg = f"Invalid regex pattern '{data['pattern']}': {e}"
+        raise ValueError(msg) from e

--- a/src/agentguard/policies/models.py
+++ b/src/agentguard/policies/models.py
@@ -1,0 +1,146 @@
+"""Policy data models: Severity, Action, Rule, Decision, Policy.
+
+These are the core types used throughout the AgentGuard policy engine.
+All are immutable (frozen dataclasses or enums) for safety.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import re
+
+
+class Severity(enum.Enum):
+    """Risk severity level for a policy rule.
+
+    Severities are ordered: LOW < MEDIUM < HIGH < CRITICAL.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Severity):
+            return NotImplemented
+        order = list(Severity)
+        return order.index(self) < order.index(other)
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, Severity):
+            return NotImplemented
+        return self == other or self.__lt__(other)
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, Severity):
+            return NotImplemented
+        order = list(Severity)
+        return order.index(self) > order.index(other)
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, Severity):
+            return NotImplemented
+        return self == other or self.__gt__(other)
+
+
+@dataclass(frozen=True)
+class Action:
+    """An action an agent wants to perform.
+
+    Attributes:
+        kind: The type of action (e.g., "shell_command", "file_write").
+        params: Key-value parameters for the action.
+    """
+
+    kind: str
+    params: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Rule:
+    """A deny rule within a policy.
+
+    A rule matches an action if:
+    1. The action's kind matches the rule's action_kind
+    2. Any of the rule's deny_patterns match any string value in the
+       action's params
+
+    Attributes:
+        action_kind: The kind of action this rule applies to.
+        deny_patterns: Compiled regex patterns. If any matches any
+            param value, the action is denied.
+        severity: How severe a violation of this rule is.
+        description: Optional human-readable description.
+    """
+
+    action_kind: str
+    deny_patterns: list[re.Pattern[str]]
+    severity: Severity
+    description: str | None = None
+
+    def matches(self, action: Action) -> bool:
+        """Check if this rule matches the given action."""
+        if action.kind != self.action_kind:
+            return False
+        for pattern in self.deny_patterns:
+            for value in action.params.values():
+                if isinstance(value, str) and pattern.search(value):
+                    return True
+        return False
+
+
+@dataclass(frozen=True)
+class Decision:
+    """The result of evaluating an action against a policy.
+
+    Attributes:
+        allowed: Whether the action is allowed.
+        denied_by: Name of the policy that denied it (if denied).
+        reason: Human-readable explanation (if denied).
+        severity: Severity of the violated rule (if denied).
+    """
+
+    allowed: bool
+    denied_by: str | None = None
+    reason: str | None = None
+    severity: Severity | None = None
+
+    @property
+    def denied(self) -> bool:
+        """Convenience: True if the action was denied."""
+        return not self.allowed
+
+
+@dataclass
+class Policy:
+    """A named collection of rules that govern agent behavior.
+
+    Attributes:
+        name: Unique identifier for this policy.
+        description: Human-readable description.
+        rules: List of deny rules. First match wins.
+    """
+
+    name: str
+    rules: list[Rule]
+    description: str | None = None
+
+    def evaluate(self, action: Action) -> Decision:
+        """Evaluate an action against all rules in this policy.
+
+        Returns the first matching rule's decision, or allows if none match.
+        """
+        for rule in self.rules:
+            if rule.matches(action):
+                return Decision(
+                    allowed=False,
+                    denied_by=self.name,
+                    reason=f"Blocked by policy: {self.name}",
+                    severity=rule.severity,
+                )
+        return Decision(allowed=True)

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,494 @@
+"""Tests for audit logging (M2.1-M2.5).
+
+Covers:
+- AuditEntry data model (M2.1)
+- Hash-chained append-only log (M2.2)
+- File-based JSONL backend (M2.3)
+- Integrity verification (M2.4)
+- Query API (M2.5)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agentguard.audit.log import AuditLog
+from agentguard.audit.models import AuditEntry
+
+
+class TestAuditEntry:
+    """M2.1: AuditEntry data model."""
+
+    def test_create_entry(self) -> None:
+        entry = AuditEntry(
+            action="shell_command",
+            actor="agent-001",
+            target="git push origin main",
+            result="allowed",
+        )
+        assert entry.action == "shell_command"
+        assert entry.actor == "agent-001"
+        assert entry.target == "git push origin main"
+        assert entry.result == "allowed"
+
+    def test_entry_has_timestamp(self) -> None:
+        before = datetime.now(tz=timezone.utc)
+        entry = AuditEntry(action="test", actor="a", target="t", result="ok")
+        after = datetime.now(tz=timezone.utc)
+        assert before <= entry.timestamp <= after
+
+    def test_entry_has_hash(self) -> None:
+        entry = AuditEntry(action="test", actor="a", target="t", result="ok")
+        assert entry.entry_hash is not None
+        assert isinstance(entry.entry_hash, str)
+        assert len(entry.entry_hash) == 64  # SHA-256 hex
+
+    def test_entry_hash_is_deterministic(self) -> None:
+        """Same data + same timestamp = same hash."""
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        e1 = AuditEntry(action="a", actor="b", target="c", result="d", timestamp=ts)
+        e2 = AuditEntry(action="a", actor="b", target="c", result="d", timestamp=ts)
+        assert e1.entry_hash == e2.entry_hash
+
+    def test_entry_hash_changes_with_data(self) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        e1 = AuditEntry(action="a", actor="b", target="c", result="d", timestamp=ts)
+        e2 = AuditEntry(action="X", actor="b", target="c", result="d", timestamp=ts)
+        assert e1.entry_hash != e2.entry_hash
+
+    def test_entry_has_previous_hash(self) -> None:
+        entry = AuditEntry(
+            action="test",
+            actor="a",
+            target="t",
+            result="ok",
+            previous_hash="abc123",
+        )
+        assert entry.previous_hash == "abc123"
+
+    def test_entry_default_previous_hash_is_none(self) -> None:
+        entry = AuditEntry(action="test", actor="a", target="t", result="ok")
+        assert entry.previous_hash is None
+
+    def test_entry_to_dict(self) -> None:
+        ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        entry = AuditEntry(
+            action="file_write",
+            actor="agent-1",
+            target="main.py",
+            result="denied",
+            timestamp=ts,
+            previous_hash="prev",
+        )
+        d = entry.to_dict()
+        assert d["action"] == "file_write"
+        assert d["actor"] == "agent-1"
+        assert d["target"] == "main.py"
+        assert d["result"] == "denied"
+        assert d["timestamp"] == "2026-01-01T12:00:00+00:00"
+        assert d["previous_hash"] == "prev"
+        assert "entry_hash" in d
+
+    def test_entry_from_dict(self) -> None:
+        ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        original = AuditEntry(
+            action="test",
+            actor="a",
+            target="t",
+            result="ok",
+            timestamp=ts,
+            previous_hash="prev",
+        )
+        restored = AuditEntry.from_dict(original.to_dict())
+        assert restored.action == original.action
+        assert restored.actor == original.actor
+        assert restored.target == original.target
+        assert restored.result == original.result
+        assert restored.timestamp == original.timestamp
+        assert restored.previous_hash == original.previous_hash
+        assert restored.entry_hash == original.entry_hash
+
+    def test_entry_with_metadata(self) -> None:
+        entry = AuditEntry(
+            action="test",
+            actor="a",
+            target="t",
+            result="ok",
+            metadata={"policy": "no-force-push", "severity": "critical"},
+        )
+        assert entry.metadata == {"policy": "no-force-push", "severity": "critical"}
+
+    def test_metadata_in_dict_roundtrip(self) -> None:
+        entry = AuditEntry(
+            action="test",
+            actor="a",
+            target="t",
+            result="ok",
+            metadata={"key": "value"},
+        )
+        restored = AuditEntry.from_dict(entry.to_dict())
+        assert restored.metadata == {"key": "value"}
+
+
+class TestAuditLogRecord:
+    """M2.2: Hash-chained append-only log."""
+
+    def test_record_returns_entry(self) -> None:
+        log = AuditLog(session_id="test-session")
+        entry = log.record(action="test", actor="a", target="t", result="ok")
+        assert isinstance(entry, AuditEntry)
+
+    def test_record_stores_entry(self) -> None:
+        log = AuditLog(session_id="test-session")
+        log.record(action="test", actor="a", target="t", result="ok")
+        assert len(log.entries) == 1
+
+    def test_first_entry_has_no_previous_hash(self) -> None:
+        log = AuditLog(session_id="test-session")
+        entry = log.record(action="test", actor="a", target="t", result="ok")
+        assert entry.previous_hash is None
+
+    def test_second_entry_chains_to_first(self) -> None:
+        log = AuditLog(session_id="test-session")
+        e1 = log.record(action="a1", actor="a", target="t", result="ok")
+        e2 = log.record(action="a2", actor="a", target="t", result="ok")
+        assert e2.previous_hash == e1.entry_hash
+
+    def test_chain_of_three_entries(self) -> None:
+        log = AuditLog(session_id="test-session")
+        e1 = log.record(action="a1", actor="a", target="t", result="ok")
+        e2 = log.record(action="a2", actor="a", target="t", result="ok")
+        e3 = log.record(action="a3", actor="a", target="t", result="ok")
+        assert e1.previous_hash is None
+        assert e2.previous_hash == e1.entry_hash
+        assert e3.previous_hash == e2.entry_hash
+
+    def test_session_id(self) -> None:
+        log = AuditLog(session_id="my-session")
+        assert log.session_id == "my-session"
+
+    def test_record_with_metadata(self) -> None:
+        log = AuditLog(session_id="test-session")
+        entry = log.record(
+            action="test",
+            actor="a",
+            target="t",
+            result="denied",
+            metadata={"policy": "no-force-push"},
+        )
+        assert entry.metadata == {"policy": "no-force-push"}
+
+    def test_entries_are_immutable_copy(self) -> None:
+        """entries property returns a copy, not the internal list."""
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        entries = log.entries
+        entries.clear()
+        assert len(log.entries) == 1  # internal state unchanged
+
+
+class TestAuditLogFile:
+    """M2.3: File-based JSONL backend."""
+
+    def test_save_creates_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        log.record(action="test", actor="a", target="t", result="ok")
+        log.save(log_file)
+        assert log_file.exists()
+
+    def test_save_writes_jsonl(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        log.save(log_file)
+        lines = log_file.read_text().strip().split("\n")
+        assert len(lines) == 2
+        # Each line is valid JSON
+        for line in lines:
+            data = json.loads(line)
+            assert "action" in data
+            assert "entry_hash" in data
+
+    def test_load_from_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t1", result="ok")
+        log.record(action="a2", actor="a", target="t2", result="denied")
+        log.save(log_file)
+
+        loaded = AuditLog.load(log_file, session_id="test-session")
+        assert len(loaded.entries) == 2
+        assert loaded.entries[0].action == "a1"
+        assert loaded.entries[1].action == "a2"
+
+    def test_load_preserves_chain(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        log.save(log_file)
+
+        loaded = AuditLog.load(log_file, session_id="test-session")
+        assert loaded.entries[1].previous_hash == loaded.entries[0].entry_hash
+
+    def test_append_to_existing_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.save(log_file)
+
+        # Load and add more entries
+        loaded = AuditLog.load(log_file, session_id="test-session")
+        loaded.record(action="a2", actor="a", target="t", result="ok")
+        loaded.save(log_file)
+
+        final = AuditLog.load(log_file, session_id="test-session")
+        assert len(final.entries) == 2
+
+    def test_load_nonexistent_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            AuditLog.load(Path("/nonexistent/audit.jsonl"), session_id="s")
+
+    def test_save_with_string_path(self, tmp_path: Path) -> None:
+        log_file = str(tmp_path / "audit.jsonl")
+        log = AuditLog(session_id="test-session")
+        log.record(action="test", actor="a", target="t", result="ok")
+        log.save(log_file)
+        assert Path(log_file).exists()
+
+
+class TestAuditLogVerify:
+    """M2.4: Integrity verification."""
+
+    def test_empty_log_verifies(self) -> None:
+        log = AuditLog(session_id="test-session")
+        assert log.verify() is True
+
+    def test_single_entry_verifies(self) -> None:
+        log = AuditLog(session_id="test-session")
+        log.record(action="test", actor="a", target="t", result="ok")
+        assert log.verify() is True
+
+    def test_chain_verifies(self) -> None:
+        log = AuditLog(session_id="test-session")
+        for i in range(5):
+            log.record(action=f"a{i}", actor="a", target="t", result="ok")
+        assert log.verify() is True
+
+    def test_tampered_entry_fails(self) -> None:
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        # Tamper with the first entry's hash
+        log._entries[0] = AuditEntry(
+            action="TAMPERED",
+            actor=log._entries[0].actor,
+            target=log._entries[0].target,
+            result=log._entries[0].result,
+            timestamp=log._entries[0].timestamp,
+            previous_hash=log._entries[0].previous_hash,
+        )
+        assert log.verify() is False
+
+    def test_broken_chain_fails(self) -> None:
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        # Replace second entry with wrong previous_hash
+        log._entries[1] = AuditEntry(
+            action="a2",
+            actor="a",
+            target="t",
+            result="ok",
+            timestamp=log._entries[1].timestamp,
+            previous_hash="wrong-hash",
+        )
+        assert log.verify() is False
+
+    def test_verify_after_save_load(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        for i in range(3):
+            log.record(action=f"a{i}", actor="a", target="t", result="ok")
+        log.save(log_file)
+
+        loaded = AuditLog.load(log_file, session_id="test-session")
+        assert loaded.verify() is True
+
+    def test_verify_tampered_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        log = AuditLog(session_id="test-session")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        log.save(log_file)
+
+        # Tamper with file: modify second line
+        lines = log_file.read_text().strip().split("\n")
+        data = json.loads(lines[1])
+        data["action"] = "TAMPERED"
+        lines[1] = json.dumps(data)
+        log_file.write_text("\n".join(lines) + "\n")
+
+        loaded = AuditLog.load(log_file, session_id="test-session")
+        assert loaded.verify() is False
+
+
+class TestAuditLogQuery:
+    """M2.5: Query API."""
+
+    def _make_log_with_entries(self) -> AuditLog:
+        log = AuditLog(session_id="test-session")
+        log.record(
+            action="shell_command",
+            actor="agent-1",
+            target="ls",
+            result="allowed",
+        )
+        log.record(
+            action="file_write",
+            actor="agent-2",
+            target="main.py",
+            result="denied",
+        )
+        log.record(
+            action="shell_command",
+            actor="agent-1",
+            target="git push",
+            result="allowed",
+        )
+        log.record(
+            action="api_call",
+            actor="agent-3",
+            target="https://api.example.com",
+            result="allowed",
+        )
+        log.record(
+            action="file_write",
+            actor="agent-1",
+            target="config.py",
+            result="denied",
+        )
+        return log
+
+    def test_query_by_action(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(action="shell_command")
+        assert len(results) == 2
+        assert all(e.action == "shell_command" for e in results)
+
+    def test_query_by_actor(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(actor="agent-1")
+        assert len(results) == 3
+        assert all(e.actor == "agent-1" for e in results)
+
+    def test_query_by_result(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(result="denied")
+        assert len(results) == 2
+        assert all(e.result == "denied" for e in results)
+
+    def test_query_combined_filters(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(action="file_write", result="denied")
+        assert len(results) == 2
+
+    def test_query_combined_actor_action(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(action="shell_command", actor="agent-1")
+        assert len(results) == 2
+
+    def test_query_no_match(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(action="nonexistent")
+        assert len(results) == 0
+
+    def test_query_no_filters_returns_all(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query()
+        assert len(results) == 5
+
+    def test_query_by_time_range(self) -> None:
+        log = AuditLog(session_id="test-session")
+        t1 = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t3 = datetime(2026, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
+
+        # Manually add entries with specific timestamps
+        log._entries.append(
+            AuditEntry(
+                action="a1",
+                actor="a",
+                target="t",
+                result="ok",
+                timestamp=t1,
+            )
+        )
+        log._entries.append(
+            AuditEntry(
+                action="a2",
+                actor="a",
+                target="t",
+                result="ok",
+                timestamp=t2,
+                previous_hash=log._entries[0].entry_hash,
+            )
+        )
+        log._entries.append(
+            AuditEntry(
+                action="a3",
+                actor="a",
+                target="t",
+                result="ok",
+                timestamp=t3,
+                previous_hash=log._entries[1].entry_hash,
+            )
+        )
+
+        after = datetime(2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+        before = datetime(2026, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+        results = log.query(after=after, before=before)
+        assert len(results) == 1
+        assert results[0].action == "a2"
+
+    def test_query_after_only(self) -> None:
+        log = AuditLog(session_id="test-session")
+        t1 = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
+        log._entries.append(
+            AuditEntry(
+                action="a1",
+                actor="a",
+                target="t",
+                result="ok",
+                timestamp=t1,
+            )
+        )
+        log._entries.append(
+            AuditEntry(
+                action="a2",
+                actor="a",
+                target="t",
+                result="ok",
+                timestamp=t2,
+                previous_hash=log._entries[0].entry_hash,
+            )
+        )
+
+        cutoff = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        results = log.query(after=cutoff)
+        assert len(results) == 1
+        assert results[0].action == "a2"
+
+    def test_query_returns_list_of_entries(self) -> None:
+        log = self._make_log_with_entries()
+        results = log.query(action="shell_command")
+        assert isinstance(results, list)
+        for entry in results:
+            assert isinstance(entry, AuditEntry)

--- a/tests/unit/test_builtins.py
+++ b/tests/unit/test_builtins.py
@@ -1,0 +1,180 @@
+"""Tests for built-in policies (M1.4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentguard.policies.builtins import (
+    list_builtins,
+    load_all_builtins,
+    load_builtin,
+)
+from agentguard.policies.models import Action, Policy
+
+
+class TestListBuiltins:
+    def test_returns_list_of_strings(self) -> None:
+        result = list_builtins()
+        assert isinstance(result, list)
+        for name in result:
+            assert isinstance(name, str)
+
+    def test_contains_expected_policies(self) -> None:
+        names = list_builtins()
+        assert "no-force-push" in names
+        assert "no-secret-exposure" in names
+        assert "no-data-deletion" in names
+
+
+class TestLoadBuiltin:
+    def test_load_no_force_push(self) -> None:
+        policy = load_builtin("no-force-push")
+        assert isinstance(policy, Policy)
+        assert policy.name == "no-force-push"
+
+    def test_load_no_secret_exposure(self) -> None:
+        policy = load_builtin("no-secret-exposure")
+        assert isinstance(policy, Policy)
+        assert policy.name == "no-secret-exposure"
+
+    def test_load_no_data_deletion(self) -> None:
+        policy = load_builtin("no-data-deletion")
+        assert isinstance(policy, Policy)
+        assert policy.name == "no-data-deletion"
+
+    def test_nonexistent_builtin_raises(self) -> None:
+        with pytest.raises(ValueError, match="not-a-real-policy"):
+            load_builtin("not-a-real-policy")
+
+
+class TestLoadAllBuiltins:
+    def test_returns_list_of_policies(self) -> None:
+        policies = load_all_builtins()
+        assert isinstance(policies, list)
+        assert len(policies) >= 3
+        for p in policies:
+            assert isinstance(p, Policy)
+
+    def test_all_names_match(self) -> None:
+        policies = load_all_builtins()
+        names = {p.name for p in policies}
+        assert "no-force-push" in names
+        assert "no-secret-exposure" in names
+        assert "no-data-deletion" in names
+
+
+class TestBuiltinPolicyBehavior:
+    """Verify each built-in policy actually blocks what it should."""
+
+    def test_no_force_push_blocks_force(self) -> None:
+        policy = load_builtin("no-force-push")
+        action = Action(
+            kind="shell_command",
+            params={"command": "git push --force origin main"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_force_push_allows_normal_push(self) -> None:
+        policy = load_builtin("no-force-push")
+        action = Action(
+            kind="shell_command",
+            params={"command": "git push origin main"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.allowed
+
+    def test_no_force_push_blocks_force_with_lease(self) -> None:
+        policy = load_builtin("no-force-push")
+        action = Action(
+            kind="shell_command",
+            params={"command": "git push --force-with-lease origin main"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_force_push_blocks_hard_reset(self) -> None:
+        policy = load_builtin("no-force-push")
+        action = Action(
+            kind="shell_command",
+            params={"command": "git reset --hard HEAD~3"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_force_push_blocks_branch_delete(self) -> None:
+        policy = load_builtin("no-force-push")
+        action = Action(
+            kind="shell_command",
+            params={"command": "git branch -D feature/test"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_secret_exposure_blocks_env_file(self) -> None:
+        policy = load_builtin("no-secret-exposure")
+        action = Action(kind="file_write", params={"path": "/app/.env"})
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_secret_exposure_blocks_aws_credentials(self) -> None:
+        policy = load_builtin("no-secret-exposure")
+        action = Action(
+            kind="file_write",
+            params={"path": "/home/user/.aws/credentials"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_secret_exposure_blocks_api_key_in_content(self) -> None:
+        policy = load_builtin("no-secret-exposure")
+        action = Action(
+            kind="file_write",
+            params={"path": "config.py", "content": 'API_KEY = "sk-abc123"'},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_secret_exposure_allows_normal_file(self) -> None:
+        policy = load_builtin("no-secret-exposure")
+        action = Action(
+            kind="file_write",
+            params={"path": "src/main.py", "content": "print('hello')"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.allowed
+
+    def test_no_data_deletion_blocks_rm_rf(self) -> None:
+        policy = load_builtin("no-data-deletion")
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_data_deletion_blocks_drop_database(self) -> None:
+        policy = load_builtin("no-data-deletion")
+        action = Action(
+            kind="shell_command",
+            params={"command": "DROP DATABASE production"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_data_deletion_blocks_truncate_table(self) -> None:
+        policy = load_builtin("no-data-deletion")
+        action = Action(
+            kind="shell_command",
+            params={"command": "TRUNCATE TABLE users"},
+        )
+        decision = policy.evaluate(action)
+        assert decision.denied
+
+    def test_no_data_deletion_allows_normal_commands(self) -> None:
+        policy = load_builtin("no-data-deletion")
+        action = Action(kind="shell_command", params={"command": "ls -la"})
+        decision = policy.evaluate(action)
+        assert decision.allowed
+
+    def test_all_builtins_have_severity(self) -> None:
+        for policy in load_all_builtins():
+            for rule in policy.rules:
+                assert rule.severity is not None

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -1,0 +1,200 @@
+"""Tests for the Guard class (M1.3)."""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from typing import TYPE_CHECKING
+
+from agentguard.policies.guard import Guard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from agentguard.policies.models import (
+    Decision,
+    Policy,
+    Rule,
+    Severity,
+)
+
+
+def _make_policy(
+    name: str = "test-policy",
+    action_kind: str = "shell_command",
+    pattern: str = "dangerous",
+    severity: Severity = Severity.HIGH,
+) -> Policy:
+    """Helper to create a simple single-rule policy."""
+    return Policy(
+        name=name,
+        rules=[
+            Rule(
+                action_kind=action_kind,
+                deny_patterns=[re.compile(pattern)],
+                severity=severity,
+            )
+        ],
+    )
+
+
+class TestGuardInit:
+    def test_empty_guard(self) -> None:
+        guard = Guard()
+        assert len(guard.policies) == 0
+
+    def test_guard_with_policies(self) -> None:
+        p1 = _make_policy("p1")
+        p2 = _make_policy("p2")
+        guard = Guard(policies=[p1, p2])
+        assert len(guard.policies) == 2
+
+
+class TestGuardAddPolicy:
+    def test_add_single_policy(self) -> None:
+        guard = Guard()
+        policy = _make_policy()
+        guard.add_policy(policy)
+        assert len(guard.policies) == 1
+        assert guard.policies[0] is policy
+
+    def test_add_multiple_policies(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy("p1"))
+        guard.add_policy(_make_policy("p2"))
+        assert len(guard.policies) == 2
+
+    def test_add_policy_returns_self_for_chaining(self) -> None:
+        guard = Guard()
+        result = guard.add_policy(_make_policy())
+        assert result is guard
+
+
+class TestGuardCheck:
+    def test_no_policies_allows(self) -> None:
+        guard = Guard()
+        result = guard.check("shell_command", command="rm -rf /")
+        assert result.allowed
+
+    def test_matching_policy_denies(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy(pattern="rm -rf"))
+        result = guard.check("shell_command", command="rm -rf /")
+        assert result.denied
+        assert result.denied_by == "test-policy"
+
+    def test_non_matching_policy_allows(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy(pattern="rm -rf"))
+        result = guard.check("shell_command", command="ls -la")
+        assert result.allowed
+
+    def test_wrong_action_kind_allows(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy(action_kind="file_write", pattern="secret"))
+        result = guard.check("shell_command", command="echo secret")
+        assert result.allowed
+
+    def test_first_denying_policy_wins(self) -> None:
+        guard = Guard()
+        guard.add_policy(
+            _make_policy("policy-a", pattern="danger", severity=Severity.HIGH),
+        )
+        guard.add_policy(
+            _make_policy("policy-b", pattern="danger", severity=Severity.CRITICAL),
+        )
+        result = guard.check("shell_command", command="danger zone")
+        assert result.denied_by == "policy-a"
+        assert result.severity == Severity.HIGH
+
+    def test_check_returns_decision(self) -> None:
+        guard = Guard()
+        result = guard.check("shell_command", command="ls")
+        assert isinstance(result, Decision)
+
+    def test_check_with_multiple_params(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy(action_kind="file_write", pattern=r"\.env$"))
+        result = guard.check("file_write", path="/app/.env", content="SECRET=123")
+        assert result.denied
+
+    def test_check_passes_when_pattern_matches_other_kind(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy(action_kind="shell_command", pattern="secret"))
+        result = guard.check("file_write", content="secret")
+        assert result.allowed
+
+    def test_check_denied_has_reason(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy("my-policy", pattern="bad"))
+        result = guard.check("shell_command", command="bad thing")
+        assert result.reason is not None
+        assert "my-policy" in result.reason
+
+    def test_check_allowed_has_no_reason(self) -> None:
+        guard = Guard()
+        guard.add_policy(_make_policy(pattern="bad"))
+        result = guard.check("shell_command", command="good thing")
+        assert result.reason is None
+        assert result.denied_by is None
+        assert result.severity is None
+
+
+class TestGuardLoadYaml:
+    def test_load_from_string(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: yaml-policy
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "git push.*--force"
+                severity: critical
+        """)
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+        assert len(guard.policies) == 1
+        result = guard.check("shell_command", command="git push --force origin main")
+        assert result.denied
+
+    def test_load_from_file(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        policy_file.write_text(
+            textwrap.dedent("""\
+            name: file-policy
+            rules:
+              - action: file_write
+                deny:
+                  - pattern: "password"
+                severity: high
+        """)
+        )
+        guard = Guard()
+        guard.load_policy_file(policy_file)
+        assert len(guard.policies) == 1
+        result = guard.check("file_write", content="password=hunter2")
+        assert result.denied
+
+    def test_load_multiple_sources(self, tmp_path: Path) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: string-policy
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm"
+                severity: low
+        """)
+        policy_file = tmp_path / "file-policy.yaml"
+        policy_file.write_text(
+            textwrap.dedent("""\
+            name: file-policy
+            rules:
+              - action: file_write
+                deny:
+                  - pattern: "secret"
+                severity: medium
+        """)
+        )
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+        guard.load_policy_file(policy_file)
+        guard.add_policy(_make_policy("code-policy", pattern="eval"))
+        assert len(guard.policies) == 3

--- a/tests/unit/test_policy_loader.py
+++ b/tests/unit/test_policy_loader.py
@@ -1,0 +1,231 @@
+"""Tests for YAML policy loader."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
+from agentguard.policies.models import Policy, Severity
+
+
+class TestLoadPolicyFromString:
+    def test_minimal_policy(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: test-policy
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm -rf /"
+                severity: critical
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert isinstance(policy, Policy)
+        assert policy.name == "test-policy"
+        assert len(policy.rules) == 1
+        assert policy.rules[0].severity == Severity.CRITICAL
+
+    def test_policy_with_description(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: my-policy
+            description: A test policy
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "dangerous"
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.description == "A test policy"
+
+    def test_multiple_rules(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: multi-rule
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "git push.*--force"
+                severity: critical
+              - action: file_write
+                deny:
+                  - pattern: '\\.env$'
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert len(policy.rules) == 2
+        assert policy.rules[0].action_kind == "shell_command"
+        assert policy.rules[1].action_kind == "file_write"
+
+    def test_multiple_deny_patterns(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: multi-pattern
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "git push.*--force"
+                  - pattern: "git reset --hard"
+                  - pattern: "git branch -D"
+                severity: critical
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert len(policy.rules[0].deny_patterns) == 3
+
+    def test_rule_with_description(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: desc-policy
+            rules:
+              - action: shell_command
+                description: Block force pushes
+                deny:
+                  - pattern: "git push.*--force"
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].description == "Block force pushes"
+
+    def test_missing_name_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm"
+                severity: low
+        """)
+        with pytest.raises(ValueError, match="name"):
+            load_policy_from_string(yaml_str)
+
+    def test_missing_rules_raises(self) -> None:
+        yaml_str = "name: no-rules\n"
+        with pytest.raises(ValueError, match="rules"):
+            load_policy_from_string(yaml_str)
+
+    def test_empty_rules_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: empty-rules
+            rules: []
+        """)
+        with pytest.raises(ValueError, match="rules"):
+            load_policy_from_string(yaml_str)
+
+    def test_rule_missing_action_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: bad-rule
+            rules:
+              - deny:
+                  - pattern: "rm"
+                severity: low
+        """)
+        with pytest.raises(ValueError, match="action"):
+            load_policy_from_string(yaml_str)
+
+    def test_rule_missing_deny_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: bad-rule
+            rules:
+              - action: shell_command
+                severity: low
+        """)
+        with pytest.raises(ValueError, match="deny"):
+            load_policy_from_string(yaml_str)
+
+    def test_rule_missing_severity_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: bad-rule
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm"
+        """)
+        with pytest.raises(ValueError, match="severity"):
+            load_policy_from_string(yaml_str)
+
+    def test_invalid_severity_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: bad-severity
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm"
+                severity: extreme
+        """)
+        with pytest.raises(ValueError, match="severity"):
+            load_policy_from_string(yaml_str)
+
+    def test_invalid_regex_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: bad-regex
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "[invalid"
+                severity: low
+        """)
+        with pytest.raises(ValueError, match="pattern"):
+            load_policy_from_string(yaml_str)
+
+    def test_deny_pattern_missing_pattern_key_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: no-pattern-key
+            rules:
+              - action: shell_command
+                deny:
+                  - regex: "something"
+                severity: low
+        """)
+        with pytest.raises(ValueError, match="pattern"):
+            load_policy_from_string(yaml_str)
+
+
+class TestLoadPolicyFromFile:
+    def test_load_from_yaml_file(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "test.yaml"
+        policy_file.write_text(
+            textwrap.dedent("""\
+            name: file-policy
+            description: Loaded from file
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm"
+                severity: low
+        """)
+        )
+        policy = load_policy_from_yaml(policy_file)
+        assert policy.name == "file-policy"
+        assert policy.description == "Loaded from file"
+
+    def test_load_from_yml_extension(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "test.yml"
+        policy_file.write_text(
+            textwrap.dedent("""\
+            name: yml-policy
+            rules:
+              - action: file_write
+                deny:
+                  - pattern: "secret"
+                severity: medium
+        """)
+        )
+        policy = load_policy_from_yaml(policy_file)
+        assert policy.name == "yml-policy"
+
+    def test_nonexistent_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_policy_from_yaml(Path("/nonexistent/policy.yaml"))
+
+    def test_load_from_string_path(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "str-path.yaml"
+        policy_file.write_text(
+            textwrap.dedent("""\
+            name: str-path-policy
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "test"
+                severity: low
+        """)
+        )
+        policy = load_policy_from_yaml(str(policy_file))
+        assert policy.name == "str-path-policy"

--- a/tests/unit/test_policy_models.py
+++ b/tests/unit/test_policy_models.py
@@ -1,0 +1,264 @@
+"""Tests for policy data models: Severity, Action, Rule, Decision, Policy."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from agentguard.policies.models import (
+    Action,
+    Decision,
+    Policy,
+    Rule,
+    Severity,
+)
+
+# === Severity enum ===
+
+
+class TestSeverity:
+    def test_severity_levels_exist(self) -> None:
+        assert Severity.LOW.value == "low"
+        assert Severity.MEDIUM.value == "medium"
+        assert Severity.HIGH.value == "high"
+        assert Severity.CRITICAL.value == "critical"
+
+    def test_severity_ordering(self) -> None:
+        """Severities must be comparable for priority sorting."""
+        assert Severity.LOW < Severity.MEDIUM
+        assert Severity.MEDIUM < Severity.HIGH
+        assert Severity.HIGH < Severity.CRITICAL
+
+    def test_severity_from_string(self) -> None:
+        assert Severity("low") == Severity.LOW
+        assert Severity("critical") == Severity.CRITICAL
+
+    def test_invalid_severity_raises(self) -> None:
+        with pytest.raises(ValueError):
+            Severity("invalid")
+
+
+# === Action dataclass ===
+
+
+class TestAction:
+    def test_action_creation(self) -> None:
+        action = Action(kind="shell_command", params={"command": "ls -la"})
+        assert action.kind == "shell_command"
+        assert action.params == {"command": "ls -la"}
+
+    def test_action_with_no_params(self) -> None:
+        action = Action(kind="file_read")
+        assert action.params == {}
+
+    def test_action_is_frozen(self) -> None:
+        action = Action(kind="shell_command")
+        with pytest.raises(FrozenInstanceError):
+            action.kind = "other"  # type: ignore[misc]
+
+
+# === Rule dataclass ===
+
+
+class TestRule:
+    def test_deny_rule_creation(self) -> None:
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"rm\s+-rf")],
+            severity=Severity.CRITICAL,
+            description="Block recursive delete",
+        )
+        assert rule.action_kind == "shell_command"
+        assert len(rule.deny_patterns) == 1
+        assert rule.severity == Severity.CRITICAL
+
+    def test_rule_matches_pattern(self) -> None:
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"git push.*--force")],
+            severity=Severity.HIGH,
+        )
+        assert rule.matches(
+            Action(
+                kind="shell_command",
+                params={"command": "git push --force origin main"},
+            )
+        )
+
+    def test_rule_does_not_match_safe_action(self) -> None:
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"git push.*--force")],
+            severity=Severity.HIGH,
+        )
+        assert not rule.matches(
+            Action(
+                kind="shell_command",
+                params={"command": "git push origin main"},
+            )
+        )
+
+    def test_rule_does_not_match_different_kind(self) -> None:
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r".*")],
+            severity=Severity.LOW,
+        )
+        assert not rule.matches(Action(kind="file_write", params={"path": "/tmp/foo"}))
+
+    def test_rule_matches_multiple_patterns(self) -> None:
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[
+                re.compile(r"git push.*--force"),
+                re.compile(r"git reset --hard"),
+            ],
+            severity=Severity.HIGH,
+        )
+        assert rule.matches(
+            Action(
+                kind="shell_command",
+                params={"command": "git reset --hard HEAD~5"},
+            )
+        )
+
+    def test_rule_matches_any_param_value(self) -> None:
+        """Pattern is checked against all string param values."""
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"secret")],
+            severity=Severity.MEDIUM,
+        )
+        assert rule.matches(
+            Action(
+                kind="shell_command",
+                params={"command": "echo", "args": "my secret value"},
+            )
+        )
+
+    def test_rule_default_description(self) -> None:
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"rm")],
+            severity=Severity.LOW,
+        )
+        assert rule.description is None
+
+
+# === Decision dataclass ===
+
+
+class TestDecision:
+    def test_allowed_decision(self) -> None:
+        decision = Decision(allowed=True)
+        assert decision.allowed
+        assert decision.denied_by is None
+        assert decision.reason is None
+
+    def test_denied_decision(self) -> None:
+        decision = Decision(
+            allowed=False,
+            denied_by="no-force-push",
+            reason="Blocked by policy: no-force-push",
+        )
+        assert not decision.allowed
+        assert decision.denied_by == "no-force-push"
+        assert decision.reason == "Blocked by policy: no-force-push"
+
+    def test_denied_property(self) -> None:
+        assert Decision(allowed=False).denied
+        assert not Decision(allowed=True).denied
+
+
+# === Policy dataclass ===
+
+
+class TestPolicy:
+    def test_policy_creation(self) -> None:
+        policy = Policy(
+            name="no-force-push",
+            description="Prevent force pushes",
+            rules=[
+                Rule(
+                    action_kind="shell_command",
+                    deny_patterns=[re.compile(r"git push.*--force")],
+                    severity=Severity.CRITICAL,
+                ),
+            ],
+        )
+        assert policy.name == "no-force-push"
+        assert len(policy.rules) == 1
+
+    def test_policy_evaluate_allows_safe_action(self) -> None:
+        policy = Policy(
+            name="no-force-push",
+            description="Prevent force pushes",
+            rules=[
+                Rule(
+                    action_kind="shell_command",
+                    deny_patterns=[re.compile(r"git push.*--force")],
+                    severity=Severity.CRITICAL,
+                ),
+            ],
+        )
+        decision = policy.evaluate(
+            Action(
+                kind="shell_command",
+                params={"command": "git push origin main"},
+            )
+        )
+        assert decision.allowed
+
+    def test_policy_evaluate_denies_matching_action(self) -> None:
+        policy = Policy(
+            name="no-force-push",
+            description="Prevent force pushes",
+            rules=[
+                Rule(
+                    action_kind="shell_command",
+                    deny_patterns=[re.compile(r"git push.*--force")],
+                    severity=Severity.CRITICAL,
+                ),
+            ],
+        )
+        decision = policy.evaluate(
+            Action(
+                kind="shell_command",
+                params={"command": "git push --force origin main"},
+            )
+        )
+        assert decision.denied
+        assert decision.denied_by == "no-force-push"
+
+    def test_policy_evaluate_returns_first_matching_rule(self) -> None:
+        policy = Policy(
+            name="destructive-git",
+            description="Block destructive git ops",
+            rules=[
+                Rule(
+                    action_kind="shell_command",
+                    deny_patterns=[re.compile(r"git push.*--force")],
+                    severity=Severity.CRITICAL,
+                ),
+                Rule(
+                    action_kind="shell_command",
+                    deny_patterns=[re.compile(r"git reset --hard")],
+                    severity=Severity.HIGH,
+                ),
+            ],
+        )
+        decision = policy.evaluate(
+            Action(
+                kind="shell_command",
+                params={"command": "git push --force origin main"},
+            )
+        )
+        assert decision.denied
+        assert decision.severity == Severity.CRITICAL
+
+    def test_policy_with_no_rules_allows_all(self) -> None:
+        policy = Policy(name="empty", rules=[])
+        decision = policy.evaluate(Action(kind="anything"))
+        assert decision.allowed


### PR DESCRIPTION
## Summary

Implements the two core milestones that make AgentGuard a functional, demoable library:

- **M1: Policy Engine** — Define safety rules in YAML, load them programmatically, and enforce them via a `Guard` class that evaluates actions against deny-pattern policies
- **M2: Audit Logging** — Record agent actions in a hash-chained, tamper-evident audit log with JSONL persistence, integrity verification, and query filtering

## What's included

### M1: Policy Engine
- `policies/models.py` — `Severity`, `Action`, `Rule`, `Decision`, `Policy` data models with regex pattern matching
- `policies/loader.py` — YAML parser with full validation (required fields, severity values, regex compilation)
- `policies/guard.py` — `Guard` class: central API for adding policies and checking actions
- `policies/builtins.py` — 3 built-in policies: `no-force-push`, `no-secret-exposure`, `no-data-deletion`
- 3 YAML policy files in `builtin_policies/`

### M2: Audit Logging
- `audit/models.py` — `AuditEntry` with SHA-256 content hashing and serialization
- `audit/log.py` — `AuditLog` with hash-chained `record()`, JSONL `save()`/`load()`, `verify()` integrity checking, and `query()` with filters (action, actor, result, time range)

### Quality
- **125 tests**, all passing across Python 3.10–3.13
- **93% code coverage** (90% gate)
- Ruff lint + format clean
- mypy strict mode clean
- `types-PyYAML` added to dev dependencies for CI mypy compatibility