### PR TITLE
chore: add .agentguard/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 private/
 output/
 .opencode/
+.agentguard/
 AGENTS.md
 AGENTS.core.md
 AGENTS.worker.md


### PR DESCRIPTION
## Summary
- Add `.agentguard/` directory to `.gitignore` to exclude local policy overrides from version control
- This was missed during the AgentGuard MCP rollout (PR #17 added auto-discovery, but the directory wasn't gitignored)