### PR TITLE
docs: update README and MCP docs for 9-tool coverage and client enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ That trust is misplaced:
 
 AgentGuard guards AI agents at **two layers**:
 
-1. **MCP Server** — sits between the agent and your OS. Intercepts every
-   `shell_execute`, `file_read`, and `file_write` call. Enforces policies
-   before execution. Works with any MCP client.
+1. **MCP Server** — sits between the agent and your OS. Intercepts
+   `shell_execute`, `file_read`, `file_write`, `file_edit`, `file_glob`,
+   `file_grep`, and `file_list` calls. Enforces policies before
+   execution. Works with any MCP client (see
+   [enforcement levels](#mcp-client-enforcement) below).
 
 2. **LLM API Proxy** — sits between the agent and the LLM API. Scans
    outbound prompts for secrets/PII before they reach the LLM. Scans
@@ -67,11 +69,45 @@ pip install agentguard[mcp]
 }
 ```
 
-Every `shell_execute`, `file_read`, and `file_write` call now passes
-through AgentGuard. Denied actions never execute. Everything is logged.
+Every `shell_execute`, `file_read`, `file_write`, `file_edit`,
+`file_glob`, `file_grep`, and `file_list` call now passes through
+AgentGuard. Denied actions never execute. Everything is logged.
 
-Works with **any MCP client**: Claude Desktop, Cursor, Windsurf,
-VS Code Copilot, OpenCode, Cline, Zed, and custom agents.
+### MCP Client Enforcement
+
+AgentGuard's MCP server provides 7 action tools and 2 sidecar tools.
+Enforcement coverage depends on whether the MCP client has its own
+native tools that bypass the MCP server:
+
+| Client | Native Tools? | Full Enforcement? | Notes |
+|--------|:---:|:---:|---|
+| **Claude Desktop** | No | ✅ Yes | All tools come from MCP — full coverage |
+| **OpenCode** | Yes | ✅ Yes | Deny native tools via config (see below) |
+| **Cursor** | Yes | ⚠️ Partial | Native tools bypass AgentGuard |
+| **Windsurf** | Yes | ⚠️ Partial | Native tools bypass AgentGuard |
+| **VS Code Copilot** | Yes | ⚠️ Partial | Native tools bypass AgentGuard |
+| **Cline** | Yes | ⚠️ Partial | Native tools bypass AgentGuard |
+| **Zed** | Yes | ⚠️ Partial | Native tools bypass AgentGuard |
+
+For clients with native tools that cannot be disabled, AgentGuard still
+enforces policies on all calls that go through the MCP server — but the
+agent may also use native tools that bypass enforcement entirely.
+
+**OpenCode full enforcement:** Add permission denials to your
+`opencode.json` to route all operations through AgentGuard:
+
+```json
+{
+  "permission": {
+    "bash": "deny",
+    "read": "deny",
+    "edit": "deny",
+    "write": "deny",
+    "glob": "deny",
+    "grep": "deny"
+  }
+}
+```
 
 ### LLM API Proxy — guard prompts and responses
 
@@ -106,9 +142,10 @@ provider adapter.
 ### Policy Engine
 
 YAML policies with regex-based deny patterns. Separate action kinds
-for tool calls (`shell_execute`, `file_read`, `file_write`) and LLM
-traffic (`llm_request`, `llm_response`). Optional `scan` field targets
-specific parts of LLM messages (`messages`, `system`, `content`, `all`).
+for tool calls (`shell_execute`, `file_read`, `file_write`, `file_edit`,
+`file_glob`, `file_grep`, `file_list`) and LLM traffic (`llm_request`,
+`llm_response`). Optional `scan` field targets specific parts of LLM
+messages (`messages`, `system`, `content`, `all`).
 
 ```yaml
 # policies/safety.yaml
@@ -264,6 +301,20 @@ session info) and `agentguard_audit_query` (search audit by action,
 result, or actor) — so you can ask the agent "what policies are
 active?" or "show me all denied actions."
 
+### MCP Action Tools
+
+In addition to `shell_execute`, `file_read`, and `file_write`, the
+MCP server provides:
+
+| Tool | Description |
+|------|-------------|
+| `file_edit` | Exact string replacement in files |
+| `file_glob` | Pattern-based file search (mtime-sorted) |
+| `file_grep` | Regex content search with file filter |
+| `file_list` | Directory listing with ignore patterns |
+
+All 7 action tools enforce policies and log to the audit trail.
+
 ## CLI
 
 ```
@@ -318,7 +369,7 @@ src/agentguard/
 5. **Streaming-aware** — scans SSE responses in real time, terminates on violation
 6. **Extensible** — YAML policies, pluggable providers, pluggable interceptors
 7. **Type-safe** — full mypy strict compliance, py.typed marker
-8. **Tested** — 892 tests, TDD, CI on Python 3.10–3.13
+8. **Tested** — 927 tests, TDD, CI on Python 3.10–3.13
 
 ## Roadmap
 
@@ -327,6 +378,7 @@ src/agentguard/
 - [x] Runtime guardrail interceptor with pre/post hooks
 - [x] EU AI Act compliance report generator (JSON + text)
 - [x] MCP server with transparent policy enforcement and sidecar tools
+- [x] Extended MCP tools (file_edit, file_glob, file_grep, file_list)
 - [x] CLI tool (`check`, `audit`, `policies`, `report`, `serve`, `proxy`)
 - [x] LLM API proxy with outbound scanner (secrets, PII, internal paths)
 - [x] Streaming inbound scanner (SSE sliding window, mid-stream termination)

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -2,10 +2,12 @@
 
 Transparent MCP proxy with policy enforcement and audit logging.
 
-The MCP server exposes agent tools (`shell_execute`, `file_read`,
-`file_write`) that pass through AgentGuard's policy engine before
-execution. See the [MCP Integration Guide](../guides/mcp-integration.md)
-for usage instructions.
+The MCP server exposes 7 action tools (`shell_execute`, `file_read`,
+`file_write`, `file_edit`, `file_glob`, `file_grep`, `file_list`) and
+2 introspection tools (`agentguard_status`, `agentguard_audit_query`)
+that pass through AgentGuard's policy engine before execution. See the
+[MCP Integration Guide](../guides/mcp-integration.md) for usage
+instructions and client enforcement levels.
 
 ## create_server
 

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -13,8 +13,9 @@ Agent  ──►  AgentGuard MCP Server  ──►  System
                └── audit log
 ```
 
-The MCP server exposes three action tools (`shell_execute`, `file_read`,
-`file_write`) and two introspection tools (`agentguard_status`,
+The MCP server exposes seven action tools (`shell_execute`, `file_read`,
+`file_write`, `file_edit`, `file_glob`, `file_grep`, `file_list`) and
+two introspection tools (`agentguard_status`,
 `agentguard_audit_query`). When an agent calls a tool:
 
 1. The request is checked against all loaded policies.
@@ -111,6 +112,70 @@ Write content to a file. Parent directories are created if needed.
 file_write(path="output.txt", content="Hello, world!")
 ```
 
+### `file_edit`
+
+Perform exact string replacement in a file. Rejects if the old string
+is not found, matches multiple times (without `replace_all`), or is
+identical to the new string.
+
+```
+file_edit(path="src/main.py", old_string="v1", new_string="v2")
+file_edit(path="src/main.py", old_string="foo", new_string="bar", replace_all=True)
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | `str` | Yes | File path to edit. |
+| `old_string` | `str` | Yes | Exact text to find. |
+| `new_string` | `str` | Yes | Replacement text. |
+| `replace_all` | `bool` | No | Replace all occurrences (default: `False`). |
+
+### `file_glob`
+
+Search for files matching a glob pattern. Returns up to 100 results
+sorted by modification time (most recent first).
+
+```
+file_glob(pattern="**/*.py")
+file_glob(pattern="src/**/*.ts", path="/project")
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `pattern` | `str` | Yes | Glob pattern (e.g., `**/*.py`). |
+| `path` | `str` | No | Base directory (default: current directory). |
+
+### `file_grep`
+
+Search file contents using regex patterns. Returns up to 100 matches
+with file path, line number, and matching content.
+
+```
+file_grep(pattern="def test_", path="tests/")
+file_grep(pattern="TODO", include="*.py")
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `pattern` | `str` | Yes | Regex pattern to search for. |
+| `path` | `str` | No | Directory to search (default: current directory). |
+| `include` | `str` | No | File filter (e.g., `*.py`, `*.{ts,tsx}`). |
+
+### `file_list`
+
+List directory contents. Directories are marked with a trailing `/`.
+Common directories (`.git`, `node_modules`, `__pycache__`, etc.) are
+excluded by default. Returns up to 100 entries.
+
+```
+file_list()
+file_list(path="src/")
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | `str` | No | Directory to list (default: current directory). |
+
 ### `agentguard_status`
 
 Show the current server status: loaded policies, actor name, session ID,
@@ -128,6 +193,39 @@ AND-combined.
 ```
 agentguard_audit_query(action="shell_execute", result="denied")
 ```
+
+## Client enforcement levels
+
+Most MCP clients have their own native tools (shell, file read/write,
+etc.) that bypass the MCP server entirely. Enforcement coverage depends
+on whether the client can disable these native tools:
+
+| Client | Full Enforcement? | Notes |
+|--------|:---:|---|
+| Claude Desktop | ✅ Yes | No native tools — all tools come from MCP |
+| OpenCode | ✅ Yes | Deny native tools via `opencode.json` config |
+| Cursor, Windsurf, VS Code Copilot, Cline, Zed | ⚠️ Partial | Native tools bypass AgentGuard |
+
+### OpenCode configuration
+
+To achieve full enforcement with OpenCode, deny native tools so all
+operations route through AgentGuard's MCP tools:
+
+```json
+{
+  "permission": {
+    "bash": "deny",
+    "read": "deny",
+    "edit": "deny",
+    "write": "deny",
+    "glob": "deny",
+    "grep": "deny"
+  }
+}
+```
+
+MCP tools (prefixed with `agentguard_` by OpenCode) are unaffected by
+these denials.
 
 ## Custom policies
 


### PR DESCRIPTION
## Summary

- Fix misleading "Works with any MCP client" claim in README to document actual enforcement levels per client
- Add client enforcement table showing Claude Desktop and OpenCode get full enforcement, while other clients have partial coverage due to native tools
- Document OpenCode permission config for full enforcement (`bash`/`read`/`write`/`edit`/`glob`/`grep` → `deny`)
- Add documentation for 4 new MCP tools (`file_edit`, `file_glob`, `file_grep`, `file_list`) to integration guide
- Update API reference to reflect 7 action tools + 2 sidecar tools
- Update test count from 892 → 927

## Files Changed

- `README.md` — Client enforcement table, new tool table, updated counts
- `docs/guides/mcp-integration.md` — New tool docs with parameter tables, client enforcement section with OpenCode config
- `docs/api/mcp.md` — Updated tool count in description