### PR TITLE
feat: add `agentguard serve` CLI subcommand for MCP server launch

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -5,6 +5,7 @@ Provides command-line access to AgentGuard's core capabilities:
 - audit: Inspect and verify audit logs
 - report: Generate compliance reports
 - policies: List and inspect available policies
+- serve: Start the MCP server with policy enforcement
 - version: Print the AgentGuard version
 
 Uses only stdlib argparse (no external dependencies).
@@ -23,6 +24,11 @@ if TYPE_CHECKING:
 
     from agentguard.audit.log import AuditLog
     from agentguard.audit.models import AuditEntry
+
+try:
+    from agentguard.mcp.server import create_server
+except ImportError:
+    create_server = None  # type: ignore[assignment]
 
 
 class _Parsers:
@@ -146,6 +152,34 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["text", "json"],
         default="text",
         help="Output format (default: text).",
+    )
+
+    # --- serve ---
+    serve_parser = subparsers.add_parser(
+        "serve", help="Start the AgentGuard MCP server."
+    )
+    serve_parser.add_argument(
+        "--builtins",
+        action="store_true",
+        help="Load all built-in policies.",
+    )
+    serve_parser.add_argument(
+        "--auto-discover",
+        action="store_true",
+        help="Auto-discover policies from standard locations.",
+    )
+    serve_parser.add_argument(
+        "--policy-dir",
+        help="Directory containing policy YAML files.",
+    )
+    serve_parser.add_argument(
+        "--audit-dir",
+        help="Directory where audit logs are saved.",
+    )
+    serve_parser.add_argument(
+        "--actor",
+        default="agent",
+        help="Actor name for audit entries (default: agent).",
     )
 
     # --- report ---
@@ -394,6 +428,43 @@ def _cmd_audit_query(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_serve(args: argparse.Namespace) -> int:
+    """Start the AgentGuard MCP server."""
+    if create_server is None:
+        print(
+            "Error: MCP dependencies not installed. "
+            "Install with: pip install agentguard[mcp]",
+            file=sys.stderr,
+        )
+        return 1
+
+    policy_dir = getattr(args, "policy_dir", None)
+    if policy_dir is not None and not Path(policy_dir).is_dir():
+        print(
+            f"Error: Policy directory not found: {policy_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        app = create_server(
+            policy_dir=policy_dir,
+            audit_dir=getattr(args, "audit_dir", None),
+            actor=args.actor,
+            load_builtins=args.builtins,
+            auto_discover=args.auto_discover,
+        )
+        app.run()
+    except ImportError:
+        print(
+            "Error: MCP dependencies not installed. "
+            "Install with: pip install agentguard[mcp]",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
 def _cmd_report(args: argparse.Namespace) -> int:
     """Generate a compliance report."""
     framework = args.framework.lower()
@@ -462,6 +533,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "check":
         return _cmd_check(args)
+
+    if args.command == "serve":
+        return _cmd_serve(args)
 
     if args.command == "audit":
         if args.audit_command == "verify":

--- a/src/agentguard/mcp/__main__.py
+++ b/src/agentguard/mcp/__main__.py
@@ -1,0 +1,16 @@
+"""Entry point for ``python -m agentguard.mcp``.
+
+Starts an AgentGuard MCP server with built-in policies and
+auto-discovery enabled. For more control over server options,
+use the CLI: ``agentguard serve --help``.
+"""
+
+from __future__ import annotations
+
+from agentguard.mcp.server import create_server
+
+app = create_server(
+    load_builtins=True,
+    auto_discover=True,
+)
+app.run()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -592,3 +592,156 @@ class TestAutoDiscovery:
         exit_code, stdout, _ = _run_cli("check", "shell_command", "command=rm -rf /")
         assert exit_code == 0
         assert "allowed" in stdout.lower()
+
+
+# --- Serve command ---
+
+
+class TestServeCommand:
+    """Tests for the ``agentguard serve`` CLI subcommand."""
+
+    def test_serve_appears_in_help(self) -> None:
+        """The serve subcommand should appear in --help output."""
+        exit_code, stdout, _ = _run_cli("--help")
+        assert exit_code == 0
+        assert "serve" in stdout
+
+    def test_serve_help_shows_options(self) -> None:
+        """Running ``agentguard serve --help`` shows all options."""
+        exit_code, stdout, _ = _run_cli("serve", "--help")
+        assert exit_code == 0
+        assert "--builtins" in stdout
+        assert "--auto-discover" in stdout
+        assert "--policy-dir" in stdout
+        assert "--audit-dir" in stdout
+        assert "--actor" in stdout
+
+    def test_serve_calls_create_server_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no flags, serve calls create_server with defaults and runs it."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli("serve")
+        assert exit_code == 0
+        mock_create.assert_called_once_with(
+            policy_dir=None,
+            audit_dir=None,
+            actor="agent",
+            load_builtins=False,
+            auto_discover=False,
+        )
+        mock_app.run.assert_called_once()
+
+    def test_serve_passes_all_flags(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All CLI flags are forwarded to create_server."""
+        from unittest.mock import MagicMock
+
+        policy_dir = tmp_path / "policies"
+        policy_dir.mkdir()
+        audit_dir = tmp_path / "audit"
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli(
+            "serve",
+            "--builtins",
+            "--auto-discover",
+            "--policy-dir",
+            str(policy_dir),
+            "--audit-dir",
+            str(audit_dir),
+            "--actor",
+            "my-agent",
+        )
+        assert exit_code == 0
+        mock_create.assert_called_once_with(
+            policy_dir=str(policy_dir),
+            audit_dir=str(audit_dir),
+            actor="my-agent",
+            load_builtins=True,
+            auto_discover=True,
+        )
+        mock_app.run.assert_called_once()
+
+    def test_serve_builtins_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--builtins flag enables built-in policies."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli("serve", "--builtins")
+        assert exit_code == 0
+        mock_create.assert_called_once_with(
+            policy_dir=None,
+            audit_dir=None,
+            actor="agent",
+            load_builtins=True,
+            auto_discover=False,
+        )
+
+    def test_serve_auto_discover_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--auto-discover flag enables policy auto-discovery."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli("serve", "--auto-discover")
+        assert exit_code == 0
+        mock_create.assert_called_once_with(
+            policy_dir=None,
+            audit_dir=None,
+            actor="agent",
+            load_builtins=False,
+            auto_discover=True,
+        )
+
+    def test_serve_nonexistent_policy_dir(self) -> None:
+        """--policy-dir pointing to a non-existent directory should error."""
+        from unittest.mock import MagicMock, patch
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        with patch("agentguard.cli.create_server", mock_create):
+            exit_code, _, stderr = _run_cli("serve", "--policy-dir", "/nonexistent/dir")
+        assert exit_code == 1
+        assert "not found" in stderr.lower() or "not exist" in stderr.lower()
+        mock_app.run.assert_not_called()
+
+    def test_serve_mcp_import_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When mcp is not installed, serve should print a helpful error."""
+
+        # Simulate import error by patching the import in the handler
+        def _raise_import_error(*args: object, **kwargs: object) -> None:
+            raise ImportError("No module named 'mcp'")
+
+        monkeypatch.setattr("agentguard.cli.create_server", _raise_import_error)
+
+        exit_code, _, stderr = _run_cli("serve")
+        assert exit_code == 1
+        assert "mcp" in stderr.lower()
+
+    def test_serve_custom_actor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--actor flag customizes the actor name."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli("serve", "--actor", "custom-bot")
+        assert exit_code == 0
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["actor"] == "custom-bot"

--- a/tests/unit/test_mcp_main.py
+++ b/tests/unit/test_mcp_main.py
@@ -1,0 +1,40 @@
+"""Tests for the ``python -m agentguard.mcp`` entry point."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestMCPMain:
+    """Tests for agentguard.mcp.__main__ module."""
+
+    def test_main_module_creates_and_runs_server(self) -> None:
+        """Running ``python -m agentguard.mcp`` creates a server and runs it."""
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+
+        with patch("agentguard.mcp.server.create_server", mock_create):
+            import importlib
+
+            import agentguard.mcp.__main__ as main_mod
+
+            # Reset to count only the reload call
+            mock_create.reset_mock()
+            mock_app.reset_mock()
+            importlib.reload(main_mod)
+
+        mock_create.assert_called_once_with(
+            load_builtins=True,
+            auto_discover=True,
+        )
+        mock_app.run.assert_called_once()
+
+    def test_main_module_is_importable(self) -> None:
+        """The __main__ module should be importable without errors."""
+        with patch("agentguard.mcp.server.create_server") as mock_create:
+            mock_create.return_value = MagicMock()
+            import importlib
+
+            import agentguard.mcp.__main__ as main_mod
+
+            importlib.reload(main_mod)


### PR DESCRIPTION
## Summary

- Add `agentguard serve` CLI subcommand that starts the MCP server with configurable options (`--builtins`, `--auto-discover`, `--policy-dir`, `--audit-dir`, `--actor`)
- Add `python -m agentguard.mcp` entry point for quick server launch with sensible defaults (builtins + auto-discovery enabled)
- Graceful error handling when `mcp` optional dependency is not installed

## Details

This enables launching AgentGuard as an MCP server from the command line, which is required for integration with MCP clients like opencode. The `serve` subcommand exposes all `create_server()` options as CLI flags.

### Files changed
- `src/agentguard/cli.py` — Added `serve` subcommand to parser and `_cmd_serve()` handler with lazy `mcp` import
- `src/agentguard/mcp/__main__.py` — New module for `python -m agentguard.mcp` entry point
- `tests/unit/test_cli.py` — 9 new tests for `serve` subcommand (help, flags, error handling)
- `tests/unit/test_mcp_main.py` — 2 new tests for `__main__` module

### Test results
410 tests passing (11 new), ruff clean.