### PR TITLE
docs: add MkDocs Material documentation site with API reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # RSN private files (NEVER commit)
 private/
+output/
 .opencode/
 AGENTS.md
 AGENTS.core.md

--- a/docs/api/audit.md
+++ b/docs/api/audit.md
@@ -1,0 +1,28 @@
+# Audit API Reference
+
+Structured, tamper-evident action logging with hash chaining and
+JSONL persistence.
+
+## Package exports
+
+```python
+from agentguard.audit import AuditEntry, AuditLog
+```
+
+## AuditLog
+
+Hash-chained, append-only audit log.
+
+::: agentguard.audit.log.AuditLog
+    options:
+      show_source: true
+      members_order: source
+
+## AuditEntry
+
+A single entry in the audit trail.
+
+::: agentguard.audit.models.AuditEntry
+    options:
+      show_source: true
+      members_order: source

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,13 @@
+# CLI API Reference
+
+Command-line interface for AgentGuard. Uses only stdlib `argparse`
+with no external dependencies.
+
+See the [CLI Reference Guide](../guides/cli-reference.md) for
+usage examples and full command documentation.
+
+## Entry point
+
+::: agentguard.cli.main
+    options:
+      show_source: true

--- a/docs/api/compliance.md
+++ b/docs/api/compliance.md
@@ -1,0 +1,76 @@
+# Compliance API Reference
+
+Report generators and renderers for regulatory compliance assessment.
+Currently supports the EU AI Act (Regulation 2024/1689).
+
+## Package exports
+
+```python
+from agentguard.compliance import (
+    ComplianceReport, EUAIActReportGenerator, Finding,
+    FindingSeverity, ReportSection, SectionStatus,
+    render_json, render_text,
+)
+```
+
+## EUAIActReportGenerator
+
+Generates EU AI Act compliance reports from audit logs.
+
+::: agentguard.compliance.eu_ai_act.EUAIActReportGenerator
+    options:
+      show_source: true
+      members_order: source
+
+## ComplianceReport
+
+A complete compliance report.
+
+::: agentguard.compliance.models.ComplianceReport
+    options:
+      show_source: true
+      members_order: source
+
+## ReportSection
+
+A section covering one regulatory article.
+
+::: agentguard.compliance.models.ReportSection
+    options:
+      show_source: true
+
+## Finding
+
+A single compliance finding.
+
+::: agentguard.compliance.models.Finding
+    options:
+      show_source: true
+
+## FindingSeverity
+
+Severity levels for compliance findings.
+
+::: agentguard.compliance.models.FindingSeverity
+    options:
+      show_source: true
+
+## SectionStatus
+
+Status values for report sections.
+
+::: agentguard.compliance.models.SectionStatus
+    options:
+      show_source: true
+
+## Renderers
+
+Functions for rendering reports to different formats.
+
+::: agentguard.compliance.renderers.render_json
+    options:
+      show_source: true
+
+::: agentguard.compliance.renderers.render_text
+    options:
+      show_source: true

--- a/docs/api/guardrails.md
+++ b/docs/api/guardrails.md
@@ -1,0 +1,46 @@
+# Guardrails API Reference
+
+Runtime interceptors that combine policy checking, action execution,
+and audit logging into a single pipeline.
+
+## Package exports
+
+```python
+from agentguard.guardrails import (
+    ActionResult, ExecutionResult, Guardrail, Interceptor,
+)
+```
+
+## Guardrail
+
+The main runtime safety layer. Checks policies before executing actions
+and records everything in the audit log.
+
+::: agentguard.guardrails.guardrail.Guardrail
+    options:
+      show_source: true
+      members_order: source
+
+## ExecutionResult
+
+The result of a guarded action execution.
+
+::: agentguard.guardrails.guardrail.ExecutionResult
+    options:
+      show_source: true
+
+## ActionResult
+
+The result of executing an agent action via an interceptor.
+
+::: agentguard.guardrails.models.ActionResult
+    options:
+      show_source: true
+
+## Interceptor
+
+Protocol for action executors.
+
+::: agentguard.guardrails.models.Interceptor
+    options:
+      show_source: true

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -1,0 +1,16 @@
+# MCP Server API Reference
+
+Transparent MCP proxy with policy enforcement and audit logging.
+
+The MCP server exposes agent tools (`shell_execute`, `file_read`,
+`file_write`) that pass through AgentGuard's policy engine before
+execution. See the [MCP Integration Guide](../guides/mcp-integration.md)
+for usage instructions.
+
+## create_server
+
+Factory function that creates a configured MCP server instance.
+
+::: agentguard.mcp.server.create_server
+    options:
+      show_source: true

--- a/docs/api/policies.md
+++ b/docs/api/policies.md
@@ -1,0 +1,91 @@
+# Policies API Reference
+
+The policy engine defines rules for what agents can and cannot do.
+It is the core of AgentGuard's safety layer.
+
+## Package exports
+
+```python
+from agentguard.policies import (
+    Action, Decision, Guard, Policy, Rule, Severity,
+    list_builtins, load_all_builtins, load_builtin,
+    load_policy_from_string, load_policy_from_yaml,
+)
+```
+
+## Guard
+
+The central policy enforcement point.
+
+::: agentguard.policies.guard.Guard
+    options:
+      show_source: true
+      members_order: source
+
+## Policy
+
+A named collection of deny rules.
+
+::: agentguard.policies.models.Policy
+    options:
+      show_source: true
+
+## Rule
+
+A single deny rule within a policy.
+
+::: agentguard.policies.models.Rule
+    options:
+      show_source: true
+
+## Decision
+
+The result of evaluating an action against policies.
+
+::: agentguard.policies.models.Decision
+    options:
+      show_source: true
+
+## Action
+
+An action an agent wants to perform.
+
+::: agentguard.policies.models.Action
+    options:
+      show_source: true
+
+## Severity
+
+Risk severity levels.
+
+::: agentguard.policies.models.Severity
+    options:
+      show_source: true
+
+## YAML Loader
+
+Functions for loading policies from YAML.
+
+::: agentguard.policies.loader.load_policy_from_string
+    options:
+      show_source: true
+
+::: agentguard.policies.loader.load_policy_from_yaml
+    options:
+      show_source: true
+
+## Built-in Policies
+
+Access to AgentGuard's bundled policy definitions.
+
+::: agentguard.policies.builtins.list_builtins
+    options:
+      show_source: true
+
+::: agentguard.policies.builtins.load_builtin
+    options:
+      show_source: true
+
+::: agentguard.policies.builtins.load_all_builtins
+    options:
+      show_source: true

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,49 @@
+# Installation
+
+## Requirements
+
+- Python 3.10 or later
+- pip (or any PEP 517-compatible installer)
+
+## Install from PyPI
+
+```bash
+pip install agentguard
+```
+
+## Install with MCP support
+
+To use the MCP server for Claude Desktop integration:
+
+```bash
+pip install agentguard[mcp]
+```
+
+## Install from source
+
+```bash
+git clone https://github.com/Roboter-Schlafen-Nicht/agentguard.git
+cd agentguard
+pip install -e ".[dev]"
+```
+
+## Verify installation
+
+```bash
+agentguard version
+```
+
+Or from Python:
+
+```python
+import agentguard
+print(agentguard.__version__)
+```
+
+## Optional dependencies
+
+| Extra | Description |
+|-------|-------------|
+| `mcp` | MCP server support (`mcp>=1.0`) |
+| `dev` | Development tools (pytest, ruff, mypy) |
+| `docs` | Documentation build (mkdocs-material, mkdocstrings) |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,125 @@
+# Quick Start
+
+This guide walks through the core AgentGuard workflow: define policies,
+check actions, log results, and generate compliance reports.
+
+## 1. Check actions against policies
+
+The `Guard` class is the central policy enforcement point. Load policies
+from YAML files or use the built-in policies:
+
+```python
+from agentguard import Guard
+
+guard = Guard()
+
+# Load built-in policies
+from agentguard.policies.builtins import load_all_builtins
+for policy in load_all_builtins():
+    guard.add_policy(policy)
+
+# Check if an action is allowed
+decision = guard.check("shell_command", command="ls -la")
+print(decision.allowed)  # True
+
+decision = guard.check("shell_command", command="git push --force")
+print(decision.allowed)  # False
+print(decision.reason)   # "Matches deny pattern: --force"
+```
+
+## 2. Record actions in an audit log
+
+The `AuditLog` creates tamper-evident, hash-chained records of all
+agent actions:
+
+```python
+from agentguard import AuditLog
+
+log = AuditLog("session-001")
+
+log.record(
+    action="shell_command",
+    actor="coding-agent",
+    target="ls -la",
+    result="allowed",
+)
+
+log.record(
+    action="file_write",
+    actor="coding-agent",
+    target="/tmp/output.txt",
+    result="allowed",
+)
+
+# Save to disk as JSONL
+log.save("audit.jsonl")
+
+# Later: verify integrity
+log = AuditLog.load("audit.jsonl", "session-001")
+assert log.verify()  # True if untampered
+```
+
+## 3. Use the Guardrail for combined enforcement
+
+The `Guardrail` combines policy checking, execution, and audit logging
+into a single workflow:
+
+```python
+from agentguard import Guard, AuditLog, Guardrail
+
+guard = Guard()
+guard.load_policy_file("policies/no-force-push.yaml")
+log = AuditLog("session-001")
+
+guardrail = Guardrail(guard=guard, audit_log=log, actor="my-agent")
+
+# Execute with safety checks
+result = guardrail.execute(
+    action_kind="shell_command",
+    target="ls -la",
+    executor=lambda: "file1.txt\nfile2.txt",
+    command="ls -la",
+)
+
+print(result.allowed)  # True
+print(result.output)   # "file1.txt\nfile2.txt"
+```
+
+## 4. Generate compliance reports
+
+Generate EU AI Act compliance reports from audit data:
+
+```python
+from agentguard import AuditLog
+from agentguard.compliance import EUAIActReportGenerator, render_text
+
+log = AuditLog.load("audit.jsonl", "session-001")
+generator = EUAIActReportGenerator()
+report = generator.generate(log)
+
+print(render_text(report))
+```
+
+## 5. Use the CLI
+
+AgentGuard includes a command-line tool:
+
+```bash
+# Check an action against built-in policies
+agentguard check --builtins shell_command command="git push --force"
+
+# Verify an audit log
+agentguard audit verify audit.jsonl --session session-001
+
+# Generate a compliance report
+agentguard report eu-ai-act audit.jsonl --session session-001
+
+# List built-in policies
+agentguard policies list
+```
+
+## Next steps
+
+- [Policy Authoring](../guides/policy-authoring.md) -- Write custom policies
+- [Audit Logging](../guides/audit-logging.md) -- Advanced audit log usage
+- [MCP Integration](../guides/mcp-integration.md) -- Use with Claude Desktop

--- a/docs/guides/audit-logging.md
+++ b/docs/guides/audit-logging.md
@@ -1,0 +1,108 @@
+# Audit Logging
+
+AgentGuard's audit system creates tamper-evident, hash-chained logs of
+all agent actions. Each entry is linked to the previous one via SHA-256
+hashes, making it possible to detect any tampering.
+
+## Creating an audit log
+
+```python
+from agentguard import AuditLog
+
+log = AuditLog("session-001")
+```
+
+The session ID groups related entries together. Use a unique ID per
+agent session.
+
+## Recording actions
+
+```python
+log.record(
+    action="shell_command",
+    actor="coding-agent",
+    target="ls -la /tmp",
+    result="allowed",
+)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `action` | str | Action type (e.g. `shell_command`, `file_write`) |
+| `actor` | str | Who performed the action |
+| `target` | str | What the action targeted |
+| `result` | str | Outcome (e.g. `allowed`, `denied`, `error`) |
+
+## Saving and loading
+
+```python
+# Save to JSONL file
+log.save("audit.jsonl")
+
+# Load from file
+log = AuditLog.load("audit.jsonl", "session-001")
+```
+
+The JSONL format stores one JSON object per line, making it
+append-friendly and easy to parse.
+
+## Verifying integrity
+
+```python
+if log.verify():
+    print("Log integrity verified")
+else:
+    print("WARNING: Log may have been tampered with")
+```
+
+The `verify()` method recalculates the hash chain and checks that
+each entry's hash matches. Any modification to an entry will break
+the chain.
+
+## Querying entries
+
+```python
+# Filter by action type
+results = log.query(action="shell_command")
+
+# Filter by actor
+results = log.query(actor="coding-agent")
+
+# Filter by result
+results = log.query(result="denied")
+
+# Combine filters
+results = log.query(action="file_write", result="allowed")
+```
+
+## Hash chain structure
+
+Each `AuditEntry` contains:
+
+- `timestamp` -- When the action occurred
+- `action` -- The action type
+- `actor` -- Who performed it
+- `target` -- What was targeted
+- `result` -- The outcome
+- `previous_hash` -- SHA-256 hash of the previous entry
+- `hash` -- SHA-256 hash of this entry (including `previous_hash`)
+
+The first entry uses an empty string as `previous_hash`. This creates
+an append-only chain where any modification invalidates all subsequent
+entries.
+
+## CLI usage
+
+```bash
+# Verify log integrity
+agentguard audit verify audit.jsonl --session session-001
+
+# Show all entries
+agentguard audit show audit.jsonl --session session-001
+
+# Query entries
+agentguard audit query audit.jsonl --session session-001 --action shell_command
+agentguard audit query audit.jsonl --session session-001 --result denied --format json
+```

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -1,0 +1,232 @@
+# CLI Reference
+
+AgentGuard provides a command-line interface for policy checking, audit
+log inspection, and compliance reporting. The CLI uses only Python's
+stdlib `argparse` — no external dependencies.
+
+## Installation
+
+The CLI is installed automatically with AgentGuard:
+
+```bash
+pip install agentguard
+```
+
+After installation, the `agentguard` command is available:
+
+```bash
+agentguard --version
+```
+
+## Commands
+
+### `agentguard version`
+
+Print the installed AgentGuard version.
+
+```bash
+agentguard version
+# or
+agentguard --version
+```
+
+---
+
+### `agentguard policies list`
+
+List all available built-in policies.
+
+```bash
+agentguard policies list
+```
+
+Output:
+
+```
+Built-in policies:
+  - no-data-deletion
+  - no-force-push
+  - no-secret-exposure
+```
+
+### `agentguard policies show <name>`
+
+Show the details of a built-in policy, including its rules, severity
+levels, and deny patterns.
+
+```bash
+agentguard policies show no-force-push
+```
+
+Output:
+
+```
+Policy: no-force-push
+Description: Prevents destructive git force-push operations
+Rules (1):
+  1. action: shell_command
+     severity: high
+     description: Block git push --force and -f flags
+     deny patterns: ['git\\s+push\\s+.*--force', 'git\\s+push\\s+-f\\b']
+```
+
+---
+
+### `agentguard check`
+
+Check an action against loaded policies. Returns exit code 0 if allowed,
+1 if denied, 2 on usage errors.
+
+```bash
+agentguard check [OPTIONS] ACTION_KIND [PARAMS...]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `ACTION_KIND` | The action kind to check (e.g. `shell_command`, `file_write`). |
+| `PARAMS` | Action parameters as `key=value` pairs. |
+
+**Options:**
+
+| Option | Description |
+|---|---|
+| `--builtins` | Load all built-in policies. |
+| `--policy PATH` | Path to a policy YAML file (repeatable). |
+| `--policy-dir DIR` | Directory containing policy YAML files. |
+| `--format {text,json}` | Output format (default: `text`). |
+
+**Examples:**
+
+```bash
+# Check against built-in policies
+agentguard check --builtins shell_command command="git push --force"
+
+# Check against a custom policy file
+agentguard check --policy my-policy.yaml file_write path="/etc/passwd"
+
+# Check against all policies in a directory
+agentguard check --policy-dir ./policies shell_command command="rm -rf /"
+
+# JSON output
+agentguard check --builtins --format json shell_command command="ls -la"
+```
+
+**Text output (denied):**
+
+```
+DENIED: Action 'shell_command' was denied.
+  Policy: no-force-push
+  Reason: Matches deny pattern: git\s+push\s+.*--force
+  Severity: high
+```
+
+**JSON output (allowed):**
+
+```json
+{
+  "allowed": true
+}
+```
+
+---
+
+### `agentguard audit verify`
+
+Verify the integrity of an audit log's hash chain. Returns exit code 0
+if valid, 1 if tampered.
+
+```bash
+agentguard audit verify FILE [--session ID]
+```
+
+| Option | Description |
+|---|---|
+| `--session ID` | Session ID for the log (default: `unknown`). |
+
+```bash
+agentguard audit verify audit.jsonl --session session-001
+```
+
+### `agentguard audit show`
+
+Display all entries in an audit log.
+
+```bash
+agentguard audit show FILE [--session ID] [--format {text,json}]
+```
+
+| Option | Description |
+|---|---|
+| `--session ID` | Session ID for the log (default: `unknown`). |
+| `--format {text,json}` | Output format (default: `text`). |
+
+```bash
+agentguard audit show audit.jsonl --format json
+```
+
+### `agentguard audit query`
+
+Query audit log entries with filters. All filters are AND-combined.
+
+```bash
+agentguard audit query FILE [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--session ID` | Session ID for the log (default: `unknown`). |
+| `--action TYPE` | Filter by action type (e.g. `shell_command`). |
+| `--actor NAME` | Filter by actor name. |
+| `--result RESULT` | Filter by result (e.g. `allowed`, `denied`). |
+| `--format {text,json}` | Output format (default: `text`). |
+
+```bash
+# Find all denied actions
+agentguard audit query audit.jsonl --result denied
+
+# Find shell commands by a specific actor
+agentguard audit query audit.jsonl --action shell_command --actor coding-agent
+```
+
+---
+
+### `agentguard report`
+
+Generate a compliance report from an audit log.
+
+```bash
+agentguard report FRAMEWORK FILE [OPTIONS]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `FRAMEWORK` | Compliance framework. Currently supported: `eu-ai-act`. |
+| `FILE` | Path to the audit JSONL file. |
+
+**Options:**
+
+| Option | Description |
+|---|---|
+| `--session ID` | Session ID for the log (default: `unknown`). |
+| `--format {text,json}` | Output format (default: `text`). |
+| `--output PATH` | Write report to a file instead of stdout. |
+
+```bash
+# Text report to stdout
+agentguard report eu-ai-act audit.jsonl --session session-001
+
+# JSON report to file
+agentguard report eu-ai-act audit.jsonl --format json --output report.json
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success (action allowed, log valid, report generated). |
+| `1` | Failure (action denied, log tampered, error). |
+| `2` | Usage error (missing arguments, invalid parameters). |

--- a/docs/guides/compliance-reports.md
+++ b/docs/guides/compliance-reports.md
@@ -1,0 +1,91 @@
+# Compliance Reports
+
+AgentGuard can generate compliance reports from audit log data. Currently
+supports the EU AI Act framework.
+
+## EU AI Act reports
+
+The `EUAIActReportGenerator` evaluates audit logs against four articles
+of the EU AI Act:
+
+| Article | Topic |
+|---------|-------|
+| Art. 9 | Risk Management |
+| Art. 12 | Record-Keeping |
+| Art. 13 | Transparency |
+| Art. 14 | Human Oversight |
+
+### Generating a report
+
+```python
+from agentguard import AuditLog
+from agentguard.compliance import EUAIActReportGenerator, render_text, render_json
+
+# Load audit data
+log = AuditLog.load("audit.jsonl", "session-001")
+
+# Generate report
+generator = EUAIActReportGenerator()
+report = generator.generate(log)
+
+# Render as text
+print(render_text(report))
+
+# Render as JSON
+print(render_json(report))
+```
+
+### Writing to a file
+
+```python
+render_text(report, output="report.txt")
+render_json(report, output="report.json")
+```
+
+## Report structure
+
+A `ComplianceReport` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `framework` | str | Framework name (e.g. "EU AI Act") |
+| `generated_at` | datetime | When the report was created |
+| `sections` | list | One section per article/requirement |
+| `summary` | str | Overall compliance summary |
+
+Each `ReportSection` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | str | Section title (e.g. "Art. 9 - Risk Management") |
+| `status` | SectionStatus | `compliant`, `partial`, or `non_compliant` |
+| `findings` | list | Specific findings |
+| `recommendations` | list | Improvement suggestions |
+
+## CLI usage
+
+```bash
+# Text report to stdout
+agentguard report eu-ai-act audit.jsonl --session session-001
+
+# JSON report
+agentguard report eu-ai-act audit.jsonl --session session-001 --format json
+
+# Write to file
+agentguard report eu-ai-act audit.jsonl --session session-001 --output report.txt
+```
+
+## Custom frameworks
+
+The compliance module is designed to be extensible. To add a new
+framework, create a report generator that accepts an `AuditLog` and
+returns a `ComplianceReport`:
+
+```python
+from agentguard.compliance.models import ComplianceReport, ReportSection
+
+class MyFrameworkReportGenerator:
+    def generate(self, audit_log: AuditLog) -> ComplianceReport:
+        # Analyze audit_log.entries and build sections
+        ...
+```

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -1,0 +1,175 @@
+# MCP Integration
+
+AgentGuard ships an [MCP](https://modelcontextprotocol.io/) server that
+acts as a transparent safety proxy for AI agents. Every tool call passes
+through the policy engine and is recorded in a tamper-evident audit log.
+
+## How it works
+
+```
+Agent  ──►  AgentGuard MCP Server  ──►  System
+               │                           │
+               ├── policy check ◄──────────┘
+               └── audit log
+```
+
+The MCP server exposes three action tools (`shell_execute`, `file_read`,
+`file_write`) and two introspection tools (`agentguard_status`,
+`agentguard_audit_query`). When an agent calls a tool:
+
+1. The request is checked against all loaded policies.
+2. If denied, a `ToolError` is raised and the denial is logged.
+3. If allowed, the action executes and the result is logged.
+
+## Claude Desktop setup
+
+Add AgentGuard to your Claude Desktop configuration
+(`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "agentguard": {
+      "command": "uvx",
+      "args": [
+        "agentguard",
+        "--policy-dir", "./policies",
+        "--audit-dir", "./audit-logs",
+        "--load-builtins"
+      ]
+    }
+  }
+}
+```
+
+Or if installed locally with `pip`:
+
+```json
+{
+  "mcpServers": {
+    "agentguard": {
+      "command": "python",
+      "args": [
+        "-m", "agentguard.mcp",
+        "--policy-dir", "./policies",
+        "--audit-dir", "./audit-logs",
+        "--load-builtins"
+      ]
+    }
+  }
+}
+```
+
+## Programmatic usage
+
+Create an MCP server instance in Python:
+
+```python
+from agentguard.mcp.server import create_server
+
+app = create_server(
+    policy_dir="./policies",
+    audit_dir="./audit-logs",
+    actor="my-agent",
+    load_builtins=True,
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `policy_dir` | `str \| None` | `None` | Directory containing YAML policy files. |
+| `audit_dir` | `str \| None` | `None` | Directory for audit log output. If `None`, logs stay in memory. |
+| `actor` | `str` | `"agent"` | Actor name recorded in audit entries. |
+| `load_builtins` | `bool` | `False` | Load AgentGuard's built-in policies. |
+
+## Available tools
+
+### `shell_execute`
+
+Execute a shell command. The command is checked against policies before
+execution. Commands time out after 30 seconds.
+
+```
+shell_execute(command="ls -la")
+```
+
+### `file_read`
+
+Read a text file. Binary files are rejected automatically.
+
+```
+file_read(path="src/main.py")
+```
+
+### `file_write`
+
+Write content to a file. Parent directories are created if needed.
+
+```
+file_write(path="output.txt", content="Hello, world!")
+```
+
+### `agentguard_status`
+
+Show the current server status: loaded policies, actor name, session ID,
+and audit entry count.
+
+```
+agentguard_status()
+```
+
+### `agentguard_audit_query`
+
+Query the audit log by action type, result, or actor. All filters are
+AND-combined.
+
+```
+agentguard_audit_query(action="shell_execute", result="denied")
+```
+
+## Custom policies
+
+Place YAML policy files in the directory specified by `--policy-dir`.
+See the [Policy Authoring](policy-authoring.md) guide for the full
+policy format.
+
+Example policy that blocks dangerous git operations:
+
+```yaml
+name: safe-git
+description: Prevent destructive git operations
+rules:
+  - action: shell_execute
+    severity: high
+    description: Block force push
+    deny_patterns:
+      - "git\\s+push\\s+.*--force"
+      - "git\\s+push\\s+-f"
+```
+
+!!! note
+    The MCP server checks both the MCP tool name (`shell_execute`) and
+    the legacy action name (`shell_command`) for backward compatibility
+    with policies written for the Python API.
+
+## Audit logs
+
+When `audit_dir` is configured, the server writes a JSONL file for each
+session (`ag-<session-hex>.jsonl`). These files can be verified and
+queried with the CLI:
+
+```bash
+# Verify integrity
+agentguard audit verify audit-logs/ag-abc123.jsonl
+
+# Show all entries
+agentguard audit show audit-logs/ag-abc123.jsonl
+
+# Generate compliance report
+agentguard report eu-ai-act audit-logs/ag-abc123.jsonl
+```
+
+See the [Audit Logging](audit-logging.md) and
+[Compliance Reports](compliance-reports.md) guides for more details.

--- a/docs/guides/policy-authoring.md
+++ b/docs/guides/policy-authoring.md
@@ -1,0 +1,137 @@
+# Policy Authoring
+
+Policies define what actions agents are allowed or denied. AgentGuard
+supports YAML-based policy definitions with regex pattern matching.
+
+## Policy structure
+
+A policy YAML file has this structure:
+
+```yaml
+name: my-policy
+description: Optional description of what this policy enforces
+rules:
+  - action: shell_command
+    deny:
+      - pattern: "rm -rf"
+        description: Prevent recursive deletion
+      - pattern: "--force"
+    severity: critical
+    description: Block dangerous shell commands
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique name for the policy |
+| `description` | No | Human-readable description |
+| `rules` | Yes | List of rules to enforce |
+
+### Rule fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `action` | Yes | Action kind to match (e.g. `shell_command`, `file_write`) |
+| `deny` | Yes | List of deny patterns |
+| `severity` | No | `low`, `medium`, `high`, or `critical` (default: `medium`) |
+| `description` | No | Human-readable rule description |
+
+### Deny pattern fields
+
+Each deny pattern can be a string (shorthand) or an object:
+
+```yaml
+# Shorthand -- just the regex pattern
+deny:
+  - pattern: "rm -rf"
+
+# With description
+deny:
+  - pattern: "rm -rf"
+    description: Prevent recursive force deletion
+```
+
+## Built-in policies
+
+AgentGuard ships with three built-in policies:
+
+| Policy | Description |
+|--------|-------------|
+| `no-force-push` | Blocks `git push --force` and similar |
+| `no-secret-exposure` | Blocks commands that may expose secrets |
+| `no-data-deletion` | Blocks destructive deletion commands |
+
+Use them in Python:
+
+```python
+from agentguard.policies.builtins import load_builtin, load_all_builtins
+
+# Load one
+policy = load_builtin("no-force-push")
+
+# Load all
+policies = load_all_builtins()
+```
+
+Or via CLI:
+
+```bash
+agentguard policies list
+agentguard policies show no-force-push
+```
+
+## Loading policies
+
+### From YAML files
+
+```python
+from agentguard import Guard
+
+guard = Guard()
+guard.load_policy_file("path/to/policy.yaml")
+```
+
+### From a directory
+
+```python
+from pathlib import Path
+
+guard = Guard()
+for yaml_file in Path("policies/").glob("*.yaml"):
+    guard.load_policy_file(yaml_file)
+```
+
+### From YAML strings
+
+```python
+from agentguard.policies.loader import load_policy_from_string
+
+policy = load_policy_from_string("""
+name: inline-policy
+rules:
+  - action: file_write
+    deny:
+      - pattern: "/etc/"
+    severity: high
+""")
+```
+
+## How matching works
+
+When `guard.check()` is called, the Guard evaluates all loaded policies:
+
+1. Each rule's `action` field is compared to the `action_kind` argument
+2. If matched, each deny pattern's `pattern` is tested as a regex
+   against all parameter values
+3. If any pattern matches, the action is denied
+4. If no rules deny the action, it is allowed
+
+```python
+decision = guard.check("shell_command", command="git push --force origin main")
+
+# decision.allowed == False
+# decision.denied_by == "no-force-push"
+# decision.reason == "Matches deny pattern: --force"
+# decision.severity == Severity.CRITICAL
+```

--- a/docs/guides/runtime-guardrails.md
+++ b/docs/guides/runtime-guardrails.md
@@ -1,0 +1,107 @@
+# Runtime Guardrails
+
+The `Guardrail` class combines policy checking, execution, and audit
+logging into a single workflow. It validates actions before execution
+and records everything to an audit log.
+
+## Basic usage
+
+```python
+from agentguard import Guard, AuditLog, Guardrail
+
+guard = Guard()
+guard.load_policy_file("policies/no-force-push.yaml")
+log = AuditLog("session-001")
+
+guardrail = Guardrail(guard=guard, audit_log=log, actor="my-agent")
+```
+
+## Executing actions
+
+The `execute()` method checks the action against policies, runs it if
+allowed, and logs the result:
+
+```python
+result = guardrail.execute(
+    action_kind="shell_command",
+    target="ls -la",
+    executor=lambda: "file1.txt\nfile2.txt",
+    command="ls -la",
+)
+
+print(result.allowed)   # True
+print(result.output)    # "file1.txt\nfile2.txt"
+print(result.decision)  # The full Decision object
+```
+
+### When an action is denied
+
+```python
+result = guardrail.execute(
+    action_kind="shell_command",
+    target="git push --force",
+    executor=lambda: None,  # Never called
+    command="git push --force",
+)
+
+print(result.allowed)  # False
+print(result.output)   # None -- executor was not called
+```
+
+The executor function is only called if the policy check passes.
+
+## Custom interceptors
+
+Interceptors let you add custom logic before or after execution.
+An interceptor is any callable that takes an `ActionResult` and returns
+a modified `ActionResult`:
+
+```python
+from agentguard.guardrails import ActionResult
+
+def log_interceptor(result: ActionResult) -> ActionResult:
+    """Log all actions to an external system."""
+    print(f"Action: {result.action_kind} -> {result.allowed}")
+    return result
+
+guardrail = Guardrail(
+    guard=guard,
+    audit_log=log,
+    actor="my-agent",
+    interceptors=[log_interceptor],
+)
+```
+
+Interceptors run after the policy check but before the executor.
+
+## ExecutionResult
+
+The `execute()` method returns an `ExecutionResult` with:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `allowed` | bool | Whether the action was permitted |
+| `output` | Any | Return value of the executor (None if denied) |
+| `decision` | Decision | The policy decision object |
+| `action_kind` | str | The action type that was checked |
+| `target` | str | The action target |
+
+## Error handling
+
+If the executor raises an exception, it is recorded in the audit log
+with `result="error"` and the exception is re-raised:
+
+```python
+def failing_executor() -> str:
+    raise RuntimeError("Something went wrong")
+
+try:
+    result = guardrail.execute(
+        action_kind="shell_command",
+        target="broken-command",
+        executor=failing_executor,
+        command="broken-command",
+    )
+except RuntimeError:
+    pass  # Error is logged to audit before re-raising
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,58 @@
+# AgentGuard
+
+**Safety and audit framework for autonomous AI agents.**
+
+AgentGuard provides runtime guardrails, action logging, policy enforcement,
+and compliance reporting for AI agent systems.
+
+## Key Features
+
+- **Policy Engine** -- Define rules for what agents can and cannot do using
+  YAML policies or Python code
+- **Audit Logging** -- Structured, tamper-evident, hash-chained action logs
+  in JSONL format
+- **Runtime Guardrails** -- Validate actions before execution with
+  configurable interceptors
+- **Compliance Reports** -- Generate EU AI Act compliance reports from
+  audit data
+- **MCP Server** -- Transparent policy enforcement via Model Context Protocol
+- **CLI Tool** -- Command-line access to all core capabilities
+
+## Design Principles
+
+1. **Framework-agnostic** -- Works with any agent framework or custom agents
+2. **Zero-dependency core** -- Core library requires only PyYAML
+3. **Pluggable policies** -- YAML or Python policy definitions
+4. **Immutable audit logs** -- Append-only, hash-chained for integrity
+5. **Type-safe** -- Full mypy strict compliance
+
+## Quick Example
+
+```python
+from agentguard import Guard
+
+guard = Guard()
+guard.load_policy_file("policies/no-force-push.yaml")
+
+decision = guard.check("shell_command", command="git push --force")
+if not decision.allowed:
+    print(f"Blocked: {decision.reason}")
+```
+
+## Getting Started
+
+- [Installation](getting-started/installation.md) -- Install AgentGuard
+- [Quick Start](getting-started/quickstart.md) -- First steps with policies and auditing
+
+## Guides
+
+- [Policy Authoring](guides/policy-authoring.md) -- Write custom policies
+- [Audit Logging](guides/audit-logging.md) -- Record and verify agent actions
+- [Runtime Guardrails](guides/runtime-guardrails.md) -- Wrap execution with safety checks
+- [Compliance Reports](guides/compliance-reports.md) -- Generate EU AI Act reports
+- [MCP Integration](guides/mcp-integration.md) -- Use with Claude Desktop and other MCP clients
+- [CLI Reference](guides/cli-reference.md) -- Command-line tool usage
+
+## License
+
+AgentGuard is licensed under [AGPL-3.0-or-later](https://www.gnu.org/licenses/agpl-3.0.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,75 @@
+site_name: AgentGuard
+site_url: https://roboter-schlafen-nicht.github.io/agentguard/
+site_description: Safety and audit framework for autonomous AI agents
+repo_url: https://github.com/Roboter-Schlafen-Nicht/agentguard
+repo_name: Roboter-Schlafen-Nicht/agentguard
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - toc.follow
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            docstring_style: google
+            members_order: source
+            merge_init_into_class: true
+            show_signature_annotations: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quickstart.md
+  - Guides:
+      - Policy Authoring: guides/policy-authoring.md
+      - Audit Logging: guides/audit-logging.md
+      - Runtime Guardrails: guides/runtime-guardrails.md
+      - Compliance Reports: guides/compliance-reports.md
+      - MCP Integration: guides/mcp-integration.md
+      - CLI Reference: guides/cli-reference.md
+  - API Reference:
+      - Policies: api/policies.md
+      - Audit: api/audit.md
+      - Guardrails: api/guardrails.md
+      - Compliance: api/compliance.md
+      - MCP Server: api/mcp.md
+      - CLI: api/cli.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ dev = [
     "types-PyYAML>=6.0",
     "mcp>=1.0",
 ]
+docs = [
+    "mkdocs-material>=9.0",
+    "mkdocstrings[python]>=0.24",
+]
 
 [project.scripts]
 agentguard = "agentguard.cli:main"


### PR DESCRIPTION
## Summary

- Add complete documentation site using MkDocs Material with mkdocstrings for auto-generated API reference
- Create 6 usage guides: policy authoring, audit logging, runtime guardrails, compliance reports, MCP integration, CLI reference
- Create 6 API reference pages covering all public modules: policies, audit, guardrails, compliance, MCP server, CLI
- Add `docs` optional dependency group to `pyproject.toml` (`mkdocs-material>=9.0`, `mkdocstrings[python]>=0.24`)
- Add `output/` to `.gitignore`

## Documentation Structure

```
docs/
  index.md                          -- Home page
  getting-started/
    installation.md                 -- Installation guide
    quickstart.md                   -- Quick start tutorial
  guides/
    policy-authoring.md             -- Writing custom policies
    audit-logging.md                -- Audit log usage
    runtime-guardrails.md           -- Guardrail pipeline usage
    compliance-reports.md           -- Compliance report generation
    mcp-integration.md              -- MCP/Claude Desktop setup
    cli-reference.md                -- CLI command reference
  api/
    policies.md                     -- Policy engine API (mkdocstrings)
    audit.md                        -- Audit log API (mkdocstrings)
    guardrails.md                   -- Guardrails API (mkdocstrings)
    compliance.md                   -- Compliance API (mkdocstrings)
    mcp.md                          -- MCP server API (mkdocstrings)
    cli.md                          -- CLI API (mkdocstrings)
```

## Verification

- `mkdocs build --strict` passes with no errors
- Full test suite passes (296 tests)
- Ruff lint and format pass