### PR TITLE
docs: mark M5 OpenClaw integration complete in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ agentguard/
 - [x] Audit log with hash-chaining
 - [x] Runtime guardrail interceptor
 - [x] EU AI Act compliance report generator
+- [x] OpenClaw integration (`@agentguard/openclaw` TypeScript plugin)
 - [ ] LangChain / CrewAI / AutoGen integrations
 - [ ] CLI tool for policy management
 - [ ] Documentation site


### PR DESCRIPTION
## Summary

- Check off M5 OpenClaw integration in README roadmap section

Follows the merge of PR #6 which implemented the full TypeScript-native
OpenClaw integration plugin (`@agentguard/openclaw`).