### PR TITLE
feat: LLM proxy integration — daemon script, OpenCode config, and guide

### DIFF
--- a/docs/guides/proxy-integration.md
+++ b/docs/guides/proxy-integration.md
@@ -1,0 +1,319 @@
+# LLM API Proxy Integration Guide
+
+This guide covers integrating the AgentGuard LLM API proxy with AI
+coding tools. The proxy sits between your AI tool and the LLM API,
+scanning outbound prompts for secrets/PII and inbound responses for
+prompt injection — transparently, without any cooperation from the LLM.
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────────────┐     ┌──────────────────┐
+│  AI Tool     │────▶│  AgentGuard Proxy     │────▶│  LLM API         │
+│  (OpenCode,  │◀────│  (localhost:8080)      │◀────│  (Copilot, OpenAI│
+│   Cursor...) │     │                        │     │   Anthropic...)   │
+└─────────────┘     │  ✓ Outbound scanning   │     └──────────────────┘
+                     │  ✓ Inbound scanning    │
+                     │  ✓ Policy enforcement  │
+                     │  ✓ Audit logging       │
+                     └──────────────────────┘
+```
+
+**What the proxy catches:**
+
+| Direction | Threat | Example |
+|-----------|--------|---------|
+| Outbound  | Secret leakage | API keys, tokens, passwords in prompts |
+| Outbound  | PII leakage | Email addresses, SSNs, phone numbers |
+| Outbound  | Internal paths | File system paths, private IPs |
+| Outbound  | Prompt injection | "Ignore previous instructions" |
+| Inbound   | Response injection | Exfiltration URLs, hidden instructions |
+| Inbound   | Persona hijacking | DAN-style jailbreak responses |
+| Inbound   | Drift triggers | Emotional manipulation, grandiose claims |
+
+## Prerequisites
+
+```bash
+pip install agentguard[proxy]
+```
+
+## Quick Start
+
+### 1. Start the proxy
+
+```bash
+# Default: all built-in policies, response scanning enabled
+agentguard proxy https://api.githubcopilot.com \
+  --builtins --scan-responses --audit-dir audit/ --port 8080
+```
+
+Or use the daemon management script:
+
+```bash
+# Start as background daemon with health checks
+bash scripts/proxy.sh start
+
+# Check status
+bash scripts/proxy.sh status
+
+# Stop
+bash scripts/proxy.sh stop
+```
+
+### 2. Point your AI tool at the proxy
+
+Instead of connecting directly to the LLM API, configure your tool to
+use `http://127.0.0.1:8080` as its API base URL. The proxy forwards
+all requests transparently, including authentication headers.
+
+---
+
+## OpenCode (Full Enforcement)
+
+OpenCode achieves **full two-layer enforcement** with AgentGuard:
+
+- **Layer 1 (MCP):** Tool calls go through the AgentGuard MCP server
+- **Layer 2 (Proxy):** LLM API calls go through the AgentGuard proxy
+
+### Setup
+
+**Step 1:** Start the proxy before launching OpenCode:
+
+```bash
+bash scripts/proxy.sh start
+```
+
+**Step 2:** Add the proxy endpoint to your `opencode.json`:
+
+```json
+{
+  "model": "github-copilot/claude-opus-4.6",
+  "provider": {
+    "github-copilot": {
+      "options": {
+        "baseURL": "http://127.0.0.1:8080"
+      }
+    }
+  },
+  "mcp": {
+    "agentguard": {
+      "type": "local",
+      "command": ["agentguard", "serve", "--builtins", "--auto-discover", "--audit-dir", "private/audit"]
+    }
+  },
+  "permission": {
+    "*": "allow",
+    "bash": "deny",
+    "read": "deny",
+    "write": "deny",
+    "edit": "deny",
+    "glob": "deny",
+    "grep": "deny"
+  }
+}
+```
+
+This gives you:
+
+- ✅ All tool calls (shell, file read/write/edit/glob/grep) enforced via MCP
+- ✅ All LLM prompts scanned for secrets, PII, and injection attacks
+- ✅ All LLM responses scanned for prompt injection and exfiltration
+- ✅ Full audit trail for both layers
+
+### Upstream URLs by provider
+
+| Provider | Upstream URL |
+|----------|-------------|
+| GitHub Copilot | `https://api.githubcopilot.com` |
+| OpenAI | `https://api.openai.com` |
+| Anthropic | `https://api.anthropic.com` |
+| Azure OpenAI | `https://{resource}.openai.azure.com` |
+| Ollama (local) | `http://localhost:11434` |
+
+For providers other than GitHub Copilot, update both the proxy
+upstream URL and the `baseURL` in `opencode.json`:
+
+```bash
+# For direct OpenAI
+bash scripts/proxy.sh start --upstream https://api.openai.com
+```
+
+```json
+{
+  "provider": {
+    "openai": {
+      "options": {
+        "baseURL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Claude Desktop
+
+Claude Desktop uses the Anthropic API. Configure it by setting the
+`ANTHROPIC_BASE_URL` environment variable before launching:
+
+```bash
+# Start the proxy targeting Anthropic
+agentguard proxy https://api.anthropic.com \
+  --builtins --scan-responses --audit-dir audit/ --port 8080
+
+# Launch Claude Desktop with proxy
+ANTHROPIC_BASE_URL=http://127.0.0.1:8080 open -a "Claude"
+```
+
+> **Note:** Full Anthropic message format support requires the
+> Anthropic provider adapter (coming soon). Basic support works via
+> the built-in fallback parser.
+
+---
+
+## Cursor
+
+Cursor supports custom API endpoints in its settings:
+
+1. Start the proxy: `bash scripts/proxy.sh start`
+2. Open Cursor Settings → Models → OpenAI API Base URL
+3. Set to `http://127.0.0.1:8080`
+4. Or set the environment variable:
+   ```bash
+   OPENAI_BASE_URL=http://127.0.0.1:8080 cursor .
+   ```
+
+---
+
+## Cline (VS Code Extension)
+
+Cline allows custom API base URLs in its extension settings:
+
+1. Start the proxy: `bash scripts/proxy.sh start`
+2. Open VS Code Settings → Cline → API Base URL
+3. Set to `http://127.0.0.1:8080`
+
+---
+
+## VS Code Copilot
+
+VS Code Copilot routes through GitHub's infrastructure. Use the
+system-level proxy setting:
+
+1. Start the proxy on the appropriate port
+2. In VS Code settings: `"http.proxy": "http://127.0.0.1:8080"`
+3. Or set the `HTTPS_PROXY` environment variable
+
+> **Note:** This routes ALL VS Code HTTP traffic through the proxy,
+> not just LLM calls. Use with caution.
+
+---
+
+## Windsurf / Zed
+
+For tools that support OpenAI-compatible endpoints:
+
+1. Start the proxy with the appropriate upstream
+2. Configure the tool's API endpoint to `http://127.0.0.1:8080`
+3. Authentication headers pass through transparently
+
+---
+
+## Protection Presets
+
+The proxy supports three protection levels:
+
+| Preset | Policies | Best for |
+|--------|:---:|---------|
+| `permissive` | 3 | Development — blocks only catastrophic actions |
+| `balanced` | 8 | Default — covers tools and basic LLM filtering |
+| `strict` | 11 | Production — includes drift detection and persona safety |
+
+```bash
+# Use a preset
+bash scripts/proxy.sh start --preset balanced
+
+# Or load all built-in policies (equivalent to strict + tool policies)
+bash scripts/proxy.sh start --builtins
+```
+
+---
+
+## Daemon Management
+
+The `scripts/proxy.sh` script manages the proxy lifecycle:
+
+```bash
+# Start with defaults (GitHub Copilot, all policies, response scanning)
+bash scripts/proxy.sh start
+
+# Start with custom settings
+bash scripts/proxy.sh start \
+  --upstream https://api.openai.com \
+  --port 9090 \
+  --preset balanced \
+  --audit-dir ./my-audit/
+
+# Check status and loaded policies
+bash scripts/proxy.sh status
+
+# Quick health check (for CI/scripts — exits 0 if healthy)
+bash scripts/proxy.sh health
+
+# Stop the daemon
+bash scripts/proxy.sh stop
+```
+
+### Environment variables
+
+Override defaults without CLI flags:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTGUARD_PROXY_UPSTREAM` | `https://api.githubcopilot.com` | Upstream LLM API |
+| `AGENTGUARD_PROXY_PORT` | `8080` | Proxy listen port |
+| `AGENTGUARD_PROXY_PRESET` | (none) | Protection preset |
+| `AGENTGUARD_PROXY_AUDIT_DIR` | `./private/audit/proxy` | Audit log directory |
+
+---
+
+## Verifying the Integration
+
+After configuring, verify everything works:
+
+```bash
+# 1. Check proxy is healthy
+bash scripts/proxy.sh health
+
+# 2. Send a test request
+curl -s http://127.0.0.1:8080/_status | python3 -m json.tool
+
+# 3. Verify policy enforcement (should return 403)
+curl -s http://127.0.0.1:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"My key is sk-abc123def456ghi789"}]}'
+
+# 4. Check audit log
+ls private/audit/proxy/*.jsonl
+
+# 5. Verify audit chain integrity
+agentguard audit verify private/audit/proxy/*.jsonl
+```
+
+---
+
+## Combining with MCP Server
+
+For maximum protection, run both layers:
+
+```
+AI Tool ──┬── LLM calls ──▶ AgentGuard Proxy ──▶ LLM API
+          │
+          └── Tool calls ──▶ AgentGuard MCP ──▶ OS (shell, files)
+```
+
+The MCP server and proxy each maintain their own audit logs. Both
+are hash-chained and independently verifiable.
+
+See [MCP Integration Guide](mcp-integration.md) for MCP setup details.

--- a/examples/opencode-proxy-config.json
+++ b/examples/opencode-proxy-config.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "_comment": "Example: OpenCode with AgentGuard MCP + LLM proxy (full two-layer protection)",
+  "model": "github-copilot/claude-opus-4.6",
+  "provider": {
+    "github-copilot": {
+      "options": {
+        "baseURL": "http://127.0.0.1:8080"
+      }
+    }
+  },
+  "mcp": {
+    "agentguard": {
+      "type": "local",
+      "command": ["agentguard", "serve", "--builtins", "--auto-discover", "--audit-dir", "private/audit"]
+    }
+  },
+  "permission": {
+    "*": "allow",
+    "bash": "deny",
+    "read": "deny",
+    "write": "deny",
+    "edit": "deny",
+    "glob": "deny",
+    "grep": "deny"
+  }
+}

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# AgentGuard LLM API Proxy — daemon management
+# Usage: proxy.sh {start|stop|status|health} [OPTIONS]
+#
+# Starts the AgentGuard proxy as a background daemon, manages its
+# lifecycle, and checks health. Designed for integration with OpenCode
+# and other AI coding tools.
+#
+# Options (for 'start'):
+#   --upstream URL      Upstream LLM API (default: https://api.githubcopilot.com)
+#   --port PORT         Proxy port (default: 8080)
+#   --preset LEVEL      Protection preset: strict|balanced|permissive
+#   --builtins          Load all built-in policies (default if no --preset)
+#   --scan-responses    Scan upstream responses (default: enabled)
+#   --no-scan-responses Disable response scanning
+#   --audit-dir DIR     Audit log directory (default: ./private/audit/proxy)
+#   --actor NAME        Actor name for audit (default: opencode-proxy)
+#   --timeout SECS      Upstream timeout (default: 300)
+#   --pid-dir DIR       Directory for PID/log files (default: ./private/run)
+#
+# Environment:
+#   AGENTGUARD_PROXY_UPSTREAM   Override default upstream URL
+#   AGENTGUARD_PROXY_PORT       Override default port
+#   AGENTGUARD_PROXY_PRESET     Override default preset
+#   AGENTGUARD_PROXY_AUDIT_DIR  Override default audit directory
+
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────
+
+UPSTREAM="${AGENTGUARD_PROXY_UPSTREAM:-https://api.githubcopilot.com}"
+PORT="${AGENTGUARD_PROXY_PORT:-8080}"
+PRESET="${AGENTGUARD_PROXY_PRESET:-}"
+USE_BUILTINS=true
+SCAN_RESPONSES=true
+AUDIT_DIR="${AGENTGUARD_PROXY_AUDIT_DIR:-./private/audit/proxy}"
+ACTOR="opencode-proxy"
+TIMEOUT=300
+PID_DIR="./private/run"
+
+# ── Parse arguments ─────────────────────────────────────────────────
+
+ACTION="${1:-help}"
+shift 2>/dev/null || true
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --upstream)       UPSTREAM="$2"; shift 2 ;;
+        --port)           PORT="$2"; shift 2 ;;
+        --preset)         PRESET="$2"; USE_BUILTINS=false; shift 2 ;;
+        --builtins)       USE_BUILTINS=true; PRESET=""; shift ;;
+        --scan-responses) SCAN_RESPONSES=true; shift ;;
+        --no-scan-responses) SCAN_RESPONSES=false; shift ;;
+        --audit-dir)      AUDIT_DIR="$2"; shift 2 ;;
+        --actor)          ACTOR="$2"; shift 2 ;;
+        --timeout)        TIMEOUT="$2"; shift 2 ;;
+        --pid-dir)        PID_DIR="$2"; shift 2 ;;
+        *)                echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ── Paths ────────────────────────────────────────────────────────────
+
+PID_FILE="${PID_DIR}/proxy.pid"
+LOG_FILE="${PID_DIR}/proxy.log"
+
+# ── Functions ────────────────────────────────────────────────────────
+
+is_running() {
+    if [[ -f "$PID_FILE" ]]; then
+        local pid
+        pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        # Stale PID file
+        rm -f "$PID_FILE"
+    fi
+    return 1
+}
+
+get_pid() {
+    if [[ -f "$PID_FILE" ]]; then
+        cat "$PID_FILE"
+    fi
+}
+
+do_start() {
+    if is_running; then
+        echo "AgentGuard proxy already running (PID: $(get_pid))"
+        echo "Use 'proxy.sh stop' first, or 'proxy.sh status' for details."
+        return 1
+    fi
+
+    mkdir -p "$AUDIT_DIR" "$PID_DIR"
+
+    # Build command — use the agentguard CLI (supports --preset)
+    local cmd=(agentguard proxy "$UPSTREAM"
+        --port "$PORT"
+        --audit-dir "$AUDIT_DIR"
+        --actor "$ACTOR"
+        --timeout "$TIMEOUT"
+    )
+
+    if [[ -n "$PRESET" ]]; then
+        cmd+=(--preset "$PRESET")
+    elif [[ "$USE_BUILTINS" == "true" ]]; then
+        cmd+=(--builtins)
+    fi
+
+    if [[ "$SCAN_RESPONSES" == "true" ]]; then
+        cmd+=(--scan-responses)
+    fi
+
+    # Start as background daemon
+    setsid "${cmd[@]}" </dev/null > "$LOG_FILE" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$PID_FILE"
+
+    # Wait for readiness (up to 10 seconds)
+    local attempts=0
+    local max_attempts=20
+    while [[ $attempts -lt $max_attempts ]]; do
+        sleep 0.5
+        # Check if process died
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "❌ Proxy failed to start. Log:" >&2
+            tail -20 "$LOG_FILE" >&2
+            rm -f "$PID_FILE"
+            return 1
+        fi
+        # Check health endpoint
+        if curl -sf "http://127.0.0.1:${PORT}/_health" >/dev/null 2>&1; then
+            local health
+            health=$(curl -s "http://127.0.0.1:${PORT}/_health")
+            local policies
+            policies=$(echo "$health" | python3 -c "import json,sys; print(json.load(sys.stdin).get('policies_loaded', '?'))" 2>/dev/null || echo "?")
+            echo "✅ AgentGuard proxy started"
+            echo "   PID:      $pid"
+            echo "   Port:     $PORT"
+            echo "   Upstream: $UPSTREAM"
+            echo "   Policies: $policies loaded"
+            echo "   Audit:    $AUDIT_DIR"
+            echo "   Log:      $LOG_FILE"
+            return 0
+        fi
+        attempts=$((attempts + 1))
+    done
+
+    echo "⚠️  Proxy started (PID: $pid) but health check not responding after 10s" >&2
+    echo "   Check log: $LOG_FILE" >&2
+    return 1
+}
+
+do_stop() {
+    if ! is_running; then
+        echo "AgentGuard proxy is not running"
+        return 0
+    fi
+
+    local pid
+    pid=$(get_pid)
+    echo "Stopping AgentGuard proxy (PID: $pid)..."
+    kill "$pid" 2>/dev/null
+
+    # Wait for graceful shutdown (up to 5 seconds)
+    local attempts=0
+    while [[ $attempts -lt 10 ]]; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            rm -f "$PID_FILE"
+            echo "✅ Proxy stopped"
+            return 0
+        fi
+        sleep 0.5
+        attempts=$((attempts + 1))
+    done
+
+    # Force kill
+    kill -9 "$pid" 2>/dev/null
+    rm -f "$PID_FILE"
+    echo "✅ Proxy force-stopped"
+}
+
+do_status() {
+    if ! is_running; then
+        echo "AgentGuard proxy is not running"
+        return 1
+    fi
+
+    local pid
+    pid=$(get_pid)
+    echo "AgentGuard proxy is running (PID: $pid)"
+
+    # Get detailed status from the proxy
+    if curl -sf "http://127.0.0.1:${PORT}/_status" >/dev/null 2>&1; then
+        echo ""
+        curl -s "http://127.0.0.1:${PORT}/_status" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f\"   Session:  {data.get('session_id', '?')}\")
+print(f\"   Actor:    {data.get('actor', '?')}\")
+print(f\"   Upstream: {data.get('upstream', '?')}\")
+print(f\"   Policies: {data.get('policies_loaded', '?')} loaded\")
+names = data.get('policy_names', [])
+if names:
+    for n in names:
+        print(f\"             - {n}\")
+print(f\"   Audit:    {data.get('audit_entries', 0)} entries this session\")
+print(f\"   Scanning: responses={'yes' if data.get('scan_responses') else 'no'}\")
+" 2>/dev/null
+    else
+        echo "   (health endpoint not responding)"
+    fi
+}
+
+do_health() {
+    if ! curl -sf "http://127.0.0.1:${PORT}/_health" >/dev/null 2>&1; then
+        echo "UNHEALTHY: proxy not responding on port $PORT"
+        return 1
+    fi
+    echo "HEALTHY"
+    curl -s "http://127.0.0.1:${PORT}/_health" | python3 -m json.tool 2>/dev/null
+}
+
+do_help() {
+    echo "AgentGuard LLM API Proxy — daemon management"
+    echo ""
+    echo "Usage: proxy.sh {start|stop|status|health} [OPTIONS]"
+    echo ""
+    echo "Commands:"
+    echo "  start    Start the proxy daemon"
+    echo "  stop     Stop the proxy daemon"
+    echo "  status   Show proxy status and loaded policies"
+    echo "  health   Quick health check (for scripts)"
+    echo ""
+    echo "Options (for 'start'):"
+    echo "  --upstream URL       Upstream LLM API (default: https://api.githubcopilot.com)"
+    echo "  --port PORT          Proxy port (default: 8080)"
+    echo "  --preset LEVEL       Protection preset: strict|balanced|permissive"
+    echo "  --builtins           Load all built-in policies (default)"
+    echo "  --scan-responses     Enable response scanning (default)"
+    echo "  --no-scan-responses  Disable response scanning"
+    echo "  --audit-dir DIR      Audit log directory"
+    echo "  --actor NAME         Actor name for audit entries"
+    echo "  --timeout SECS       Upstream request timeout (default: 300)"
+    echo "  --pid-dir DIR        Directory for PID and log files"
+    echo ""
+    echo "Environment variables:"
+    echo "  AGENTGUARD_PROXY_UPSTREAM   Override upstream URL"
+    echo "  AGENTGUARD_PROXY_PORT       Override port"
+    echo "  AGENTGUARD_PROXY_PRESET     Override preset"
+    echo "  AGENTGUARD_PROXY_AUDIT_DIR  Override audit directory"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+case "$ACTION" in
+    start)  do_start ;;
+    stop)   do_stop ;;
+    status) do_status ;;
+    health) do_health ;;
+    help|--help|-h) do_help ;;
+    *)
+        echo "Unknown command: $ACTION" >&2
+        echo "Usage: proxy.sh {start|stop|status|health}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds the infrastructure to integrate the AgentGuard LLM API proxy with AI coding tools, starting with OpenCode (GitHub Copilot).

### Changes

- **`scripts/proxy.sh`** — Daemon management script with `start`, `stop`, `status`, and `health` commands. Features: readiness polling with health checks, PID file management, double-start prevention, graceful shutdown with force-kill fallback, preset/env var support, detailed status output showing all loaded policies.

- **`examples/opencode-proxy-config.json`** — Reference `opencode.json` showing full two-layer enforcement (MCP server for tool calls + proxy for LLM traffic). Configures `baseURL` override to route GitHub Copilot API calls through the proxy.

- **`docs/guides/proxy-integration.md`** — Comprehensive integration guide covering OpenCode, Claude Desktop, Cursor, Cline, VS Code Copilot, Windsurf, and Zed. Includes upstream URL reference table, protection preset comparison, daemon management docs, and verification steps.

### Validated

Manually tested end-to-end with live GitHub Copilot API:
- ✅ Non-streaming requests forwarded successfully
- ✅ Streaming SSE responses (chunks + `[DONE]`) flow through correctly
- ✅ Secret detection blocks prompts containing API keys (403)
- ✅ Prompt injection detection blocks jailbreak attempts (403)
- ✅ PII leak detection blocks SSN/email in prompts (403)
- ✅ Audit log records all actions with verified hash chain integrity
- ✅ Auth headers (`gho_...` OAuth token) pass through transparently
- ✅ Daemon script: start, stop, status, health, double-start prevention, preset switching