### PR TITLE
feat: add private policy auto-discovery

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -236,6 +236,7 @@ def _parse_params(params: list[str]) -> dict[str, str]:
 def _cmd_check(args: argparse.Namespace) -> int:
     """Check an action against policies."""
     from agentguard.policies.builtins import load_all_builtins
+    from agentguard.policies.discovery import auto_discover
     from agentguard.policies.guard import Guard
 
     if args.action_kind is None:
@@ -243,6 +244,9 @@ def _cmd_check(args: argparse.Namespace) -> int:
         return 2
 
     guard = Guard()
+
+    # Determine if user explicitly provided policy sources
+    has_explicit_policies = bool(args.policy) or bool(args.policy_dir)
 
     # Load policies
     if args.builtins:
@@ -270,6 +274,11 @@ def _cmd_check(args: argparse.Namespace) -> int:
             except Exception as e:
                 print(f"Error loading policy '{yaml_file}': {e}", file=sys.stderr)
                 return 1
+
+    # Auto-discover policies when no explicit --policy or --policy-dir given
+    if not has_explicit_policies:
+        for policy in auto_discover():
+            guard.add_policy(policy)
 
     try:
         params = _parse_params(args.params or [])

--- a/src/agentguard/mcp/server.py
+++ b/src/agentguard/mcp/server.py
@@ -25,6 +25,7 @@ def create_server(
     audit_dir: str | None = None,
     actor: str = "agent",
     load_builtins: bool = False,
+    auto_discover: bool = False,
 ) -> FastMCP:
     """Create an AgentGuard MCP server.
 
@@ -35,6 +36,9 @@ def create_server(
             during the session. If None, logs are kept in memory only.
         actor: Name of the actor recorded in audit entries.
         load_builtins: Whether to load AgentGuard's built-in policies.
+        auto_discover: Whether to auto-discover policies from standard
+            locations (``.agentguard/policies/``, ``~/.agentguard/policies/``,
+            ``$AGENTGUARD_POLICY_DIR``). Disabled by default.
 
     Returns:
         A FastMCP application with tools registered.
@@ -54,6 +58,12 @@ def create_server(
             raise FileNotFoundError(msg)
         for yaml_file in sorted(policy_path.glob("*.yaml")):
             guard.load_policy_file(yaml_file)
+
+    if auto_discover:
+        from agentguard.policies.discovery import auto_discover as _auto_discover
+
+        for policy in _auto_discover():
+            guard.add_policy(policy)
 
     if load_builtins:
         for policy in load_all_builtins():

--- a/src/agentguard/policies/__init__.py
+++ b/src/agentguard/policies/__init__.py
@@ -1,6 +1,7 @@
 """Policy engine for defining and enforcing agent behavior rules."""
 
 from agentguard.policies.builtins import list_builtins, load_all_builtins, load_builtin
+from agentguard.policies.discovery import auto_discover, discover_policies
 from agentguard.policies.guard import Guard
 from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
 from agentguard.policies.models import Action, Decision, Policy, Rule, Severity
@@ -12,6 +13,8 @@ __all__ = [
     "Policy",
     "Rule",
     "Severity",
+    "auto_discover",
+    "discover_policies",
     "list_builtins",
     "load_all_builtins",
     "load_builtin",

--- a/src/agentguard/policies/discovery.py
+++ b/src/agentguard/policies/discovery.py
@@ -1,0 +1,158 @@
+"""Policy auto-discovery.
+
+Automatically discovers and loads policy YAML files from standard
+locations, enabling private/custom policies without explicit CLI flags.
+
+Discovery order (first found wins for duplicate policy names):
+1. ``$AGENTGUARD_POLICY_DIR`` — colon-separated list of directories
+2. Project-level: ``.agentguard/policies/`` relative to CWD
+3. User-level: ``~/.agentguard/policies/``
+
+All directories are scanned for ``*.yaml`` files. Files are loaded
+alphabetically within each directory. If two directories contain a
+policy with the same name, the one from the higher-priority directory
+is kept.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentguard.policies.loader import load_policy_from_yaml
+
+if TYPE_CHECKING:
+    from agentguard.policies.models import Policy
+
+logger = logging.getLogger(__name__)
+
+_ENV_VAR = "AGENTGUARD_POLICY_DIR"
+
+
+def default_project_dir() -> Path:
+    """Return the default project-level policy directory.
+
+    Returns:
+        ``.agentguard/policies/`` relative to the current working directory.
+    """
+    return Path.cwd() / ".agentguard" / "policies"
+
+
+def default_user_dir() -> Path:
+    """Return the default user-level policy directory.
+
+    Returns:
+        ``~/.agentguard/policies/``.
+    """
+    return Path.home() / ".agentguard" / "policies"
+
+
+def discover_policy_dirs(
+    *,
+    project_dir: Path | None = None,
+    user_dir: Path | None = None,
+) -> list[Path]:
+    """Discover directories containing policy YAML files.
+
+    Checks (in priority order):
+    1. Directories from ``$AGENTGUARD_POLICY_DIR`` (colon-separated)
+    2. Project-level directory
+    3. User-level directory
+
+    Only directories that actually exist are returned. Duplicates
+    (by resolved path) are removed.
+
+    Args:
+        project_dir: Project-level policy directory to check.
+        user_dir: User-level policy directory to check.
+
+    Returns:
+        List of existing directories, ordered by priority.
+    """
+    candidates: list[Path] = []
+
+    # 1. Environment variable directories
+    env_value = os.environ.get(_ENV_VAR, "").strip()
+    if env_value:
+        for part in env_value.split(":"):
+            part = part.strip()
+            if part:
+                candidates.append(Path(part))
+
+    # 2. Project-level
+    if project_dir is not None:
+        candidates.append(project_dir)
+
+    # 3. User-level
+    if user_dir is not None:
+        candidates.append(user_dir)
+
+    # Filter to existing directories and deduplicate by resolved path
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved not in seen and candidate.is_dir():
+            seen.add(resolved)
+            result.append(candidate)
+
+    return result
+
+
+def discover_policies(
+    *,
+    project_dir: Path | None = None,
+    user_dir: Path | None = None,
+) -> list[Policy]:
+    """Discover and load policies from standard locations.
+
+    Scans directories returned by :func:`discover_policy_dirs` for
+    ``*.yaml`` files and loads them as policies. Files are loaded
+    alphabetically within each directory. If two directories contain
+    a policy with the same ``name``, the one from the higher-priority
+    directory is kept (first wins).
+
+    Invalid YAML files are skipped with a warning log.
+
+    Args:
+        project_dir: Project-level policy directory to check.
+        user_dir: User-level policy directory to check.
+
+    Returns:
+        List of loaded Policy objects, deduplicated by name.
+    """
+    dirs = discover_policy_dirs(project_dir=project_dir, user_dir=user_dir)
+
+    seen_names: set[str] = set()
+    policies: list[Policy] = []
+
+    for policy_dir in dirs:
+        for yaml_file in sorted(policy_dir.glob("*.yaml")):
+            try:
+                policy = load_policy_from_yaml(yaml_file)
+            except Exception:
+                logger.warning("Skipping invalid policy file: %s", yaml_file)
+                continue
+
+            if policy.name not in seen_names:
+                seen_names.add(policy.name)
+                policies.append(policy)
+
+    return policies
+
+
+def auto_discover() -> list[Policy]:
+    """Discover policies using default project and user directories.
+
+    Convenience wrapper around :func:`discover_policies` that uses
+    :func:`default_project_dir` and :func:`default_user_dir`.
+
+    Returns:
+        List of auto-discovered Policy objects.
+    """
+    return discover_policies(
+        project_dir=default_project_dir(),
+        user_dir=default_user_dir(),
+    )

--- a/src/agentguard/policies/guard.py
+++ b/src/agentguard/policies/guard.py
@@ -39,6 +39,37 @@ class Guard:
         """
         self._policies: list[Policy] = list(policies) if policies else []
 
+    @classmethod
+    def with_auto_discovery(cls, *, include_builtins: bool = False) -> Guard:
+        """Create a Guard with auto-discovered policies.
+
+        Loads policies from standard locations:
+        1. ``$AGENTGUARD_POLICY_DIR`` (colon-separated directories)
+        2. ``.agentguard/policies/`` (project-level, relative to CWD)
+        3. ``~/.agentguard/policies/`` (user-level)
+
+        Args:
+            include_builtins: Also load AgentGuard's built-in policies
+                (appended after discovered policies).
+
+        Returns:
+            A new Guard instance with discovered (and optionally
+            built-in) policies loaded.
+        """
+        from agentguard.policies.builtins import load_all_builtins
+        from agentguard.policies.discovery import auto_discover
+
+        policies = auto_discover()
+
+        if include_builtins:
+            seen_names = {p.name for p in policies}
+            for builtin in load_all_builtins():
+                if builtin.name not in seen_names:
+                    seen_names.add(builtin.name)
+                    policies.append(builtin)
+
+        return cls(policies=policies)
+
     @property
     def policies(self) -> list[Policy]:
         """Return the list of loaded policies."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,6 +12,8 @@ from agentguard.cli import main
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 
 def _run_cli(*args: str) -> tuple[int, str, str]:
     """Run the CLI with the given arguments and capture output.
@@ -479,3 +481,114 @@ class TestErrorHandling:
         )
         assert exit_code == 1
         assert "error" in stderr.lower()
+
+
+# --- Auto-discovery ---
+
+
+class TestAutoDiscovery:
+    """CLI auto-discovers policies from .agentguard/policies/ when no
+    --policy or --policy-dir flags are given."""
+
+    def test_auto_discovers_project_policies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When CWD has .agentguard/policies/, check loads them automatically."""
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        policy_dir = tmp_path / ".agentguard" / "policies"
+        policy_dir.mkdir(parents=True)
+        _create_policy_file(policy_dir / "test.yaml")
+
+        # rm -rf should be denied by the auto-discovered policy
+        exit_code, stdout, _ = _run_cli("check", "shell_command", "command=rm -rf /")
+        assert exit_code == 1
+        assert "denied" in stdout.lower()
+
+    def test_auto_discover_allows_safe_commands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Auto-discovered policies should still allow non-matching commands."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        policy_dir = tmp_path / ".agentguard" / "policies"
+        policy_dir.mkdir(parents=True)
+        _create_policy_file(policy_dir / "test.yaml")
+
+        exit_code, stdout, _ = _run_cli("check", "shell_command", "command=ls -la")
+        assert exit_code == 0
+        assert "allowed" in stdout.lower()
+
+    def test_explicit_policy_overrides_auto_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When --policy or --policy-dir is given, auto-discovery is skipped."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        # Project-level policy that blocks rm
+        project_dir = tmp_path / ".agentguard" / "policies"
+        project_dir.mkdir(parents=True)
+        _create_policy_file(project_dir / "block-rm.yaml")
+
+        # Explicit empty policy dir (no policies)
+        explicit_dir = tmp_path / "explicit-policies"
+        explicit_dir.mkdir()
+
+        # With --policy-dir pointing to empty dir, auto-discovery is skipped
+        exit_code, stdout, _ = _run_cli(
+            "check",
+            "--policy-dir",
+            str(explicit_dir),
+            "shell_command",
+            "command=rm -rf /",
+        )
+        assert exit_code == 0
+        assert "allowed" in stdout.lower()
+
+    def test_builtins_flag_still_works_with_auto_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--builtins flag should NOT suppress auto-discovery."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        policy_dir = tmp_path / ".agentguard" / "policies"
+        policy_dir.mkdir(parents=True)
+        _create_policy_file(policy_dir / "test.yaml")
+
+        # Should have both builtins and auto-discovered
+        exit_code, stdout, _ = _run_cli(
+            "check", "--builtins", "shell_command", "command=rm -rf /"
+        )
+        assert exit_code == 1
+        assert "denied" in stdout.lower()
+
+    def test_env_var_policies_loaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AGENTGUARD_POLICY_DIR env var policies are auto-discovered."""
+        monkeypatch.chdir(tmp_path)
+
+        env_dir = tmp_path / "env-policies"
+        env_dir.mkdir()
+        _create_policy_file(env_dir / "test.yaml")
+        monkeypatch.setenv("AGENTGUARD_POLICY_DIR", str(env_dir))
+
+        exit_code, stdout, _ = _run_cli("check", "shell_command", "command=rm -rf /")
+        assert exit_code == 1
+        assert "denied" in stdout.lower()
+
+    def test_no_auto_discovery_when_no_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When no policy dirs exist, check allows everything (no crash)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        exit_code, stdout, _ = _run_cli("check", "shell_command", "command=rm -rf /")
+        assert exit_code == 0
+        assert "allowed" in stdout.lower()

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,356 @@
+"""Tests for policy auto-discovery (private policies)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentguard.policies.models import Policy
+
+if TYPE_CHECKING:
+    import pytest
+
+SAMPLE_POLICY_YAML = textwrap.dedent("""\
+    name: custom-no-rm
+    description: Block rm commands
+    rules:
+      - action: shell_command
+        deny:
+          - pattern: '\\brm\\b'
+        severity: high
+""")
+
+SAMPLE_POLICY_2_YAML = textwrap.dedent("""\
+    name: custom-no-curl
+    description: Block curl commands
+    rules:
+      - action: shell_command
+        deny:
+          - pattern: '\\bcurl\\b'
+        severity: medium
+""")
+
+
+def _write_policy(directory: Path, filename: str, content: str) -> Path:
+    """Write a policy YAML file into a directory."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestDiscoverPolicyDirs:
+    """Test discover_policy_dirs() — finds directories to search."""
+
+    def test_returns_empty_when_nothing_exists(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        dirs = discover_policy_dirs(
+            project_dir=tmp_path / "nonexistent",
+            user_dir=tmp_path / "also-nonexistent",
+        )
+        assert dirs == []
+
+    def test_finds_project_level_dir(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        project_policies = tmp_path / ".agentguard" / "policies"
+        project_policies.mkdir(parents=True)
+
+        dirs = discover_policy_dirs(
+            project_dir=project_policies,
+            user_dir=tmp_path / "nonexistent",
+        )
+        assert dirs == [project_policies]
+
+    def test_finds_user_level_dir(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        user_policies = tmp_path / ".agentguard" / "policies"
+        user_policies.mkdir(parents=True)
+
+        dirs = discover_policy_dirs(
+            project_dir=tmp_path / "nonexistent",
+            user_dir=user_policies,
+        )
+        assert dirs == [user_policies]
+
+    def test_finds_both_project_and_user(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        project_policies = tmp_path / "project" / ".agentguard" / "policies"
+        project_policies.mkdir(parents=True)
+        user_policies = tmp_path / "home" / ".agentguard" / "policies"
+        user_policies.mkdir(parents=True)
+
+        dirs = discover_policy_dirs(
+            project_dir=project_policies,
+            user_dir=user_policies,
+        )
+        # Project comes before user (higher priority)
+        assert dirs == [project_policies, user_policies]
+
+    def test_env_var_dirs_come_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        env_dir = tmp_path / "env-policies"
+        env_dir.mkdir(parents=True)
+        project_policies = tmp_path / "project" / ".agentguard" / "policies"
+        project_policies.mkdir(parents=True)
+
+        monkeypatch.setenv("AGENTGUARD_POLICY_DIR", str(env_dir))
+
+        dirs = discover_policy_dirs(
+            project_dir=project_policies,
+            user_dir=tmp_path / "nonexistent",
+        )
+        assert dirs == [env_dir, project_policies]
+
+    def test_env_var_multiple_dirs_colon_separated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        dir1 = tmp_path / "policies-a"
+        dir1.mkdir()
+        dir2 = tmp_path / "policies-b"
+        dir2.mkdir()
+
+        monkeypatch.setenv("AGENTGUARD_POLICY_DIR", f"{dir1}:{dir2}")
+
+        dirs = discover_policy_dirs(
+            project_dir=tmp_path / "nonexistent",
+            user_dir=tmp_path / "also-nonexistent",
+        )
+        assert dirs == [dir1, dir2]
+
+    def test_env_var_skips_nonexistent_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        fake_dir = tmp_path / "fake"
+
+        monkeypatch.setenv("AGENTGUARD_POLICY_DIR", f"{real_dir}:{fake_dir}")
+
+        dirs = discover_policy_dirs(
+            project_dir=tmp_path / "nonexistent",
+            user_dir=tmp_path / "also-nonexistent",
+        )
+        assert dirs == [real_dir]
+
+    def test_no_duplicates(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policy_dirs
+
+        same_dir = tmp_path / ".agentguard" / "policies"
+        same_dir.mkdir(parents=True)
+
+        dirs = discover_policy_dirs(
+            project_dir=same_dir,
+            user_dir=same_dir,
+        )
+        assert dirs == [same_dir]
+
+
+class TestDiscoverPolicies:
+    """Test discover_policies() — loads Policy objects from auto-discovered dirs."""
+
+    def test_returns_empty_when_no_dirs_exist(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        policies = discover_policies(
+            project_dir=tmp_path / "nonexistent",
+            user_dir=tmp_path / "also-nonexistent",
+        )
+        assert policies == []
+
+    def test_loads_policy_from_project_dir(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        project_policies = tmp_path / ".agentguard" / "policies"
+        _write_policy(project_policies, "custom-no-rm.yaml", SAMPLE_POLICY_YAML)
+
+        policies = discover_policies(
+            project_dir=project_policies,
+            user_dir=tmp_path / "nonexistent",
+        )
+        assert len(policies) == 1
+        assert policies[0].name == "custom-no-rm"
+        assert isinstance(policies[0], Policy)
+
+    def test_loads_policy_from_user_dir(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        user_policies = tmp_path / ".agentguard" / "policies"
+        _write_policy(user_policies, "custom-no-curl.yaml", SAMPLE_POLICY_2_YAML)
+
+        policies = discover_policies(
+            project_dir=tmp_path / "nonexistent",
+            user_dir=user_policies,
+        )
+        assert len(policies) == 1
+        assert policies[0].name == "custom-no-curl"
+
+    def test_loads_from_multiple_dirs(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        project_dir = tmp_path / "project" / ".agentguard" / "policies"
+        user_dir = tmp_path / "home" / ".agentguard" / "policies"
+        _write_policy(project_dir, "custom-no-rm.yaml", SAMPLE_POLICY_YAML)
+        _write_policy(user_dir, "custom-no-curl.yaml", SAMPLE_POLICY_2_YAML)
+
+        policies = discover_policies(
+            project_dir=project_dir,
+            user_dir=user_dir,
+        )
+        assert len(policies) == 2
+        names = [p.name for p in policies]
+        assert "custom-no-rm" in names
+        assert "custom-no-curl" in names
+
+    def test_deduplicates_by_name_first_wins(self, tmp_path: Path) -> None:
+        """If same policy name appears in project and user dir, project wins."""
+        from agentguard.policies.discovery import discover_policies
+
+        project_dir = tmp_path / "project" / ".agentguard" / "policies"
+        user_dir = tmp_path / "home" / ".agentguard" / "policies"
+
+        # Same policy name in both dirs, different descriptions
+        project_yaml = SAMPLE_POLICY_YAML.replace(
+            "Block rm commands", "Project version"
+        )
+        user_yaml = SAMPLE_POLICY_YAML.replace("Block rm commands", "User version")
+
+        _write_policy(project_dir, "custom-no-rm.yaml", project_yaml)
+        _write_policy(user_dir, "custom-no-rm.yaml", user_yaml)
+
+        policies = discover_policies(
+            project_dir=project_dir,
+            user_dir=user_dir,
+        )
+        assert len(policies) == 1
+        assert policies[0].name == "custom-no-rm"
+        assert policies[0].description == "Project version"
+
+    def test_env_var_policies_take_highest_priority(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        env_dir = tmp_path / "env-policies"
+        project_dir = tmp_path / "project" / ".agentguard" / "policies"
+
+        env_yaml = SAMPLE_POLICY_YAML.replace("Block rm commands", "Env version")
+        project_yaml = SAMPLE_POLICY_YAML.replace(
+            "Block rm commands", "Project version"
+        )
+
+        _write_policy(env_dir, "custom-no-rm.yaml", env_yaml)
+        _write_policy(project_dir, "custom-no-rm.yaml", project_yaml)
+
+        monkeypatch.setenv("AGENTGUARD_POLICY_DIR", str(env_dir))
+
+        policies = discover_policies(
+            project_dir=project_dir,
+            user_dir=tmp_path / "nonexistent",
+        )
+        assert len(policies) == 1
+        assert policies[0].description == "Env version"
+
+    def test_skips_non_yaml_files(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        project_dir.mkdir(parents=True)
+        _write_policy(project_dir, "custom-no-rm.yaml", SAMPLE_POLICY_YAML)
+        (project_dir / "README.md").write_text("not a policy", encoding="utf-8")
+        (project_dir / "notes.txt").write_text("also not a policy", encoding="utf-8")
+
+        policies = discover_policies(
+            project_dir=project_dir,
+            user_dir=tmp_path / "nonexistent",
+        )
+        assert len(policies) == 1
+        assert policies[0].name == "custom-no-rm"
+
+    def test_skips_invalid_yaml_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        from agentguard.policies.discovery import discover_policies
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        _write_policy(project_dir, "valid.yaml", SAMPLE_POLICY_YAML)
+        _write_policy(project_dir, "invalid.yaml", "not: a: valid: policy:")
+
+        with caplog.at_level(logging.WARNING, logger="agentguard.policies.discovery"):
+            policies = discover_policies(
+                project_dir=project_dir,
+                user_dir=tmp_path / "nonexistent",
+            )
+
+        # Valid policy loaded, invalid skipped
+        assert len(policies) == 1
+        assert policies[0].name == "custom-no-rm"
+        # Warning logged for the invalid one
+        assert any("invalid.yaml" in record.message for record in caplog.records)
+
+    def test_sorted_by_filename_within_dir(self, tmp_path: Path) -> None:
+        from agentguard.policies.discovery import discover_policies
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        _write_policy(project_dir, "z-policy.yaml", SAMPLE_POLICY_2_YAML)
+        _write_policy(project_dir, "a-policy.yaml", SAMPLE_POLICY_YAML)
+
+        policies = discover_policies(
+            project_dir=project_dir,
+            user_dir=tmp_path / "nonexistent",
+        )
+        assert len(policies) == 2
+        # Sorted alphabetically by filename
+        assert policies[0].name == "custom-no-rm"  # a-policy.yaml
+        assert policies[1].name == "custom-no-curl"  # z-policy.yaml
+
+
+class TestDefaultPaths:
+    """Test that default_project_dir() and default_user_dir() return correct paths."""
+
+    def test_default_project_dir_relative_to_cwd(self) -> None:
+        from agentguard.policies.discovery import default_project_dir
+
+        result = default_project_dir()
+        assert result == Path.cwd() / ".agentguard" / "policies"
+
+    def test_default_user_dir_in_home(self) -> None:
+        from agentguard.policies.discovery import default_user_dir
+
+        result = default_user_dir()
+        assert result == Path.home() / ".agentguard" / "policies"
+
+
+class TestDiscoverPoliciesConvenience:
+    """Test the convenience function that uses default paths."""
+
+    def test_auto_discover_uses_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ensure auto_discover() calls discover_policies with default paths."""
+        from agentguard.policies.discovery import auto_discover
+
+        # Set CWD to tmp_path so the project dir is predictable
+        monkeypatch.chdir(tmp_path)
+        # Remove env var to avoid interference
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        _write_policy(project_dir, "custom-no-rm.yaml", SAMPLE_POLICY_YAML)
+
+        policies = auto_discover()
+        assert len(policies) == 1
+        assert policies[0].name == "custom-no-rm"

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -10,6 +10,8 @@ from agentguard.policies.guard import Guard
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 from agentguard.policies.models import (
     Decision,
     Policy,
@@ -198,3 +200,89 @@ class TestGuardLoadYaml:
         guard.load_policy_file(policy_file)
         guard.add_policy(_make_policy("code-policy", pattern="eval"))
         assert len(guard.policies) == 3
+
+
+class TestGuardAutoDiscover:
+    """Tests for Guard.with_auto_discovery() class method."""
+
+    def test_with_auto_discovery_loads_project_policies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        project_dir.mkdir(parents=True)
+        (project_dir / "no-rm.yaml").write_text(
+            textwrap.dedent("""\
+                name: no-rm
+                rules:
+                  - action: shell_command
+                    deny:
+                      - pattern: "\\\\brm\\\\b"
+                    severity: critical
+            """),
+            encoding="utf-8",
+        )
+
+        guard = Guard.with_auto_discovery()
+        assert len(guard.policies) == 1
+        assert guard.policies[0].name == "no-rm"
+
+    def test_with_auto_discovery_returns_guard_instance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        guard = Guard.with_auto_discovery()
+        assert isinstance(guard, Guard)
+
+    def test_with_auto_discovery_no_policies_returns_empty_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        guard = Guard.with_auto_discovery()
+        assert len(guard.policies) == 0
+
+    def test_with_auto_discovery_include_builtins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        guard = Guard.with_auto_discovery(include_builtins=True)
+        # Should have at least the 5 built-in policies
+        assert len(guard.policies) >= 5
+        names = [p.name for p in guard.policies]
+        assert "no-force-push" in names
+
+    def test_with_auto_discovery_combines_discovered_and_builtins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        project_dir.mkdir(parents=True)
+        (project_dir / "custom.yaml").write_text(
+            textwrap.dedent("""\
+                name: custom-policy
+                rules:
+                  - action: shell_command
+                    deny:
+                      - pattern: "custom-bad"
+                    severity: low
+            """),
+            encoding="utf-8",
+        )
+
+        guard = Guard.with_auto_discovery(include_builtins=True)
+        names = [p.name for p in guard.policies]
+        # Discovered policies come first, then builtins
+        assert "custom-policy" in names
+        assert "no-force-push" in names
+        # Custom should be before builtins
+        assert names.index("custom-policy") < names.index("no-force-push")

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -690,3 +690,106 @@ class TestAuditQueryTool:
             assert "0" in text or "no entries" in text.lower() or "[]" in text
 
         await with_server(check)
+
+
+# ===========================================================================
+# Test: Auto-discovery in MCP server
+# ===========================================================================
+
+
+class TestMCPAutoDiscovery:
+    """Test that the MCP server supports auto_discover parameter."""
+
+    @pytest.mark.anyio
+    async def test_auto_discover_loads_project_policies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Server with auto_discover=True should load project-level policies."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        project_dir.mkdir(parents=True)
+        (project_dir / "block-rm.yaml").write_text(
+            "name: block-rm\n"
+            "description: Block rm commands\n"
+            "rules:\n"
+            "  - action: shell_execute\n"
+            "    deny:\n"
+            "      - pattern: '\\brm\\b'\n"
+            "    severity: critical\n"
+        )
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("agentguard_status", {})
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "block-rm" in text
+
+        await with_server_auto_discover(check)
+
+    @pytest.mark.anyio
+    async def test_auto_discover_false_skips_project_policies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """auto_discover=False (default) skips project policies."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENTGUARD_POLICY_DIR", raising=False)
+
+        project_dir = tmp_path / ".agentguard" / "policies"
+        project_dir.mkdir(parents=True)
+        (project_dir / "block-rm.yaml").write_text(
+            "name: block-rm\n"
+            "description: Block rm commands\n"
+            "rules:\n"
+            "  - action: shell_execute\n"
+            "    deny:\n"
+            "      - pattern: '\\brm\\b'\n"
+            "    severity: critical\n"
+        )
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("agentguard_status", {})
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "block-rm" not in text
+
+        # Default (no auto_discover) — should NOT load project policies
+        await with_server(check)
+
+
+async def with_server_auto_discover(
+    fn: Any,
+    *,
+    audit_dir: Path | None = None,
+    actor: str = "test-agent",
+) -> None:
+    """Like with_server but with auto_discover=True."""
+    from agentguard.mcp.server import create_server
+
+    app = create_server(
+        audit_dir=str(audit_dir) if audit_dir else None,
+        actor=actor,
+        auto_discover=True,
+    )
+
+    server = app._mcp_server  # type: ignore[attr-defined]
+
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
+
+    async with anyio.create_task_group() as tg:
+
+        async def run_server() -> None:
+            await server.run(
+                c2s_recv,
+                s2c_send,
+                server.create_initialization_options(),
+            )
+
+        async def run_client() -> None:
+            async with ClientSession(s2c_recv, c2s_send) as session:
+                await session.initialize()
+                await fn(session)
+                tg.cancel_scope.cancel()
+
+        tg.start_soon(run_server)
+        tg.start_soon(run_client)


### PR DESCRIPTION
## Summary

- Add automatic loading of custom policies from standard directories (`.agentguard/policies/`, `~/.agentguard/policies/`, `$AGENTGUARD_POLICY_DIR`) when no explicit `--policy` or `--policy-dir` flags are given
- Add `Guard.with_auto_discovery()` classmethod and `auto_discover` parameter to MCP `create_server()`
- 33 new tests (399 total), all passing across Python 3.10-3.13

## Details

**Discovery module** (`src/agentguard/policies/discovery.py`):
- `discover_policy_dirs()` — finds directories in priority order: env var > project > user
- `discover_policies()` — loads all `.yaml` files from discovered dirs with dedup by name
- `auto_discover()` — convenience function combining discovery + loading

**CLI integration** (`src/agentguard/cli.py`):
- Auto-discovers when no `--policy` or `--policy-dir` flags given
- `--builtins` does NOT suppress auto-discovery
- Explicit flags DO suppress auto-discovery

**Guard integration** (`src/agentguard/policies/guard.py`):
- `Guard.with_auto_discovery(include_builtins=False)` classmethod

**MCP integration** (`src/agentguard/mcp/server.py`):
- `auto_discover=False` parameter on `create_server()`

**Files changed:** 9 files (2 new, 7 modified), 881 insertions