### PR TITLE
feat: add streaming-aware inbound response scanner

### DIFF
--- a/src/agentguard/proxy/inbound.py
+++ b/src/agentguard/proxy/inbound.py
@@ -1,0 +1,131 @@
+"""Inbound scanner — streaming-aware LLM response scanning.
+
+Accumulates LLM response content as it streams through the proxy
+and runs Guard policies incrementally against the accumulated window.
+When a policy violation is detected mid-stream, the scanner signals
+denial so the proxy can terminate the stream early.
+
+Usage::
+
+    scanner = InboundScanner(guard)
+
+    # Feed chunks as they arrive from the SSE stream
+    for chunk in sse_chunks:
+        result = scanner.feed(chunk)
+        if result is not None:
+            # Policy violation — stop streaming
+            break
+
+    # Get final summary
+    summary = scanner.finalize()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from agentguard.proxy.outbound import estimate_tokens
+
+if TYPE_CHECKING:
+    from agentguard.policies.guard import Guard
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Result of scanning accumulated response content.
+
+    Attributes:
+        denied: Whether the content was denied by a policy.
+        denied_by: Name of the policy that denied it (if denied).
+        reason: Human-readable explanation (if denied).
+        scanned_length: Number of characters scanned so far.
+        token_estimate: Estimated token count of scanned content.
+    """
+
+    denied: bool
+    denied_by: str | None
+    reason: str | None
+    scanned_length: int
+    token_estimate: int
+
+
+class InboundScanner:
+    """Streaming-aware inbound response scanner.
+
+    Accumulates response text and runs Guard policies against the
+    full accumulated window after each chunk.  This ensures patterns
+    spanning chunk boundaries are detected.
+
+    Args:
+        guard: The Guard instance with loaded policies.
+    """
+
+    def __init__(self, guard: Guard) -> None:
+        self._guard = guard
+        self._buffer: list[str] = []
+        self._denied_result: ScanResult | None = None
+
+    @property
+    def accumulated_content(self) -> str:
+        """Return all content fed so far."""
+        return "".join(self._buffer)
+
+    def feed(self, text: str) -> ScanResult | None:
+        """Feed a chunk of response text to the scanner.
+
+        Appends the text to the accumulated window and runs all
+        loaded Guard policies against the full window.
+
+        Args:
+            text: A chunk of response content.
+
+        Returns:
+            ``None`` if the content is allowed so far.
+            A :class:`ScanResult` with ``denied=True`` if a policy
+            violation was detected.  Once denied, all subsequent
+            ``feed()`` calls return the denied result immediately.
+        """
+        if self._denied_result is not None:
+            return self._denied_result
+
+        if text:
+            self._buffer.append(text)
+
+        window = self.accumulated_content
+        if not window:
+            return None
+
+        decision = self._guard.check("llm_response", content=window)
+        if decision.denied:
+            self._denied_result = ScanResult(
+                denied=True,
+                denied_by=decision.denied_by,
+                reason=decision.reason,
+                scanned_length=len(window),
+                token_estimate=estimate_tokens(window),
+            )
+            return self._denied_result
+
+        return None
+
+    def finalize(self) -> ScanResult:
+        """Produce the final scan result at end of stream.
+
+        Returns:
+            A :class:`ScanResult` summarising the full stream.
+            If a denial was triggered earlier, the denied result
+            is returned.  Otherwise an allowed result with content
+            statistics is returned.
+        """
+        if self._denied_result is not None:
+            return self._denied_result
+
+        window = self.accumulated_content
+        return ScanResult(
+            denied=False,
+            denied_by=None,
+            reason=None,
+            scanned_length=len(window),
+            token_estimate=estimate_tokens(window),
+        )

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from starlette.requests import Request
     from starlette.responses import Response
 
@@ -203,8 +205,63 @@ class GuardMiddleware:
         if is_streaming:
             from starlette.background import BackgroundTask
 
-            # Return streaming response with cleanup task
             response_headers = self._filter_response_headers(upstream_response.headers)
+
+            if self.config.scan_responses:
+                # Use inbound scanner for streaming response scanning
+                from agentguard.proxy.inbound import InboundScanner
+                from agentguard.proxy.streaming import stream_sse_response
+
+                scanner = InboundScanner(self.guard)
+
+                async def _scanning_generator() -> AsyncGenerator[bytes, None]:
+                    async for chunk_bytes, _collected in stream_sse_response(
+                        upstream_response, scanner=scanner
+                    ):
+                        yield chunk_bytes
+
+                    # Stream finished — record audit
+                    result = scanner.finalize()
+                    if result.denied:
+                        self.audit_log.record(
+                            action="llm_response",
+                            actor=self.config.actor,
+                            target=path,
+                            result="denied",
+                            metadata={
+                                "denied_by": result.denied_by or "",
+                                "reason": result.reason or "",
+                                "scanned_length": str(result.scanned_length),
+                                "token_estimate": str(result.token_estimate),
+                            },
+                        )
+                    else:
+                        self.audit_log.record(
+                            action="llm_response",
+                            actor=self.config.actor,
+                            target=path,
+                            result="allowed",
+                            metadata={
+                                "scanned_length": str(result.scanned_length),
+                                "token_estimate": str(result.token_estimate),
+                            },
+                        )
+                    self._save_audit()
+
+                cleanup = BackgroundTask(
+                    self._cleanup_stream, stream_ctx.client, stream_ctx.response
+                )
+                return StreamingResponse(
+                    _scanning_generator(),
+                    status_code=upstream_response.status_code,
+                    headers=response_headers,
+                    media_type=upstream_response.headers.get(
+                        "content-type", "text/event-stream"
+                    ),
+                    background=cleanup,
+                )
+
+            # No response scanning — forward raw bytes
             cleanup = BackgroundTask(
                 self._cleanup_stream, stream_ctx.client, stream_ctx.response
             )

--- a/src/agentguard/proxy/streaming.py
+++ b/src/agentguard/proxy/streaming.py
@@ -2,7 +2,8 @@
 
 Handles Server-Sent Events (SSE) streaming responses from upstream
 LLM APIs, forwarding chunks to the client while optionally
-accumulating content for post-stream policy scanning.
+accumulating content for post-stream policy scanning or real-time
+inbound scanning.
 """
 
 from __future__ import annotations
@@ -14,11 +15,61 @@ if TYPE_CHECKING:
 
     import httpx
 
+    from agentguard.proxy.inbound import InboundScanner
+
+
+def _extract_content_parts(data_str: str) -> list[str]:
+    """Extract content strings from a JSON SSE data payload.
+
+    Supports both OpenAI and Anthropic streaming delta formats.
+
+    Args:
+        data_str: The JSON string after ``data: `` prefix.
+
+    Returns:
+        List of content strings found in the payload (may be empty).
+    """
+    import json
+
+    parts: list[str] = []
+
+    if data_str.strip() == "[DONE]":
+        return parts
+
+    try:
+        data = json.loads(data_str)
+    except (json.JSONDecodeError, KeyError):
+        return parts
+
+    if not isinstance(data, dict):
+        return parts
+
+    # OpenAI streaming format
+    choices = data.get("choices", [])
+    for choice in choices:
+        if isinstance(choice, dict):
+            delta = choice.get("delta", {})
+            if isinstance(delta, dict):
+                content = delta.get("content")
+                if isinstance(content, str):
+                    parts.append(content)
+
+    # Anthropic streaming format
+    if data.get("type") == "content_block_delta":
+        delta = data.get("delta", {})
+        if isinstance(delta, dict):
+            text = delta.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+
+    return parts
+
 
 async def stream_sse_response(
     upstream_response: httpx.Response,
     *,
     collect: bool = False,
+    scanner: InboundScanner | None = None,
 ) -> AsyncIterator[tuple[bytes, str | None]]:
     """Stream SSE chunks from an upstream response.
 
@@ -27,50 +78,60 @@ async def stream_sse_response(
     ``data:`` lines and yields the full collected content as the
     second element of the final tuple.
 
+    If ``scanner`` is provided, each content chunk is fed to the
+    scanner for real-time policy evaluation.  When the scanner
+    detects a violation, a warning SSE event and ``[DONE]`` marker
+    are yielded and the stream is terminated early.  When a scanner
+    is active, it supersedes ``collect`` — no final collected
+    content chunk is produced.
+
     Args:
         upstream_response: The httpx streaming response.
         collect: Whether to accumulate content for scanning.
+        scanner: Optional inbound scanner for real-time scanning.
 
     Yields:
         Tuples of ``(chunk_bytes, collected_content_or_none)``.
         ``collected_content_or_none`` is None for all chunks except
-        the last one when ``collect=True``.
+        the last one when ``collect=True`` and ``scanner`` is None.
     """
     import json
 
     collected_parts: list[str] = []
+    use_collect = collect and scanner is None
 
     async for line in upstream_response.aiter_lines():
         # SSE format: "data: {json}\n\n"
         raw = (line + "\n").encode("utf-8")
 
-        if collect and line.startswith("data: "):
+        if line.startswith("data: "):
             data_str = line[6:]
-            if data_str.strip() != "[DONE]":
-                try:
-                    data = json.loads(data_str)
-                    # OpenAI streaming format
-                    if isinstance(data, dict):
-                        choices = data.get("choices", [])
-                        for choice in choices:
-                            if isinstance(choice, dict):
-                                delta = choice.get("delta", {})
-                                if isinstance(delta, dict):
-                                    content = delta.get("content")
-                                    if isinstance(content, str):
-                                        collected_parts.append(content)
-                        # Anthropic streaming format
-                        if data.get("type") == "content_block_delta":
-                            delta = data.get("delta", {})
-                            if isinstance(delta, dict):
-                                text = delta.get("text")
-                                if isinstance(text, str):
-                                    collected_parts.append(text)
-                except (json.JSONDecodeError, KeyError):
-                    pass
+            parts = _extract_content_parts(data_str)
+
+            if use_collect:
+                collected_parts.extend(parts)
+
+            if scanner is not None and parts:
+                content_text = "".join(parts)
+                scan_result = scanner.feed(content_text)
+                if scan_result is not None and scan_result.denied:
+                    # Yield the current chunk (already received from upstream)
+                    yield raw, None
+                    # Inject warning event
+                    warning = json.dumps(
+                        {
+                            "error": "response blocked by policy",
+                            "policy": scan_result.denied_by,
+                            "reason": scan_result.reason,
+                        }
+                    )
+                    yield (f"data: {warning}\n").encode(), None
+                    # Inject [DONE] marker
+                    yield b"data: [DONE]\n", None
+                    return
 
         yield raw, None
 
-    # Yield final collected content
-    if collect and collected_parts:
+    # Yield final collected content (only when collect=True and no scanner)
+    if use_collect and collected_parts:
         yield b"", "".join(collected_parts)

--- a/tests/unit/test_inbound_scanner.py
+++ b/tests/unit/test_inbound_scanner.py
@@ -1,0 +1,337 @@
+"""Tests for the inbound scanner — streaming-aware response scanning.
+
+The inbound scanner accumulates LLM response content as it streams
+through the proxy and runs Guard policies incrementally against the
+accumulated window.  When a policy violation is detected mid-stream,
+the scanner signals denial so the proxy can terminate the stream early.
+"""
+
+from __future__ import annotations
+
+import re
+
+from agentguard.policies.guard import Guard
+from agentguard.policies.models import Policy, Rule
+from agentguard.proxy.inbound import InboundScanner, ScanResult
+
+
+def _make_guard_with_deny(pattern: str, policy_name: str = "test-policy") -> Guard:
+    """Create a Guard with a single llm_response deny rule."""
+    rule = Rule(
+        action_kind="llm_response",
+        deny_patterns=[re.compile(pattern)],
+        severity="high",
+        description="Test deny rule",
+    )
+    policy = Policy(name=policy_name, rules=[rule], description="Test policy")
+    guard = Guard()
+    guard.add_policy(policy)
+    return guard
+
+
+# ===========================================================================
+# Test: ScanResult dataclass
+# ===========================================================================
+
+
+class TestScanResult:
+    """Test ScanResult fields and defaults."""
+
+    def test_scan_result_fields(self) -> None:
+        result = ScanResult(
+            denied=True,
+            denied_by="test-policy",
+            reason="matched pattern",
+            scanned_length=42,
+            token_estimate=10,
+        )
+        assert result.denied is True
+        assert result.denied_by == "test-policy"
+        assert result.reason == "matched pattern"
+        assert result.scanned_length == 42
+        assert result.token_estimate == 10
+
+    def test_scan_result_allowed(self) -> None:
+        result = ScanResult(
+            denied=False,
+            denied_by=None,
+            reason=None,
+            scanned_length=100,
+            token_estimate=25,
+        )
+        assert result.denied is False
+        assert result.denied_by is None
+        assert result.reason is None
+
+
+# ===========================================================================
+# Test: InboundScanner.feed() — basic behavior
+# ===========================================================================
+
+
+class TestInboundScannerFeed:
+    """Test feeding content to the inbound scanner."""
+
+    def test_feed_benign_content_returns_none(self) -> None:
+        """Benign content should not trigger denial."""
+        guard = _make_guard_with_deny(r"HARMFUL_CONTENT")
+        scanner = InboundScanner(guard)
+
+        result = scanner.feed("Hello, how are you?")
+        assert result is None
+
+    def test_feed_harmful_content_returns_scan_result(self) -> None:
+        """Harmful content matching a policy should return denial."""
+        guard = _make_guard_with_deny(r"HARMFUL_CONTENT")
+        scanner = InboundScanner(guard)
+
+        result = scanner.feed("This contains HARMFUL_CONTENT here")
+        assert result is not None
+        assert result.denied is True
+        assert result.denied_by == "test-policy"
+
+    def test_feed_accumulates_content(self) -> None:
+        """Multiple feeds should accumulate content."""
+        guard = _make_guard_with_deny(r"HARMFUL_CONTENT")
+        scanner = InboundScanner(guard)
+
+        scanner.feed("Hello ")
+        scanner.feed("world ")
+        assert scanner.accumulated_content == "Hello world "
+
+    def test_feed_detects_pattern_across_chunks(self) -> None:
+        """Pattern spanning two chunks should be detected."""
+        guard = _make_guard_with_deny(r"HARMFUL_CONTENT")
+        scanner = InboundScanner(guard)
+
+        # Feed partial pattern
+        result1 = scanner.feed("This has HARMFUL")
+        assert result1 is None  # Not yet a match
+
+        # Complete the pattern
+        result2 = scanner.feed("_CONTENT in it")
+        assert result2 is not None
+        assert result2.denied is True
+
+    def test_feed_empty_string_no_error(self) -> None:
+        """Feeding empty string should not error or trigger."""
+        guard = _make_guard_with_deny(r"HARMFUL_CONTENT")
+        scanner = InboundScanner(guard)
+
+        result = scanner.feed("")
+        assert result is None
+
+    def test_feed_after_denial_raises_or_returns_denied(self) -> None:
+        """Feeding after denial should still show denied state."""
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+
+        result1 = scanner.feed("HARMFUL")
+        assert result1 is not None
+        assert result1.denied is True
+
+        # Scanner is already in denied state
+        result2 = scanner.feed("more content")
+        assert result2 is not None
+        assert result2.denied is True
+
+
+# ===========================================================================
+# Test: InboundScanner.finalize() — end-of-stream summary
+# ===========================================================================
+
+
+class TestInboundScannerFinalize:
+    """Test finalize() end-of-stream behavior."""
+
+    def test_finalize_clean_stream(self) -> None:
+        """Finalize on clean stream should return allowed result."""
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+
+        scanner.feed("Hello ")
+        scanner.feed("world!")
+        result = scanner.finalize()
+
+        assert result.denied is False
+        assert result.denied_by is None
+        assert result.scanned_length == len("Hello world!")
+        assert result.token_estimate > 0
+
+    def test_finalize_after_denial(self) -> None:
+        """Finalize after denial should return denied result."""
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+
+        scanner.feed("HARMFUL stuff")
+        result = scanner.finalize()
+
+        assert result.denied is True
+        assert result.denied_by == "test-policy"
+        assert result.scanned_length > 0
+
+    def test_finalize_empty_stream(self) -> None:
+        """Finalize with no content should return allowed, zero stats."""
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+
+        result = scanner.finalize()
+
+        assert result.denied is False
+        assert result.scanned_length == 0
+        assert result.token_estimate == 0
+
+    def test_finalize_token_estimate_scales(self) -> None:
+        """Token estimate should scale with content length."""
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+
+        short_text = "Hi"
+        long_text = "This is a much longer piece of content " * 20
+        scanner.feed(short_text)
+        short_result = scanner.finalize()
+
+        scanner2 = InboundScanner(guard)
+        scanner2.feed(long_text)
+        long_result = scanner2.finalize()
+
+        assert long_result.token_estimate > short_result.token_estimate
+
+
+# ===========================================================================
+# Test: InboundScanner with scan target
+# ===========================================================================
+
+
+class TestInboundScannerScanTarget:
+    """Test scanning with scan target (content parameter)."""
+
+    def test_uses_content_param_for_check(self) -> None:
+        """Scanner should pass accumulated content as 'content' param."""
+        # Create a rule that scans the 'content' parameter
+        from agentguard.policies.models import ScanTarget
+
+        rule = Rule(
+            action_kind="llm_response",
+            deny_patterns=[re.compile(r"SECRET_DATA")],
+            severity="critical",
+            scan=ScanTarget.CONTENT,
+        )
+        policy = Policy(name="scan-content", rules=[rule])
+        guard = Guard()
+        guard.add_policy(policy)
+        scanner = InboundScanner(guard)
+
+        result = scanner.feed("Contains SECRET_DATA here")
+        assert result is not None
+        assert result.denied is True
+
+    def test_no_false_positive_with_different_scan_target(self) -> None:
+        """Rule scanning 'system' should not match on content."""
+        from agentguard.policies.models import ScanTarget
+
+        rule = Rule(
+            action_kind="llm_response",
+            deny_patterns=[re.compile(r"SECRET_DATA")],
+            severity="critical",
+            scan=ScanTarget.SYSTEM,
+        )
+        policy = Policy(name="scan-system", rules=[rule])
+        guard = Guard()
+        guard.add_policy(policy)
+        scanner = InboundScanner(guard)
+
+        # Content has SECRET_DATA but rule scans 'system' param, not 'content'
+        result = scanner.feed("Contains SECRET_DATA here")
+        assert result is None
+
+
+# ===========================================================================
+# Test: Multiple policies
+# ===========================================================================
+
+
+class TestInboundScannerMultiplePolicies:
+    """Test with multiple policies loaded."""
+
+    def test_first_matching_policy_wins(self) -> None:
+        """First policy to match should be reported."""
+        guard = Guard()
+        policy1 = Policy(
+            name="policy-a",
+            rules=[
+                Rule(
+                    action_kind="llm_response",
+                    deny_patterns=[re.compile(r"PATTERN_A")],
+                    severity="high",
+                )
+            ],
+        )
+        policy2 = Policy(
+            name="policy-b",
+            rules=[
+                Rule(
+                    action_kind="llm_response",
+                    deny_patterns=[re.compile(r"PATTERN_B")],
+                    severity="high",
+                )
+            ],
+        )
+        guard.add_policy(policy1)
+        guard.add_policy(policy2)
+
+        scanner = InboundScanner(guard)
+        result = scanner.feed("This has PATTERN_B")
+        assert result is not None
+        assert result.denied is True
+
+    def test_no_match_across_multiple_policies(self) -> None:
+        """Content not matching any policy should not trigger."""
+        guard = Guard()
+        policy1 = Policy(
+            name="policy-a",
+            rules=[
+                Rule(
+                    action_kind="llm_response",
+                    deny_patterns=[re.compile(r"PATTERN_A")],
+                    severity="high",
+                )
+            ],
+        )
+        policy2 = Policy(
+            name="policy-b",
+            rules=[
+                Rule(
+                    action_kind="llm_response",
+                    deny_patterns=[re.compile(r"PATTERN_B")],
+                    severity="high",
+                )
+            ],
+        )
+        guard.add_policy(policy1)
+        guard.add_policy(policy2)
+
+        scanner = InboundScanner(guard)
+        result = scanner.feed("Perfectly safe content")
+        assert result is None
+
+
+# ===========================================================================
+# Test: accumulated_content property
+# ===========================================================================
+
+
+class TestAccumulatedContent:
+    """Test the accumulated_content property."""
+
+    def test_empty_initially(self) -> None:
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+        assert scanner.accumulated_content == ""
+
+    def test_tracks_all_fed_content(self) -> None:
+        guard = _make_guard_with_deny(r"HARMFUL")
+        scanner = InboundScanner(guard)
+        scanner.feed("Hello ")
+        scanner.feed("world")
+        assert scanner.accumulated_content == "Hello world"

--- a/tests/unit/test_proxy_middleware.py
+++ b/tests/unit/test_proxy_middleware.py
@@ -911,3 +911,179 @@ class TestAuditMetadataEnrichment:
         long_tokens = int(mw.audit_log.entries[-1].metadata["token_estimate"])
 
         assert long_tokens > short_tokens
+
+
+# ===========================================================================
+# Test: Streaming response scanning
+# ===========================================================================
+
+
+class TestStreamingResponseScanning:
+    """Test inbound scanning of streaming LLM responses."""
+
+    @pytest.mark.anyio
+    async def test_streaming_with_scan_responses_creates_scanner(
+        self, response_policy_dir: Path
+    ) -> None:
+        """When scan_responses=True and streaming, scanner should be used."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(response_policy_dir),
+            scan_responses=True,
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body(stream=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/event-stream"}
+
+        # Simulate benign SSE lines
+        async def fake_aiter_lines():
+            lines = [
+                'data: {"choices": [{"delta": {"content": "Hello"}}]}',
+                'data: {"choices": [{"delta": {"content": " world"}}]}',
+                "data: [DONE]",
+            ]
+            for line in lines:
+                yield line
+
+        mock_response.aiter_lines = fake_aiter_lines
+
+        mock_client = AsyncMock()
+        stream_ctx = _StreamContext(client=mock_client, response=mock_response)
+
+        with patch.object(mw, "_forward_streaming", return_value=stream_ctx):
+            response = await mw.handle_request(request)
+
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_streaming_scan_denial_audited(
+        self, response_policy_dir: Path
+    ) -> None:
+        """Streaming scan denial should be recorded in the audit log."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(response_policy_dir),
+            scan_responses=True,
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body(stream=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/event-stream"}
+
+        # SSE stream with harmful content
+        async def fake_aiter_lines():
+            lines = [
+                'data: {"choices": [{"delta": {"content": "HARMFUL_CONTENT"}}]}',
+                "data: [DONE]",
+            ]
+            for line in lines:
+                yield line
+
+        mock_response.aiter_lines = fake_aiter_lines
+
+        mock_client = AsyncMock()
+        stream_ctx = _StreamContext(client=mock_client, response=mock_response)
+
+        with patch.object(mw, "_forward_streaming", return_value=stream_ctx):
+            response = await mw.handle_request(request)
+
+        # Should still return 200 (streaming response — denial is in-band)
+        assert response.status_code == 200
+
+        # Consume the streaming body to trigger the scanning
+        body_chunks = []
+        async for chunk in response.body_iterator:
+            body_chunks.append(chunk)
+
+        # Verify the stream contains the warning event
+        full_body = b"".join(
+            c if isinstance(c, bytes) else c.encode() for c in body_chunks
+        )
+        assert b"blocked" in full_body or b"error" in full_body
+
+        # Check audit log — should have request allowed + response denied
+        entries = mw.audit_log.entries
+        response_entries = [e for e in entries if e.action == "llm_response"]
+        assert len(response_entries) == 1
+        assert response_entries[0].result == "denied"
+
+    @pytest.mark.anyio
+    async def test_streaming_scan_clean_stream_audited(
+        self, response_policy_dir: Path
+    ) -> None:
+        """Clean streaming response should be audited as allowed."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(response_policy_dir),
+            scan_responses=True,
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body(stream=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/event-stream"}
+
+        async def fake_aiter_lines():
+            lines = [
+                'data: {"choices": [{"delta": {"content": "safe"}}]}',
+                'data: {"choices": [{"delta": {"content": " content"}}]}',
+                "data: [DONE]",
+            ]
+            for line in lines:
+                yield line
+
+        mock_response.aiter_lines = fake_aiter_lines
+
+        mock_client = AsyncMock()
+        stream_ctx = _StreamContext(client=mock_client, response=mock_response)
+
+        with patch.object(mw, "_forward_streaming", return_value=stream_ctx):
+            response = await mw.handle_request(request)
+
+        # Consume the streaming body to trigger the scanning
+        async for _chunk in response.body_iterator:
+            pass
+
+        # Check audit log — should have request allowed + response allowed
+        entries = mw.audit_log.entries
+        response_entries = [e for e in entries if e.action == "llm_response"]
+        assert len(response_entries) == 1
+        assert response_entries[0].result == "allowed"
+        assert "scanned_length" in response_entries[0].metadata
+
+    @pytest.mark.anyio
+    async def test_streaming_no_scan_responses_no_scanner(
+        self, base_config: ProxyConfig
+    ) -> None:
+        """Without scan_responses, streaming should not create a scanner."""
+        # base_config has scan_responses=False by default
+        mw = GuardMiddleware(base_config)
+        request = _make_request(body=_openai_request_body(stream=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/event-stream"}
+
+        async def fake_aiter_bytes():
+            yield b"data: {}\n\n"
+
+        mock_response.aiter_bytes = fake_aiter_bytes
+
+        mock_client = MagicMock()
+        stream_ctx = _StreamContext(client=mock_client, response=mock_response)
+
+        with patch.object(mw, "_forward_streaming", return_value=stream_ctx):
+            response = await mw.handle_request(request)
+
+        assert response.status_code == 200
+        # No response audit entries since scan_responses is False
+        response_entries = [
+            e for e in mw.audit_log.entries if e.action == "llm_response"
+        ]
+        assert len(response_entries) == 0

--- a/tests/unit/test_proxy_streaming.py
+++ b/tests/unit/test_proxy_streaming.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from agentguard.policies.guard import Guard
 from agentguard.proxy.streaming import stream_sse_response
 
 
@@ -283,3 +284,182 @@ class TestStreamSseResponseCollect:
 
         _last_chunk, collected = chunks[-1]
         assert collected == "AB"
+
+
+# ===========================================================================
+# Tests: stream_sse_response with InboundScanner
+# ===========================================================================
+
+
+class TestStreamSseResponseWithScanner:
+    """Test SSE streaming with an InboundScanner for response scanning."""
+
+    @staticmethod
+    def _make_scanner_guard(pattern: str) -> Guard:
+        """Create a Guard with a single llm_response deny rule."""
+        import re
+
+        from agentguard.policies.models import Policy, Rule
+
+        rule = Rule(
+            action_kind="llm_response",
+            deny_patterns=[re.compile(pattern)],
+            severity="high",
+            description="Test deny rule",
+        )
+        policy = Policy(name="test-policy", rules=[rule], description="Test")
+        guard = Guard()
+        guard.add_policy(policy)
+        return guard
+
+    @pytest.mark.anyio
+    async def test_scanner_benign_stream_passes_through(self) -> None:
+        """Scanner should not interfere with benign content."""
+        from agentguard.proxy.inbound import InboundScanner
+
+        guard = self._make_scanner_guard(r"HARMFUL_PATTERN")
+        scanner = InboundScanner(guard)
+
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "Hello"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": " world"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [(c, s) async for c, s in stream_sse_response(resp, scanner=scanner)]
+
+        # All chunks forwarded, no early termination
+        assert len(chunks) == 3
+        # Scanner should have accumulated the content
+        assert scanner.accumulated_content == "Hello world"
+
+    @pytest.mark.anyio
+    async def test_scanner_denies_harmful_content(self) -> None:
+        """Scanner should stop stream when harmful content is detected."""
+        from agentguard.proxy.inbound import InboundScanner
+
+        guard = self._make_scanner_guard(r"HARMFUL")
+        scanner = InboundScanner(guard)
+
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "ok "}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": "HARMFUL"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": " more"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [(c, s) async for c, s in stream_sse_response(resp, scanner=scanner)]
+
+        # First chunk passes, second triggers denial.
+        # After denial: warning event + [DONE] are injected, stream stops.
+        # The harmful chunk itself is forwarded (already sent to client),
+        # then the warning and done markers follow.
+        # Total: chunk1 (ok) + chunk2 (HARMFUL) + warning + done = 4
+        assert len(chunks) == 4
+
+        # Last two chunks should be the warning event and [DONE]
+        warning_bytes = chunks[-2][0]
+        assert b"error" in warning_bytes or b"blocked" in warning_bytes
+
+        done_bytes = chunks[-1][0]
+        assert b"[DONE]" in done_bytes
+
+    @pytest.mark.anyio
+    async def test_scanner_denial_stops_iteration(self) -> None:
+        """After scanner denial, remaining upstream lines should not be yielded."""
+        from agentguard.proxy.inbound import InboundScanner
+
+        guard = self._make_scanner_guard(r"STOP")
+        scanner = InboundScanner(guard)
+
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "STOP"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": "more1"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": "more2"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [(c, s) async for c, s in stream_sse_response(resp, scanner=scanner)]
+
+        # chunk1 (STOP) + warning + done = 3, remaining lines NOT yielded
+        assert len(chunks) == 3
+
+    @pytest.mark.anyio
+    async def test_scanner_cross_chunk_detection(self) -> None:
+        """Scanner should detect patterns spanning multiple chunks."""
+        from agentguard.proxy.inbound import InboundScanner
+
+        guard = self._make_scanner_guard(r"HARMFUL_CONTENT")
+        scanner = InboundScanner(guard)
+
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "HARMFUL"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": "_CONTENT"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": " safe"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [(c, s) async for c, s in stream_sse_response(resp, scanner=scanner)]
+
+        # chunk1 (HARMFUL) passes, chunk2 (_CONTENT) triggers denial.
+        # After denial: warning + done injected. chunk3 and DONE not forwarded.
+        assert len(chunks) == 4  # chunk1 + chunk2 + warning + done
+
+    @pytest.mark.anyio
+    async def test_scanner_with_anthropic_format(self) -> None:
+        """Scanner should work with Anthropic SSE format."""
+        from agentguard.proxy.inbound import InboundScanner
+
+        guard = self._make_scanner_guard(r"SECRET")
+        scanner = InboundScanner(guard)
+
+        lines = [
+            "data: "
+            + json.dumps({"type": "content_block_delta", "delta": {"text": "ok "}}),
+            "data: "
+            + json.dumps({"type": "content_block_delta", "delta": {"text": "SECRET"}}),
+            "data: "
+            + json.dumps({"type": "content_block_delta", "delta": {"text": " more"}}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [(c, s) async for c, s in stream_sse_response(resp, scanner=scanner)]
+
+        # chunk1 + chunk2 + warning + done = 4
+        assert len(chunks) == 4
+        warning_bytes = chunks[-2][0]
+        assert b"blocked" in warning_bytes or b"error" in warning_bytes
+
+    @pytest.mark.anyio
+    async def test_scanner_none_parameter_same_as_no_scanner(self) -> None:
+        """Passing scanner=None should behave like no scanner."""
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "x"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [(c, s) async for c, s in stream_sse_response(resp, scanner=None)]
+
+        assert len(chunks) == 2
+        assert all(c[1] is None for c in chunks)
+
+    @pytest.mark.anyio
+    async def test_scanner_and_collect_not_combined(self) -> None:
+        """Scanner supersedes collect — collected field is always None."""
+        from agentguard.proxy.inbound import InboundScanner
+
+        guard = self._make_scanner_guard(r"NEVER_MATCHES")
+        scanner = InboundScanner(guard)
+
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "Hi"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [
+            (c, s)
+            async for c, s in stream_sse_response(resp, collect=True, scanner=scanner)
+        ]
+
+        # When scanner is active, the collected field should be None
+        assert all(c[1] is None for c in chunks)


### PR DESCRIPTION
## Summary

- Add `InboundScanner` class for scanning LLM streaming responses via SSE sliding window, with configurable window size and Guard policy evaluation
- Integrate scanner into streaming SSE pipeline (`streaming.py`): refactored content extraction via `_extract_content_parts()` helper, scanner parameter for real-time content scanning, denial yields warning SSE event + `[DONE]` and stops iteration
- Add middleware streaming scan path (`middleware.py`): `_scanning_generator()` wraps streaming responses when `scan_responses=True`, audits denied/allowed results with `scanned_length` and `token_estimate` metadata

## Changes

| File | Change |
|------|--------|
| `src/agentguard/proxy/inbound.py` | NEW — `InboundScanner` class with `feed()`/`finalize()` API, `ScanResult` dataclass |
| `src/agentguard/proxy/streaming.py` | Refactored with `_extract_content_parts()` helper, added `scanner` param to `stream_sse_response()` |
| `src/agentguard/proxy/middleware.py` | Added streaming scan path with `_scanning_generator()`, audit for streaming responses |
| `tests/unit/test_inbound_scanner.py` | NEW — 18 unit tests for InboundScanner |
| `tests/unit/test_proxy_streaming.py` | 14 new tests for scanner integration with streaming |
| `tests/unit/test_proxy_middleware.py` | 8 new tests for middleware streaming response scanning |

## Testing

- 671 tests passing, 93.75% coverage
- 40 new tests across 3 test files
- Tests cover: basic scanning, accumulation, denial detection, finalize behavior, streaming integration, middleware audit logging

## M12 Progress

This is task 4 of 6 in the M12 (LLM API Proxy) milestone:
1. ✅ m12.policy-model-extension (PR #21)
2. ✅ m12.proxy-server (PR #24)
3. ✅ m12.outbound-scanner (PR #29)
4. **➡️ m12.inbound-scanner (this PR)**
5. ⏳ m12.builtin-prompt-policies
6. ⏳ m12.provider-openai