### PR TITLE
fix: replace ASCII architecture diagram with SVG image

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,30 +39,9 @@ AgentGuard guards AI agents at **two layers**:
    real time, including streaming (SSE). Terminates dangerous streams
    mid-flight.
 
-```
-                           ┌──────────────────────────────────────┐
-                           │           AgentGuard                 │
-                           │                                      │
-┌──────────┐   prompts     │  ┌─────────────┐    ┌────────────┐  │  forwarded    ┌─────────┐
-│ AI Agent │ ─────────────►│  │  Outbound    │───►│  LLM API   │──│─────────────► │ LLM API │
-│          │               │  │  Scanner     │    │  Proxy     │  │              │ (OpenAI │
-│          │◄──────────────│  │  (PII/keys)  │◄───│            │◄─│────────────── │  etc.)  │
-└──────────┘   responses   │  └─────────────┘    └────────────┘  │  responses   └─────────┘
-     │                     │        ▲                  ▲          │
-     │  MCP tools          │        │    policy engine │          │
-     │                     │        ▼                  ▼          │
-     │                     │  ┌─────────────┐    ┌────────────┐  │
-     └────────────────────►│  │  MCP Server │    │  Inbound   │  │
-           shell_execute   │  │  (tools)    │    │  Scanner   │  │
-           file_read       │  └─────────────┘    │  (SSE)     │  │
-           file_write      │        │            └────────────┘  │
-                           │        ▼                  │         │
-                           │  ┌─────────────────────────────┐    │
-                           │  │  Hash-Chained Audit Log     │    │
-                           │  │  (JSONL, SHA-256 linked)    │    │
-                           │  └─────────────────────────────┘    │
-                           └──────────────────────────────────────┘
-```
+<p align="center">
+  <img src="docs/architecture.svg" alt="AgentGuard architecture diagram" width="800">
+</p>
 
 **The agent doesn't know it's being guarded.** Zero prompt engineering.
 Zero cooperation required from the LLM.

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow-right" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-left" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-down" markerWidth="6" markerHeight="8" refX="3" refY="8" orient="auto">
+      <path d="M0,0 L3,8 L6,0" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrow-up" markerWidth="6" markerHeight="8" refX="3" refY="0" orient="auto">
+      <path d="M0,8 L3,0 L6,8" fill="#94a3b8"/>
+    </marker>
+  </defs>
+
+  <style>
+    .box-stroke { fill: none; stroke: #334155; stroke-width: 1.5; rx: 6; }
+    .outer-box { fill: #f8fafc; stroke: #334155; stroke-width: 2; rx: 8; }
+    .label-sm { font-size: 11px; fill: #64748b; }
+    .label-md { font-size: 13px; fill: #334155; font-weight: 500; }
+    .label-lg { font-size: 15px; fill: #1e293b; font-weight: 600; }
+    .title { font-size: 18px; fill: #0f172a; font-weight: 700; letter-spacing: 0.5px; }
+    .arrow-label { font-size: 11px; fill: #64748b; font-style: italic; }
+  </style>
+
+  <!-- Outer AgentGuard box -->
+  <rect x="220" y="20" width="480" height="480" class="outer-box"/>
+  <text x="460" y="52" text-anchor="middle" class="title">AgentGuard</text>
+
+  <!-- AI Agent box (external, left) -->
+  <rect x="20" y="100" width="130" height="80" rx="6" fill="#e0f2fe" stroke="#0284c7" stroke-width="1.5"/>
+  <text x="85" y="138" text-anchor="middle" class="label-lg" fill="#0369a1">AI Agent</text>
+  <text x="85" y="156" text-anchor="middle" class="label-sm" fill="#0369a1">(MCP client)</text>
+
+  <!-- LLM API box (external, right) -->
+  <rect x="770" y="100" width="130" height="80" rx="6" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <text x="835" y="134" text-anchor="middle" class="label-lg" fill="#92400e">LLM API</text>
+  <text x="835" y="152" text-anchor="middle" class="label-sm" fill="#92400e">(OpenAI, Anthropic,</text>
+  <text x="835" y="166" text-anchor="middle" class="label-sm" fill="#92400e">Azure, etc.)</text>
+
+  <!-- Outbound Scanner box -->
+  <rect x="250" y="90" width="170" height="100" rx="6" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+  <text x="335" y="130" text-anchor="middle" class="label-lg" fill="#991b1b">Outbound</text>
+  <text x="335" y="148" text-anchor="middle" class="label-lg" fill="#991b1b">Scanner</text>
+  <text x="335" y="170" text-anchor="middle" class="label-sm" fill="#991b1b">secrets · PII · paths</text>
+
+  <!-- LLM API Proxy box -->
+  <rect x="480" y="90" width="170" height="100" rx="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
+  <text x="565" y="130" text-anchor="middle" class="label-lg" fill="#065f46">LLM API</text>
+  <text x="565" y="148" text-anchor="middle" class="label-lg" fill="#065f46">Proxy</text>
+  <text x="565" y="170" text-anchor="middle" class="label-sm" fill="#065f46">policy enforcement</text>
+
+  <!-- Arrows: AI Agent → Outbound Scanner (prompts) -->
+  <line x1="150" y1="125" x2="248" y2="125" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <text x="199" y="118" text-anchor="middle" class="arrow-label">prompts</text>
+
+  <!-- Arrows: Outbound Scanner ← AI Agent (responses) -->
+  <line x1="248" y1="155" x2="150" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
+  <text x="199" y="172" text-anchor="middle" class="arrow-label">responses</text>
+
+  <!-- Arrows: Outbound Scanner → LLM API Proxy -->
+  <line x1="420" y1="130" x2="478" y2="130" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <!-- Arrows: Outbound Scanner ← LLM API Proxy -->
+  <line x1="478" y1="150" x2="420" y2="150" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
+
+  <!-- Arrows: LLM API Proxy → LLM API (forwarded) -->
+  <line x1="650" y1="125" x2="768" y2="125" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <text x="709" y="118" text-anchor="middle" class="arrow-label">forwarded</text>
+
+  <!-- Arrows: LLM API → LLM API Proxy (responses) -->
+  <line x1="768" y1="155" x2="650" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
+  <text x="709" y="172" text-anchor="middle" class="arrow-label">responses</text>
+
+  <!-- Policy Engine label (between scanner columns and lower boxes) -->
+  <line x1="335" y1="190" x2="335" y2="260" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)" marker-start="url(#arrow-up)"/>
+  <line x1="565" y1="190" x2="565" y2="260" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)" marker-start="url(#arrow-up)"/>
+  <text x="450" y="232" text-anchor="middle" class="label-sm">policy engine</text>
+
+  <!-- MCP Server box -->
+  <rect x="250" y="262" width="170" height="80" rx="6" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="335" y="298" text-anchor="middle" class="label-lg" fill="#5b21b6">MCP Server</text>
+  <text x="335" y="318" text-anchor="middle" class="label-sm" fill="#5b21b6">5 guarded tools</text>
+
+  <!-- Inbound Scanner box -->
+  <rect x="480" y="262" width="170" height="80" rx="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text x="565" y="298" text-anchor="middle" class="label-lg" fill="#9a3412">Inbound Scanner</text>
+  <text x="565" y="318" text-anchor="middle" class="label-sm" fill="#9a3412">SSE sliding window</text>
+
+  <!-- Arrow: AI Agent → MCP Server (tool calls) -->
+  <line x1="85" y1="180" x2="85" y2="300" stroke="#64748b" stroke-width="1.5" stroke-dasharray="0"/>
+  <line x1="85" y1="300" x2="248" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <text x="60" y="228" text-anchor="end" class="label-sm">MCP tools</text>
+  <text x="167" y="290" text-anchor="middle" class="arrow-label">shell_execute</text>
+  <text x="167" y="304" text-anchor="middle" class="arrow-label">file_read</text>
+  <text x="167" y="318" text-anchor="middle" class="arrow-label">file_write</text>
+
+  <!-- Audit Log box -->
+  <rect x="280" y="400" width="340" height="70" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1.5"/>
+  <text x="450" y="432" text-anchor="middle" class="label-lg" fill="#1e293b">Hash-Chained Audit Log</text>
+  <text x="450" y="452" text-anchor="middle" class="label-sm">JSONL · SHA-256 linked · tamper-evident</text>
+
+  <!-- Arrow: MCP Server → Audit Log -->
+  <line x1="335" y1="342" x2="335" y2="398" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
+
+  <!-- Arrow: Inbound Scanner → Audit Log -->
+  <line x1="565" y1="342" x2="565" y2="398" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
+</svg>


### PR DESCRIPTION
## Summary

- Replaced misaligned ASCII art architecture diagram with a proper SVG image (`docs/architecture.svg`)
- SVG renders consistently across GitHub, VS Code, and all markdown viewers — no monospace font alignment issues
- Embedded in README via `<img>` tag with `width="800"` for clean sizing
- Diagram shows the same architecture: AI Agent ↔ Outbound Scanner ↔ LLM API Proxy ↔ LLM API, MCP Server, Inbound Scanner, and Hash-Chained Audit Log