### PR TITLE
docs: mark M3 runtime guardrails complete in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ agentguard/
 - [x] Project scaffolding, CI, packaging
 - [x] Core policy engine (YAML + Python policies)
 - [x] Audit log with hash-chaining
-- [ ] Runtime guardrail interceptor
+- [x] Runtime guardrail interceptor
 - [ ] EU AI Act compliance report generator
 - [ ] LangChain / CrewAI / AutoGen integrations
 - [ ] CLI tool for policy management


### PR DESCRIPTION
## Summary

- Check off "Runtime guardrail interceptor" in README roadmap
- Follows merge of PR #3 which implemented M3

No code changes — docs only.