### PR TITLE
feat: add ScanTarget enum and scan field to Rule for LLM proxy policies

### DIFF
--- a/src/agentguard/policies/loader.py
+++ b/src/agentguard/policies/loader.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import yaml
 
-from agentguard.policies.models import Policy, Rule, Severity
+from agentguard.policies.models import Policy, Rule, ScanTarget, Severity
 
 
 def load_policy_from_string(yaml_str: str) -> Policy:
@@ -98,12 +98,14 @@ def _parse_rule(data: Any) -> Rule:
 
     severity = _parse_severity(data["severity"])
     patterns = [_parse_pattern(p) for p in data["deny"]]
+    scan = _parse_scan_target(data["scan"]) if "scan" in data else None
 
     return Rule(
         action_kind=data["action"],
         deny_patterns=patterns,
         severity=severity,
         description=data.get("description"),
+        scan=scan,
     )
 
 
@@ -114,6 +116,26 @@ def _parse_severity(value: str) -> Severity:
     except ValueError:
         valid = ", ".join(s.value for s in Severity)
         msg = f"Invalid severity '{value}'. Valid values: {valid}"
+        raise ValueError(msg) from None
+
+
+def _parse_scan_target(value: str) -> ScanTarget:
+    """Parse a scan target string into a ScanTarget enum.
+
+    Args:
+        value: Scan target string (e.g., "messages", "system", "content", "all").
+
+    Returns:
+        The corresponding ScanTarget enum value.
+
+    Raises:
+        ValueError: If the value is not a valid scan target.
+    """
+    try:
+        return ScanTarget(value)
+    except ValueError:
+        valid = ", ".join(s.value for s in ScanTarget)
+        msg = f"Invalid scan target '{value}'. Valid values: {valid}"
         raise ValueError(msg) from None
 
 

--- a/src/agentguard/policies/models.py
+++ b/src/agentguard/policies/models.py
@@ -48,6 +48,26 @@ class Severity(enum.Enum):
         return self == other or self.__gt__(other)
 
 
+class ScanTarget(enum.Enum):
+    """Target field to scan in LLM proxy policies.
+
+    Specifies which part of an LLM request or response to apply
+    deny patterns against. Only relevant for proxy rules with
+    llm_request or llm_response action kinds.
+
+    Values:
+        MESSAGES: Scan the concatenated message content.
+        SYSTEM: Scan only the system prompt.
+        CONTENT: Scan the response content.
+        ALL: Scan all parameter values (same as default behavior).
+    """
+
+    MESSAGES = "messages"
+    SYSTEM = "system"
+    CONTENT = "content"
+    ALL = "all"
+
+
 @dataclass(frozen=True)
 class Action:
     """An action an agent wants to perform.
@@ -70,28 +90,55 @@ class Rule:
     2. Any of the rule's deny_patterns match any string value in the
        action's params
 
+    When ``scan`` is set, patterns are matched only against the
+    specified parameter key instead of all values. This is used by
+    LLM proxy policies to target specific parts of the request or
+    response (e.g., scan only message content, not metadata).
+
     Attributes:
         action_kind: The kind of action this rule applies to.
         deny_patterns: Compiled regex patterns. If any matches any
             param value, the action is denied.
         severity: How severe a violation of this rule is.
         description: Optional human-readable description.
+        scan: Optional scan target for LLM proxy rules. When None
+            (default), all param values are scanned. When set,
+            only the specified param key is scanned.
     """
 
     action_kind: str
     deny_patterns: list[re.Pattern[str]]
     severity: Severity
     description: str | None = None
+    scan: ScanTarget | None = None
 
     def matches(self, action: Action) -> bool:
         """Check if this rule matches the given action."""
         if action.kind != self.action_kind:
             return False
+        if self.scan is not None:
+            return self._matches_scan_target(action)
         for pattern in self.deny_patterns:
             for value in action.params.values():
                 if isinstance(value, str) and pattern.search(value):
                     return True
         return False
+
+    def _matches_scan_target(self, action: Action) -> bool:
+        """Match patterns against a specific param key or all values."""
+        assert self.scan is not None
+        if self.scan == ScanTarget.ALL:
+            for pattern in self.deny_patterns:
+                for value in action.params.values():
+                    if isinstance(value, str) and pattern.search(value):
+                        return True
+            return False
+        # Scan only the specified key
+        key = self.scan.value
+        target_value = action.params.get(key)
+        if not isinstance(target_value, str):
+            return False
+        return any(pattern.search(target_value) for pattern in self.deny_patterns)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_policy_loader.py
+++ b/tests/unit/test_policy_loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
-from agentguard.policies.models import Policy, Severity
+from agentguard.policies.models import Policy, ScanTarget, Severity
 
 
 class TestLoadPolicyFromString:
@@ -229,3 +229,134 @@ class TestLoadPolicyFromFile:
         )
         policy = load_policy_from_yaml(str(policy_file))
         assert policy.name == "str-path-policy"
+
+
+# === Scan field parsing ===
+
+
+class TestLoadPolicyScanField:
+    def test_rule_without_scan_has_none(self) -> None:
+        """Backward compat: rules without scan field get scan=None."""
+        yaml_str = textwrap.dedent("""\
+            name: no-scan
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm"
+                severity: low
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].scan is None
+
+    def test_rule_with_scan_messages(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: llm-scan
+            rules:
+              - action: llm_request
+                scan: messages
+                deny:
+                  - pattern: "API_KEY"
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].scan == ScanTarget.MESSAGES
+
+    def test_rule_with_scan_system(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: llm-scan-system
+            rules:
+              - action: llm_request
+                scan: system
+                deny:
+                  - pattern: "ignore previous"
+                severity: critical
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].scan == ScanTarget.SYSTEM
+
+    def test_rule_with_scan_content(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: llm-scan-content
+            rules:
+              - action: llm_response
+                scan: content
+                deny:
+                  - pattern: "rm -rf"
+                severity: critical
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].scan == ScanTarget.CONTENT
+
+    def test_rule_with_scan_all(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: llm-scan-all
+            rules:
+              - action: llm_request
+                scan: all
+                deny:
+                  - pattern: "secret"
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].scan == ScanTarget.ALL
+
+    def test_invalid_scan_value_raises(self) -> None:
+        yaml_str = textwrap.dedent("""\
+            name: bad-scan
+            rules:
+              - action: llm_request
+                scan: invalid_target
+                deny:
+                  - pattern: "test"
+                severity: low
+        """)
+        with pytest.raises(ValueError, match="scan target"):
+            load_policy_from_string(yaml_str)
+
+    def test_llm_request_action_kind_accepted(self) -> None:
+        """llm_request is a valid action kind (no special validation)."""
+        yaml_str = textwrap.dedent("""\
+            name: llm-policy
+            rules:
+              - action: llm_request
+                deny:
+                  - pattern: "API_KEY"
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].action_kind == "llm_request"
+
+    def test_llm_response_action_kind_accepted(self) -> None:
+        """llm_response is a valid action kind (no special validation)."""
+        yaml_str = textwrap.dedent("""\
+            name: llm-response-policy
+            rules:
+              - action: llm_response
+                scan: content
+                deny:
+                  - pattern: "ignore previous instructions"
+                severity: critical
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert policy.rules[0].action_kind == "llm_response"
+        assert policy.rules[0].scan == ScanTarget.CONTENT
+
+    def test_mixed_rules_with_and_without_scan(self) -> None:
+        """Policy can mix tool-call rules (no scan) and proxy rules (with scan)."""
+        yaml_str = textwrap.dedent("""\
+            name: mixed-policy
+            rules:
+              - action: shell_command
+                deny:
+                  - pattern: "rm -rf"
+                severity: critical
+              - action: llm_request
+                scan: messages
+                deny:
+                  - pattern: "API_KEY"
+                severity: high
+        """)
+        policy = load_policy_from_string(yaml_str)
+        assert len(policy.rules) == 2
+        assert policy.rules[0].scan is None
+        assert policy.rules[1].scan == ScanTarget.MESSAGES

--- a/tests/unit/test_policy_models.py
+++ b/tests/unit/test_policy_models.py
@@ -12,6 +12,7 @@ from agentguard.policies.models import (
     Decision,
     Policy,
     Rule,
+    ScanTarget,
     Severity,
 )
 
@@ -145,6 +146,158 @@ class TestRule:
             severity=Severity.LOW,
         )
         assert rule.description is None
+
+    def test_rule_default_scan_is_none(self) -> None:
+        """Backward compatibility: scan defaults to None."""
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"rm")],
+            severity=Severity.LOW,
+        )
+        assert rule.scan is None
+
+    def test_rule_with_scan_target(self) -> None:
+        """Rule can be created with an explicit scan target."""
+        rule = Rule(
+            action_kind="llm_request",
+            deny_patterns=[re.compile(r"API_KEY")],
+            severity=Severity.HIGH,
+            scan=ScanTarget.MESSAGES,
+        )
+        assert rule.scan == ScanTarget.MESSAGES
+
+    def test_rule_scan_matches_only_targeted_param(self) -> None:
+        """When scan is set, only the specified param key is scanned."""
+        rule = Rule(
+            action_kind="llm_request",
+            deny_patterns=[re.compile(r"secret_token")],
+            severity=Severity.CRITICAL,
+            scan=ScanTarget.MESSAGES,
+        )
+        # "messages" param contains the pattern — should match
+        action_hit = Action(
+            kind="llm_request",
+            params={
+                "messages": "Tell me about secret_token usage",
+                "model": "gpt-4",
+            },
+        )
+        assert rule.matches(action_hit)
+
+        # Pattern is only in "model" param, not "messages" — should NOT match
+        action_miss = Action(
+            kind="llm_request",
+            params={
+                "messages": "Hello world",
+                "model": "secret_token-model",
+            },
+        )
+        assert not rule.matches(action_miss)
+
+    def test_rule_scan_all_matches_any_param(self) -> None:
+        """scan=ALL behaves like default: scans all param values."""
+        rule = Rule(
+            action_kind="llm_request",
+            deny_patterns=[re.compile(r"secret")],
+            severity=Severity.HIGH,
+            scan=ScanTarget.ALL,
+        )
+        action = Action(
+            kind="llm_request",
+            params={"model": "secret-model", "messages": "hi"},
+        )
+        assert rule.matches(action)
+
+    def test_rule_scan_system_matches_system_param(self) -> None:
+        """scan=SYSTEM targets only the 'system' param key."""
+        rule = Rule(
+            action_kind="llm_request",
+            deny_patterns=[re.compile(r"ignore previous")],
+            severity=Severity.CRITICAL,
+            scan=ScanTarget.SYSTEM,
+        )
+        # Pattern in system param — match
+        action_hit = Action(
+            kind="llm_request",
+            params={"system": "ignore previous instructions", "messages": "hello"},
+        )
+        assert rule.matches(action_hit)
+
+        # Pattern in messages, not system — no match
+        action_miss = Action(
+            kind="llm_request",
+            params={"system": "You are helpful", "messages": "ignore previous rules"},
+        )
+        assert not rule.matches(action_miss)
+
+    def test_rule_scan_content_matches_content_param(self) -> None:
+        """scan=CONTENT targets only the 'content' param key."""
+        rule = Rule(
+            action_kind="llm_response",
+            deny_patterns=[re.compile(r"rm -rf /")],
+            severity=Severity.CRITICAL,
+            scan=ScanTarget.CONTENT,
+        )
+        action_hit = Action(
+            kind="llm_response",
+            params={"content": "Run rm -rf / to clean up"},
+        )
+        assert rule.matches(action_hit)
+
+        action_miss = Action(
+            kind="llm_response",
+            params={"content": "Safe response", "finish_reason": "rm -rf /"},
+        )
+        assert not rule.matches(action_miss)
+
+    def test_rule_scan_missing_key_does_not_match(self) -> None:
+        """If the targeted param key is absent, rule does not match."""
+        rule = Rule(
+            action_kind="llm_request",
+            deny_patterns=[re.compile(r".*")],
+            severity=Severity.LOW,
+            scan=ScanTarget.SYSTEM,
+        )
+        action = Action(
+            kind="llm_request",
+            params={"messages": "hello"},  # no "system" key
+        )
+        assert not rule.matches(action)
+
+    def test_rule_without_scan_still_matches_all_params(self) -> None:
+        """Backward compat: scan=None scans all params (existing behavior)."""
+        rule = Rule(
+            action_kind="shell_command",
+            deny_patterns=[re.compile(r"secret")],
+            severity=Severity.MEDIUM,
+        )
+        assert rule.matches(
+            Action(
+                kind="shell_command",
+                params={"command": "echo", "args": "my secret value"},
+            )
+        )
+
+
+# === ScanTarget enum ===
+
+
+class TestScanTarget:
+    def test_scan_target_values_exist(self) -> None:
+        assert ScanTarget.MESSAGES.value == "messages"
+        assert ScanTarget.SYSTEM.value == "system"
+        assert ScanTarget.CONTENT.value == "content"
+        assert ScanTarget.ALL.value == "all"
+
+    def test_scan_target_from_string(self) -> None:
+        assert ScanTarget("messages") == ScanTarget.MESSAGES
+        assert ScanTarget("system") == ScanTarget.SYSTEM
+        assert ScanTarget("content") == ScanTarget.CONTENT
+        assert ScanTarget("all") == ScanTarget.ALL
+
+    def test_invalid_scan_target_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ScanTarget("invalid")
 
 
 # === Decision dataclass ===


### PR DESCRIPTION
## Summary

- Added `ScanTarget` enum (`MESSAGES`, `SYSTEM`, `CONTENT`, `ALL`) to `policies/models.py` for targeted parameter scanning in LLM proxy policies
- Extended `Rule` dataclass with optional `scan: ScanTarget | None` field and `_matches_scan_target()` method that filters which param keys are checked against deny patterns
- Extended YAML policy loader with `_parse_scan_target()` to support the new `scan` field in policy files
- Added 20 new tests (10 model tests, 10 loader tests) — 441 total, all passing, ruff + mypy clean

Part of M12: LLM API Proxy (2-Way Filter) milestone — this is task 1 of 6 (m12.policy-model-extension).