### PR TITLE
feat: add OpenAI-compatible provider adapter with protocol and registry

### DIFF
--- a/src/agentguard/proxy/config.py
+++ b/src/agentguard/proxy/config.py
@@ -31,6 +31,10 @@ class ProxyConfig:
         allowed_endpoints: URL path patterns that are proxied.
             Requests to other paths get 404. If empty, all paths
             are proxied.
+        provider: Name of the LLM API provider adapter to use
+            for parsing request/response bodies (e.g. ``"openai"``).
+            If None, defaults to ``"openai"`` (most LLM APIs use
+            the OpenAI-compatible format).
     """
 
     upstream_base_url: str
@@ -44,6 +48,7 @@ class ProxyConfig:
     scan_responses: bool = False
     timeout: float = 120.0
     allowed_endpoints: list[str] = field(default_factory=list)
+    provider: str | None = None
 
     def __post_init__(self) -> None:
         """Validate configuration."""

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from starlette.responses import Response
 
     from agentguard.proxy.config import ProxyConfig
+    from agentguard.proxy.providers import Provider
 
 from agentguard.audit.log import AuditLog
 from agentguard.policies.guard import Guard
@@ -58,6 +59,7 @@ class GuardMiddleware:
         """
         self.config = config
         self.guard = self._build_guard()
+        self.provider = self._resolve_provider()
         self.session_id = f"proxy-{uuid.uuid4().hex[:12]}"
         self.audit_log = AuditLog(self.session_id)
 
@@ -86,6 +88,19 @@ class GuardMiddleware:
                 guard.add_policy(policy)
 
         return guard
+
+    def _resolve_provider(self) -> Provider | None:
+        """Resolve the provider adapter from the config.
+
+        Returns:
+            A Provider instance if configured, or None to use the
+            legacy scanner module fallback.
+        """
+        if self.config.provider is not None:
+            from agentguard.proxy.providers import detect_provider
+
+            return detect_provider(provider_name=self.config.provider)
+        return None
 
     async def handle_request(self, request: Request) -> Response:
         """Handle an incoming LLM API request.
@@ -117,7 +132,10 @@ class GuardMiddleware:
 
         # Extract and scan request content
         try:
-            params = extract_request_params(body)
+            if self.provider is not None:
+                params = self.provider.extract_request_params(body)
+            else:
+                params = extract_request_params(body)
         except ValueError:
             # Non-JSON body — pass through without scanning
             params = {}
@@ -216,7 +234,7 @@ class GuardMiddleware:
 
                 async def _scanning_generator() -> AsyncGenerator[bytes, None]:
                     async for chunk_bytes, _collected in stream_sse_response(
-                        upstream_response, scanner=scanner
+                        upstream_response, scanner=scanner, provider=self.provider
                     ):
                         yield chunk_bytes
 
@@ -279,7 +297,12 @@ class GuardMiddleware:
         response_body = upstream_response.content
         if self.config.scan_responses and response_body:
             try:
-                response_params = extract_response_params(response_body)
+                if self.provider is not None:
+                    response_params = self.provider.extract_response_params(
+                        response_body
+                    )
+                else:
+                    response_params = extract_response_params(response_body)
                 if response_params:
                     response_decision = self.guard.check(
                         "llm_response", **response_params

--- a/src/agentguard/proxy/providers/__init__.py
+++ b/src/agentguard/proxy/providers/__init__.py
@@ -1,0 +1,148 @@
+"""LLM API provider adapters.
+
+Defines the Provider protocol and a registry for looking up providers
+by name.  Each provider knows how to parse request and response bodies
+for a specific LLM API format (e.g. OpenAI, Anthropic).
+
+Public API:
+- ``Provider`` — runtime-checkable protocol for provider adapters.
+- ``get_provider(name)`` — look up a provider by name.
+- ``list_providers()`` — list all registered provider names.
+- ``detect_provider(...)`` — auto-detect the provider to use.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """Protocol for LLM API format adapters.
+
+    Each provider implements request/response parsing and streaming
+    content extraction for a specific LLM API format.
+
+    Attributes:
+        name: Short identifier for this provider (e.g. ``"openai"``).
+    """
+
+    @property
+    def name(self) -> str:
+        """Short identifier for this provider."""
+        ...
+
+    def extract_request_params(self, body: bytes) -> dict[str, str]:
+        """Extract scannable parameters from a request body.
+
+        Args:
+            body: Raw request body bytes.
+
+        Returns:
+            Dictionary mapping parameter keys (``messages``, ``system``,
+            ``content``, ``model``) to string values for policy scanning.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        ...
+
+    def extract_response_params(self, body: bytes) -> dict[str, str]:
+        """Extract scannable parameters from a response body.
+
+        Args:
+            body: Raw response body bytes.
+
+        Returns:
+            Dictionary mapping parameter keys (``content``) to string
+            values for policy scanning.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        ...
+
+    def extract_stream_content(self, data_str: str) -> list[str]:
+        """Extract content strings from a streaming SSE data payload.
+
+        Args:
+            data_str: The JSON string after the ``data: `` prefix.
+
+        Returns:
+            List of content strings found in the payload (may be empty).
+        """
+        ...
+
+
+def _build_registry() -> dict[str, Provider]:
+    """Build the provider registry lazily."""
+    from agentguard.proxy.providers.openai import OpenAIProvider
+
+    return {
+        "openai": OpenAIProvider(),
+    }
+
+
+_registry: dict[str, Provider] | None = None
+
+
+def _get_registry() -> dict[str, Provider]:
+    """Get or create the provider registry."""
+    global _registry
+    if _registry is None:
+        _registry = _build_registry()
+    return _registry
+
+
+def list_providers() -> list[str]:
+    """List all registered provider names.
+
+    Returns:
+        Sorted list of provider names.
+    """
+    return sorted(_get_registry().keys())
+
+
+def get_provider(name: str) -> Provider:
+    """Look up a provider by name.
+
+    Args:
+        name: The provider name (e.g. ``"openai"``).
+
+    Returns:
+        The provider instance.
+
+    Raises:
+        ValueError: If no provider with that name is registered.
+    """
+    registry = _get_registry()
+    if name not in registry:
+        available = ", ".join(sorted(registry.keys()))
+        msg = f"No provider named '{name}'. Available: {available}"
+        raise ValueError(msg)
+    return registry[name]
+
+
+def detect_provider(
+    *,
+    provider_name: str | None = None,
+) -> Provider:
+    """Detect or look up the appropriate provider.
+
+    If ``provider_name`` is given, looks it up directly.  Otherwise
+    returns the default provider (OpenAI-compatible, since most LLM
+    APIs support OpenAI format).
+
+    Args:
+        provider_name: Explicit provider name, or None for default.
+
+    Returns:
+        The detected/selected provider instance.
+
+    Raises:
+        ValueError: If the named provider is not registered.
+    """
+    if provider_name is not None:
+        return get_provider(provider_name)
+    # Default: OpenAI format (covers OpenAI, Azure, Copilot, vLLM, etc.)
+    return get_provider("openai")

--- a/src/agentguard/proxy/providers/openai.py
+++ b/src/agentguard/proxy/providers/openai.py
@@ -1,0 +1,210 @@
+"""OpenAI-compatible API format adapter.
+
+Handles parsing and extraction for the OpenAI ``/v1/chat/completions``
+format, which is also used by Azure OpenAI, GitHub Copilot, LiteLLM,
+vLLM, Ollama, and many other OpenAI-compatible providers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class OpenAIProvider:
+    """Provider adapter for OpenAI-compatible LLM APIs.
+
+    Parses request bodies (messages array with role/content),
+    response bodies (choices array with message/content), and
+    streaming SSE deltas (choices[].delta.content).
+    """
+
+    @property
+    def name(self) -> str:
+        """Provider identifier."""
+        return "openai"
+
+    def extract_request_params(self, body: bytes) -> dict[str, str]:
+        """Extract scannable parameters from an OpenAI request body.
+
+        Parses the JSON body and extracts:
+        - ``messages``: Concatenated content from all messages.
+        - ``system``: System prompt if present (role=system messages).
+        - ``content``: All user/assistant message content concatenated.
+        - ``model``: Model name if present.
+
+        Args:
+            body: Raw request body bytes.
+
+        Returns:
+            Dictionary of parameter keys to string values.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        data = self._parse_json(body, "request")
+
+        if not isinstance(data, dict):
+            return {}
+
+        params: dict[str, str] = {}
+
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            all_content: list[str] = []
+            system_parts: list[str] = []
+            user_assistant_parts: list[str] = []
+
+            for msg in messages:
+                if not isinstance(msg, dict):
+                    continue
+                role = msg.get("role", "")
+                content = self._extract_content(msg.get("content"))
+                if not content:
+                    continue
+
+                all_content.append(content)
+
+                if role == "system":
+                    system_parts.append(content)
+                else:
+                    user_assistant_parts.append(content)
+
+            if all_content:
+                params["messages"] = "\n".join(all_content)
+            if system_parts:
+                params["system"] = "\n".join(system_parts)
+            if user_assistant_parts:
+                params["content"] = "\n".join(user_assistant_parts)
+
+        model = data.get("model")
+        if isinstance(model, str) and model:
+            params["model"] = model
+
+        return params
+
+    def extract_response_params(self, body: bytes) -> dict[str, str]:
+        """Extract scannable parameters from an OpenAI response body.
+
+        Parses the JSON body and extracts:
+        - ``content``: Generated content from choices.
+
+        Args:
+            body: Raw response body bytes.
+
+        Returns:
+            Dictionary of parameter keys to string values.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        data = self._parse_json(body, "response")
+
+        if not isinstance(data, dict):
+            return {}
+
+        params: dict[str, str] = {}
+
+        choices = data.get("choices")
+        if isinstance(choices, list):
+            parts: list[str] = []
+            for choice in choices:
+                if not isinstance(choice, dict):
+                    continue
+                # Non-streaming: message.content
+                message = choice.get("message")
+                if isinstance(message, dict):
+                    content = self._extract_content(message.get("content"))
+                    if content:
+                        parts.append(content)
+                # Streaming: delta.content
+                delta = choice.get("delta")
+                if isinstance(delta, dict):
+                    content = self._extract_content(delta.get("content"))
+                    if content:
+                        parts.append(content)
+            if parts:
+                params["content"] = "\n".join(parts)
+
+        return params
+
+    def extract_stream_content(self, data_str: str) -> list[str]:
+        """Extract content from a streaming SSE data payload.
+
+        Handles the OpenAI streaming format where each SSE event
+        contains ``choices[].delta.content``.
+
+        Args:
+            data_str: The JSON string after ``data: `` prefix.
+
+        Returns:
+            List of content strings found (may be empty).
+        """
+        parts: list[str] = []
+
+        if data_str.strip() == "[DONE]":
+            return parts
+
+        try:
+            data = json.loads(data_str)
+        except (json.JSONDecodeError, ValueError):
+            return parts
+
+        if not isinstance(data, dict):
+            return parts
+
+        choices = data.get("choices", [])
+        for choice in choices:
+            if isinstance(choice, dict):
+                delta = choice.get("delta", {})
+                if isinstance(delta, dict):
+                    content = delta.get("content")
+                    if isinstance(content, str):
+                        parts.append(content)
+
+        return parts
+
+    @staticmethod
+    def _parse_json(body: bytes, context: str) -> Any:
+        """Parse JSON from body bytes.
+
+        Args:
+            body: Raw bytes.
+            context: Description for error messages.
+
+        Returns:
+            Parsed JSON value.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        try:
+            return json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            msg = f"Invalid JSON {context} body: {e}"
+            raise ValueError(msg) from e
+
+    @staticmethod
+    def _extract_content(content: Any) -> str:
+        """Extract text from a message content field.
+
+        Handles both string content and structured content blocks
+        (list of dicts with type/text).
+
+        Args:
+            content: Message content — string, list, or None.
+
+        Returns:
+            Extracted text as a string, or empty string.
+        """
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "\n".join(parts)
+        return ""

--- a/src/agentguard/proxy/streaming.py
+++ b/src/agentguard/proxy/streaming.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import httpx
 
     from agentguard.proxy.inbound import InboundScanner
+    from agentguard.proxy.providers import Provider
 
 
 def _extract_content_parts(data_str: str) -> list[str]:
@@ -70,6 +71,7 @@ async def stream_sse_response(
     *,
     collect: bool = False,
     scanner: InboundScanner | None = None,
+    provider: Provider | None = None,
 ) -> AsyncIterator[tuple[bytes, str | None]]:
     """Stream SSE chunks from an upstream response.
 
@@ -85,10 +87,15 @@ async def stream_sse_response(
     is active, it supersedes ``collect`` — no final collected
     content chunk is produced.
 
+    If ``provider`` is given, its ``extract_stream_content()``
+    method is used for content extraction instead of the built-in
+    ``_extract_content_parts()`` fallback.
+
     Args:
         upstream_response: The httpx streaming response.
         collect: Whether to accumulate content for scanning.
         scanner: Optional inbound scanner for real-time scanning.
+        provider: Optional provider adapter for content extraction.
 
     Yields:
         Tuples of ``(chunk_bytes, collected_content_or_none)``.
@@ -106,7 +113,10 @@ async def stream_sse_response(
 
         if line.startswith("data: "):
             data_str = line[6:]
-            parts = _extract_content_parts(data_str)
+            if provider is not None:
+                parts = provider.extract_stream_content(data_str)
+            else:
+                parts = _extract_content_parts(data_str)
 
             if use_collect:
                 collected_parts.extend(parts)

--- a/tests/unit/test_provider_openai.py
+++ b/tests/unit/test_provider_openai.py
@@ -1,0 +1,261 @@
+"""Tests for Provider protocol and OpenAI provider adapter."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentguard.proxy.providers import (
+    Provider,
+    detect_provider,
+    get_provider,
+    list_providers,
+)
+from agentguard.proxy.providers.openai import OpenAIProvider
+
+
+class TestProviderProtocol:
+    """Test the Provider protocol contract."""
+
+    def test_openai_implements_protocol(self) -> None:
+        provider = OpenAIProvider()
+        assert isinstance(provider, Provider)
+
+    def test_provider_has_name(self) -> None:
+        provider = OpenAIProvider()
+        assert provider.name == "openai"
+
+
+class TestProviderRegistry:
+    """Test provider registry functions."""
+
+    def test_list_providers_includes_openai(self) -> None:
+        names = list_providers()
+        assert "openai" in names
+
+    def test_get_provider_returns_openai(self) -> None:
+        provider = get_provider("openai")
+        assert isinstance(provider, OpenAIProvider)
+
+    def test_get_provider_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="not-a-provider"):
+            get_provider("not-a-provider")
+
+    def test_detect_provider_default_is_openai(self) -> None:
+        provider = detect_provider()
+        assert provider.name == "openai"
+
+    def test_detect_provider_by_name(self) -> None:
+        provider = detect_provider(provider_name="openai")
+        assert provider.name == "openai"
+
+
+class TestOpenAIProviderRequestParsing:
+    """Test OpenAI provider request content extraction."""
+
+    def test_simple_user_message(self) -> None:
+        body = json.dumps(
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {"role": "user", "content": "Hello!"},
+                ],
+            }
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_request_params(body)
+        assert params["messages"] == "Hello!"
+        assert params["content"] == "Hello!"
+        assert params["model"] == "gpt-4"
+        assert "system" not in params
+
+    def test_system_and_user_messages(self) -> None:
+        body = json.dumps(
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hi there"},
+                ],
+            }
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_request_params(body)
+        assert "You are helpful." in params["messages"]
+        assert "Hi there" in params["messages"]
+        assert params["system"] == "You are helpful."
+        assert params["content"] == "Hi there"
+
+    def test_multi_turn_conversation(self) -> None:
+        body = json.dumps(
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {"role": "user", "content": "Question 1"},
+                    {"role": "assistant", "content": "Answer 1"},
+                    {"role": "user", "content": "Question 2"},
+                ],
+            }
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_request_params(body)
+        assert "Question 1" in params["messages"]
+        assert "Answer 1" in params["messages"]
+        assert "Question 2" in params["messages"]
+
+    def test_structured_content_blocks(self) -> None:
+        body = json.dumps(
+            {
+                "model": "gpt-4o",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Describe this image"},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "https://example.com/img.png"},
+                            },
+                        ],
+                    },
+                ],
+            }
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_request_params(body)
+        assert params["messages"] == "Describe this image"
+
+    def test_invalid_json_raises(self) -> None:
+        provider = OpenAIProvider()
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            provider.extract_request_params(b"not json")
+
+    def test_empty_messages_array(self) -> None:
+        body = json.dumps({"model": "gpt-4", "messages": []}).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_request_params(body)
+        assert "messages" not in params
+
+    def test_no_messages_field(self) -> None:
+        body = json.dumps({"model": "gpt-4"}).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_request_params(body)
+        assert "messages" not in params
+        assert params["model"] == "gpt-4"
+
+
+class TestOpenAIProviderResponseParsing:
+    """Test OpenAI provider response content extraction."""
+
+    def test_standard_chat_completion(self) -> None:
+        body = json.dumps(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello! How can I help?",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_response_params(body)
+        assert params["content"] == "Hello! How can I help?"
+
+    def test_multiple_choices(self) -> None:
+        body = json.dumps(
+            {
+                "choices": [
+                    {"message": {"content": "Response A"}},
+                    {"message": {"content": "Response B"}},
+                ]
+            }
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_response_params(body)
+        assert "Response A" in params["content"]
+        assert "Response B" in params["content"]
+
+    def test_streaming_delta(self) -> None:
+        body = json.dumps(
+            {"choices": [{"delta": {"content": "Hello"}, "index": 0}]}
+        ).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_response_params(body)
+        assert params["content"] == "Hello"
+
+    def test_invalid_json_raises(self) -> None:
+        provider = OpenAIProvider()
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            provider.extract_response_params(b"not json {")
+
+    def test_empty_choices(self) -> None:
+        body = json.dumps({"choices": []}).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_response_params(body)
+        assert "content" not in params
+
+    def test_no_content_in_message(self) -> None:
+        body = json.dumps({"choices": [{"message": {"role": "assistant"}}]}).encode()
+        provider = OpenAIProvider()
+        params = provider.extract_response_params(body)
+        assert "content" not in params
+
+
+class TestOpenAIProviderStreamContent:
+    """Test OpenAI provider streaming content extraction."""
+
+    def test_extract_delta_content(self) -> None:
+        data_str = json.dumps(
+            {"choices": [{"delta": {"content": "Hello"}, "index": 0}]}
+        )
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content(data_str)
+        assert parts == ["Hello"]
+
+    def test_done_marker_returns_empty(self) -> None:
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content("[DONE]")
+        assert parts == []
+
+    def test_empty_delta(self) -> None:
+        data_str = json.dumps({"choices": [{"delta": {}, "index": 0}]})
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content(data_str)
+        assert parts == []
+
+    def test_multiple_choices_stream(self) -> None:
+        data_str = json.dumps(
+            {
+                "choices": [
+                    {"delta": {"content": "A"}, "index": 0},
+                    {"delta": {"content": "B"}, "index": 1},
+                ]
+            }
+        )
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content(data_str)
+        assert parts == ["A", "B"]
+
+    def test_role_only_delta(self) -> None:
+        """First chunk often has role but no content."""
+        data_str = json.dumps(
+            {"choices": [{"delta": {"role": "assistant"}, "index": 0}]}
+        )
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content(data_str)
+        assert parts == []
+
+    def test_invalid_json_returns_empty(self) -> None:
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content("not json")
+        assert parts == []
+
+    def test_non_dict_returns_empty(self) -> None:
+        provider = OpenAIProvider()
+        parts = provider.extract_stream_content('"just a string"')
+        assert parts == []

--- a/tests/unit/test_proxy_config.py
+++ b/tests/unit/test_proxy_config.py
@@ -108,3 +108,35 @@ class TestProxyConfigAllowedEndpoints:
         cfg2 = ProxyConfig(upstream_base_url="https://api.openai.com")
         cfg1.allowed_endpoints.append("/v1/test")
         assert cfg2.allowed_endpoints == []
+
+
+# ===========================================================================
+# Test: Provider field
+# ===========================================================================
+
+
+class TestProxyConfigProvider:
+    """Test provider field on ProxyConfig."""
+
+    def test_provider_defaults_to_none(self) -> None:
+        """Provider should default to None."""
+        cfg = ProxyConfig(upstream_base_url="https://api.openai.com")
+        assert cfg.provider is None
+
+    def test_provider_accepts_string(self) -> None:
+        """Provider can be set to a provider name string."""
+        cfg = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            provider="openai",
+        )
+        assert cfg.provider == "openai"
+
+    def test_provider_included_in_all_fields(self) -> None:
+        """Config with all fields including provider."""
+        cfg = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            provider="openai",
+            scan_responses=True,
+        )
+        assert cfg.provider == "openai"
+        assert cfg.scan_responses is True

--- a/tests/unit/test_proxy_middleware.py
+++ b/tests/unit/test_proxy_middleware.py
@@ -1087,3 +1087,90 @@ class TestStreamingResponseScanning:
             e for e in mw.audit_log.entries if e.action == "llm_response"
         ]
         assert len(response_entries) == 0
+
+
+# ===========================================================================
+# Test: Provider integration in middleware
+# ===========================================================================
+
+
+class TestProviderIntegration:
+    """Test that middleware uses provider from config for param extraction."""
+
+    @pytest.mark.anyio
+    async def test_middleware_with_provider_config(self, policy_dir: Path) -> None:
+        """Middleware with provider='openai' should use OpenAI provider."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            provider="openai",
+        )
+        mw = GuardMiddleware(config)
+        assert mw.provider is not None
+        assert mw.provider.name == "openai"
+
+    @pytest.mark.anyio
+    async def test_middleware_without_provider_config(
+        self, base_config: ProxyConfig
+    ) -> None:
+        """Middleware without provider should use default (None → fallback)."""
+        mw = GuardMiddleware(base_config)
+        # When provider is None in config, middleware should still work
+        request = _make_request(body=_openai_request_body())
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps({"choices": []}).encode()
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch.object(mw, "_forward_request", return_value=mock_response):
+            response = await mw.handle_request(request)
+
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_provider_used_for_request_scanning(self, policy_dir: Path) -> None:
+        """Provider should be used for extracting request params."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            provider="openai",
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(
+            body=_openai_request_body(
+                messages=[
+                    {"role": "user", "content": "My password: secret123"},
+                ]
+            )
+        )
+
+        response = await mw.handle_request(request)
+        # Should be denied by the policy
+        assert response.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_provider_used_for_response_scanning(
+        self, response_policy_dir: Path
+    ) -> None:
+        """Provider should be used for extracting response params."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(response_policy_dir),
+            scan_responses=True,
+            provider="openai",
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body())
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps(
+            {"choices": [{"message": {"content": "HARMFUL_CONTENT here"}}]}
+        ).encode()
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch.object(mw, "_forward_request", return_value=mock_response):
+            response = await mw.handle_request(request)
+
+        assert response.status_code == 403

--- a/tests/unit/test_proxy_scanner.py
+++ b/tests/unit/test_proxy_scanner.py
@@ -381,3 +381,48 @@ class TestExtractResponseParamsEdgeCases:
         body = json.dumps({"id": "abc", "object": "chat.completion"}).encode()
         params = extract_response_params(body)
         assert params == {}
+
+
+# ===========================================================================
+# Scanner delegation to provider
+# ===========================================================================
+
+
+class TestScannerProviderDelegation:
+    """Test that scanner functions can delegate to a provider."""
+
+    def test_request_params_match_openai_provider(self) -> None:
+        """Scanner request params match OpenAI provider."""
+        from agentguard.proxy.providers.openai import OpenAIProvider
+
+        body = json.dumps(
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {"role": "system", "content": "Be helpful."},
+                    {"role": "user", "content": "Hello!"},
+                ],
+            }
+        ).encode()
+
+        scanner_params = extract_request_params(body)
+        provider_params = OpenAIProvider().extract_request_params(body)
+
+        # Both should extract the same key params for OpenAI format
+        assert scanner_params["messages"] == provider_params["messages"]
+        assert scanner_params["system"] == provider_params["system"]
+        assert scanner_params["content"] == provider_params["content"]
+        assert scanner_params["model"] == provider_params["model"]
+
+    def test_response_params_match_openai_provider(self) -> None:
+        """Scanner response params match OpenAI provider."""
+        from agentguard.proxy.providers.openai import OpenAIProvider
+
+        body = json.dumps(
+            {"choices": [{"message": {"content": "Hello there!"}}]}
+        ).encode()
+
+        scanner_params = extract_response_params(body)
+        provider_params = OpenAIProvider().extract_response_params(body)
+
+        assert scanner_params["content"] == provider_params["content"]

--- a/tests/unit/test_proxy_streaming.py
+++ b/tests/unit/test_proxy_streaming.py
@@ -463,3 +463,87 @@ class TestStreamSseResponseWithScanner:
 
         # When scanner is active, the collected field should be None
         assert all(c[1] is None for c in chunks)
+
+
+# ===========================================================================
+# Tests: stream_sse_response with Provider
+# ===========================================================================
+
+
+class TestStreamSseResponseWithProvider:
+    """Test SSE streaming with a Provider for content extraction."""
+
+    @pytest.mark.anyio
+    async def test_provider_extracts_content_for_collect(self) -> None:
+        """Provider should be used for content extraction when collecting."""
+        from agentguard.proxy.providers.openai import OpenAIProvider
+
+        provider = OpenAIProvider()
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "Hello"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": " world"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [
+            (c, s)
+            async for c, s in stream_sse_response(resp, collect=True, provider=provider)
+        ]
+
+        _last_chunk, collected = chunks[-1]
+        assert collected == "Hello world"
+
+    @pytest.mark.anyio
+    async def test_provider_extracts_content_for_scanner(self) -> None:
+        """Provider should be used for content extraction with scanner."""
+        import re
+
+        from agentguard.policies.models import Policy, Rule
+        from agentguard.proxy.inbound import InboundScanner
+        from agentguard.proxy.providers.openai import OpenAIProvider
+
+        rule = Rule(
+            action_kind="llm_response",
+            deny_patterns=[re.compile(r"BLOCKED")],
+            severity="high",
+            description="Test deny rule",
+        )
+        policy = Policy(name="test-policy", rules=[rule], description="Test")
+        guard = Guard()
+        guard.add_policy(policy)
+        scanner = InboundScanner(guard)
+        provider = OpenAIProvider()
+
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "ok "}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": "BLOCKED"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": " more"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [
+            (c, s)
+            async for c, s in stream_sse_response(
+                resp, scanner=scanner, provider=provider
+            )
+        ]
+
+        # Should detect denial: chunk1 + chunk2 + warning + done = 4
+        assert len(chunks) == 4
+        assert b"blocked" in chunks[-2][0] or b"error" in chunks[-2][0]
+
+    @pytest.mark.anyio
+    async def test_provider_none_uses_fallback(self) -> None:
+        """Passing provider=None should fall back to _extract_content_parts."""
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "Hello"}}]}),
+            "data: [DONE]",
+        ]
+        resp = _FakeStreamingResponse(lines)
+        chunks = [
+            (c, s)
+            async for c, s in stream_sse_response(resp, collect=True, provider=None)
+        ]
+
+        _last_chunk, collected = chunks[-1]
+        assert collected == "Hello"


### PR DESCRIPTION
## Summary

- Introduce `Provider` protocol with `extract_request_params()`, `extract_response_params()`, and `extract_stream_content()` methods for format-specific LLM API handling
- Implement `OpenAIProvider` for OpenAI chat completions format (request message flattening, response content extraction, SSE delta parsing)
- Add provider registry with `get_provider()`, `list_providers()`, and `detect_provider()` for runtime provider resolution
- Integrate provider into proxy stack: `ProxyConfig.provider` field, `GuardMiddleware._resolve_provider()` for request/response param extraction, `stream_sse_response()` provider delegation for streaming content extraction
- 27 provider unit tests + 19 integration tests (config, streaming, middleware, scanner delegation) — 778 tests total, all passing

Completes M12 milestone task `m12.provider-openai`.