### PR TITLE
feat: add systemd user service for proxy auto-start

### DIFF
--- a/docs/guides/proxy-integration.md
+++ b/docs/guides/proxy-integration.md
@@ -278,6 +278,101 @@ Override defaults without CLI flags:
 
 ---
 
+## Systemd User Service (Auto-Start)
+
+For production use, install the proxy as a systemd user service so it
+starts automatically on login and restarts on crash:
+
+### Install
+
+```bash
+bash scripts/proxy-install.sh install [preset]
+```
+
+This will:
+
+1. Resolve the full path to the `agentguard` binary
+2. Copy the service template to `~/.config/systemd/user/`
+3. Create a default config at `~/.config/agentguard/proxy.env`
+4. Enable and start the service
+
+The default preset is `builtins` (all 11 built-in policies). You can
+also specify `strict`, `balanced`, or `permissive`:
+
+```bash
+bash scripts/proxy-install.sh install balanced
+```
+
+### Configuration
+
+All settings are in `~/.config/agentguard/proxy.env`:
+
+```bash
+# Full path to agentguard binary (auto-detected at install time)
+AGENTGUARD_BIN=/path/to/agentguard
+
+# Upstream LLM API base URL
+#AGENTGUARD_UPSTREAM=https://api.githubcopilot.com
+
+# Proxy listen port
+#AGENTGUARD_PORT=8080
+
+# Upstream request timeout (seconds)
+#AGENTGUARD_TIMEOUT=300
+
+# Actor name in audit entries
+#AGENTGUARD_ACTOR=opencode-proxy
+
+# Audit log directory
+#AGENTGUARD_AUDIT_DIR=$HOME/.local/share/agentguard/audit
+```
+
+After editing, restart the service:
+
+```bash
+systemctl --user restart agentguard-proxy@builtins
+```
+
+### Management commands
+
+```bash
+# Status (with health check and policy count)
+bash scripts/proxy-install.sh status
+
+# Or use systemctl directly
+systemctl --user status agentguard-proxy@builtins
+systemctl --user restart agentguard-proxy@builtins
+systemctl --user stop agentguard-proxy@builtins
+
+# Live logs
+journalctl --user -u agentguard-proxy@builtins -f
+```
+
+### Uninstall
+
+```bash
+bash scripts/proxy-install.sh uninstall
+```
+
+This stops and disables all preset instances, removes the service unit,
+but preserves your config and audit logs.
+
+### Systemd vs daemon script
+
+| Feature | `proxy.sh` | systemd service |
+|---------|-----------|-----------------|
+| Auto-start on login | ❌ | ✅ |
+| Crash recovery | ❌ | ✅ (auto-restart) |
+| Log management | stdout/stderr | journald |
+| Resource limits | ❌ | ✅ (cgroups) |
+| Security hardening | ❌ | ✅ (NoNewPrivileges, PrivateTmp) |
+| Quick testing | ✅ | ❌ |
+
+Use `proxy.sh` for quick testing and one-off runs. Use the systemd
+service for always-on protection in development or production.
+
+---
+
 ## Verifying the Integration
 
 After configuring, verify everything works:

--- a/scripts/proxy-install.sh
+++ b/scripts/proxy-install.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Install/uninstall the AgentGuard proxy as a systemd user service.
+#
+# Usage:
+#   proxy-install.sh [install|uninstall|status]
+#
+# install:   Copy service unit, enable, start
+# uninstall: Stop, disable, remove service unit
+# status:    Show service status and health
+
+set -euo pipefail
+
+SERVICE_NAME="agentguard-proxy"
+DEFAULT_PRESET="builtins"
+UNIT_DIR="${HOME}/.config/systemd/user"
+ENV_DIR="${HOME}/.config/agentguard"
+AUDIT_DIR="${HOME}/.local/share/agentguard/audit"
+
+# Find the service template file (relative to this script)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UNIT_FILE="${SCRIPT_DIR}/../systemd/${SERVICE_NAME}@.service"
+
+ACTION="${1:-status}"
+PRESET="${2:-${DEFAULT_PRESET}}"
+INSTANCE="${SERVICE_NAME}@${PRESET}"
+
+do_install() {
+    echo "Installing AgentGuard proxy service (preset: ${PRESET})..."
+
+    # 1. Verify agentguard is available and resolve full path
+    if ! command -v agentguard &>/dev/null; then
+        echo "❌ agentguard not found in PATH" >&2
+        echo "   Install: pip install agentguard[proxy]" >&2
+        exit 1
+    fi
+    local agentguard_bin
+    agentguard_bin="$(command -v agentguard)"
+
+    # 2. Verify the unit file exists
+    if [[ ! -f "$UNIT_FILE" ]]; then
+        echo "❌ Service unit not found: ${UNIT_FILE}" >&2
+        exit 1
+    fi
+
+    # 3. Create directories
+    mkdir -p "${UNIT_DIR}" "${ENV_DIR}" "${AUDIT_DIR}"
+
+    # 4. Copy service unit
+    cp "${UNIT_FILE}" "${UNIT_DIR}/"
+    echo "   ✓ Copied service unit to ${UNIT_DIR}/"
+
+    # 5. Create default env file if it doesn't exist
+    if [[ ! -f "${ENV_DIR}/proxy.env" ]]; then
+        cat > "${ENV_DIR}/proxy.env" << ENV
+# AgentGuard Proxy Configuration
+# Uncomment and modify to override defaults.
+
+# Full path to agentguard binary (auto-detected at install time)
+AGENTGUARD_BIN=${agentguard_bin}
+
+# Upstream LLM API base URL
+#AGENTGUARD_UPSTREAM=https://api.githubcopilot.com
+
+# Proxy listen port
+#AGENTGUARD_PORT=8080
+
+# Upstream request timeout (seconds)
+#AGENTGUARD_TIMEOUT=300
+
+# Actor name in audit entries
+#AGENTGUARD_ACTOR=opencode-proxy
+
+# Audit log directory
+#AGENTGUARD_AUDIT_DIR=\$HOME/.local/share/agentguard/audit
+ENV
+        echo "   ✓ Created default config at ${ENV_DIR}/proxy.env"
+    else
+        # Ensure AGENTGUARD_BIN is set even if env file already exists
+        if ! grep -q '^AGENTGUARD_BIN=' "${ENV_DIR}/proxy.env"; then
+            echo "" >> "${ENV_DIR}/proxy.env"
+            echo "# Full path to agentguard binary (auto-detected at install time)" >> "${ENV_DIR}/proxy.env"
+            echo "AGENTGUARD_BIN=${agentguard_bin}" >> "${ENV_DIR}/proxy.env"
+            echo "   ✓ Added AGENTGUARD_BIN to existing config"
+        fi
+        echo "   ✓ Config exists at ${ENV_DIR}/proxy.env (not overwritten)"
+    fi
+
+    # 6. Reload systemd, enable and start
+    systemctl --user daemon-reload
+    systemctl --user enable "${INSTANCE}" 2>/dev/null
+    systemctl --user start "${INSTANCE}"
+
+    echo ""
+    echo "✅ AgentGuard proxy installed and running"
+    echo ""
+    echo "   Service: ${INSTANCE}"
+    echo "   Config:  ${ENV_DIR}/proxy.env"
+    echo "   Audit:   ${AUDIT_DIR}/"
+    echo "   Logs:    journalctl --user -u ${INSTANCE} -f"
+    echo ""
+
+    # 7. Wait for health and show status
+    sleep 2
+    local port
+    port=$(grep -oP 'AGENTGUARD_PORT=\K\d+' "${ENV_DIR}/proxy.env" 2>/dev/null || echo "8080")
+    if curl -sf "http://127.0.0.1:${port}/_health" >/dev/null 2>&1; then
+        local health
+        health=$(curl -s "http://127.0.0.1:${port}/_health")
+        local policies
+        policies=$(echo "$health" | python3 -c "import json,sys; print(json.load(sys.stdin).get('policies_loaded', '?'))" 2>/dev/null || echo "?")
+        echo "   Health:  ✅ ${policies} policies loaded"
+    else
+        echo "   Health:  ⏳ starting up (check: curl http://127.0.0.1:${port}/_health)"
+    fi
+
+    echo ""
+    echo "Commands:"
+    echo "   systemctl --user status ${INSTANCE}    # Status"
+    echo "   systemctl --user restart ${INSTANCE}   # Restart"
+    echo "   systemctl --user stop ${INSTANCE}      # Stop"
+    echo "   journalctl --user -u ${INSTANCE} -f    # Live logs"
+}
+
+do_uninstall() {
+    echo "Uninstalling AgentGuard proxy service..."
+
+    # Stop and disable all presets
+    for preset in builtins strict balanced permissive; do
+        local inst="${SERVICE_NAME}@${preset}"
+        if systemctl --user is-active "${inst}" &>/dev/null; then
+            systemctl --user stop "${inst}"
+            echo "   ✓ Stopped ${inst}"
+        fi
+        if systemctl --user is-enabled "${inst}" &>/dev/null 2>&1; then
+            systemctl --user disable "${inst}" 2>/dev/null
+            echo "   ✓ Disabled ${inst}"
+        fi
+    done
+
+    # Remove unit file
+    if [[ -f "${UNIT_DIR}/${SERVICE_NAME}@.service" ]]; then
+        rm "${UNIT_DIR}/${SERVICE_NAME}@.service"
+        echo "   ✓ Removed service unit"
+    fi
+
+    systemctl --user daemon-reload
+
+    echo ""
+    echo "✅ AgentGuard proxy service removed"
+    echo ""
+    echo "   Config preserved at: ${ENV_DIR}/proxy.env"
+    echo "   Audit logs at:       ${AUDIT_DIR}/"
+    echo "   (Remove manually if no longer needed)"
+}
+
+do_status() {
+    echo "AgentGuard Proxy Service Status"
+    echo "================================"
+    echo ""
+
+    local found=false
+    for preset in builtins strict balanced permissive; do
+        local inst="${SERVICE_NAME}@${preset}"
+        if systemctl --user is-active "${inst}" &>/dev/null; then
+            found=true
+            echo "● ${inst}: active (running)"
+            systemctl --user show "${inst}" --property=MainPID,ActiveEnterTimestamp \
+                --no-pager 2>/dev/null | sed 's/^/  /'
+
+            # Health check
+            local port
+            port=$(grep -oP 'AGENTGUARD_PORT=\K\d+' "${ENV_DIR}/proxy.env" 2>/dev/null || echo "8080")
+            if curl -sf "http://127.0.0.1:${port}/_status" >/dev/null 2>&1; then
+                curl -s "http://127.0.0.1:${port}/_status" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(f\"  Upstream: {d.get('upstream', '?')}\")
+print(f\"  Policies: {d.get('policies_loaded', '?')} loaded\")
+print(f\"  Audit:    {d.get('audit_entries', 0)} entries this session\")
+" 2>/dev/null
+            fi
+            echo ""
+        elif systemctl --user is-enabled "${inst}" &>/dev/null 2>&1; then
+            echo "○ ${inst}: enabled (not running)"
+            echo ""
+        fi
+    done
+
+    if [[ "$found" == "false" ]]; then
+        # Check if unit is installed at all
+        if [[ -f "${UNIT_DIR}/${SERVICE_NAME}@.service" ]]; then
+            echo "Service unit installed but no instance is active."
+            echo ""
+            echo "Start with: systemctl --user start ${SERVICE_NAME}@builtins"
+        else
+            echo "Service not installed."
+            echo ""
+            echo "Install with: bash scripts/proxy-install.sh install"
+        fi
+    fi
+}
+
+case "$ACTION" in
+    install)   do_install ;;
+    uninstall) do_uninstall ;;
+    status)    do_status ;;
+    *)
+        echo "Usage: proxy-install.sh [install|uninstall|status] [preset]"
+        echo ""
+        echo "  install [preset]  Install and start (default preset: builtins)"
+        echo "  uninstall         Stop, disable, and remove"
+        echo "  status            Show current status"
+        echo ""
+        echo "Presets: builtins, strict, balanced, permissive"
+        exit 1
+        ;;
+esac

--- a/systemd/agentguard-proxy@.service
+++ b/systemd/agentguard-proxy@.service
@@ -1,0 +1,65 @@
+# AgentGuard LLM API Proxy — systemd user service
+#
+# Template unit. The instance name selects the protection preset:
+#
+#   systemctl --user start agentguard-proxy@strict
+#   systemctl --user start agentguard-proxy@balanced
+#   systemctl --user start agentguard-proxy@builtins
+#
+# Install:
+#   bash scripts/proxy-install.sh
+#
+# Configuration:
+#   ~/.config/agentguard/proxy.env    (environment overrides)
+#
+# Logs:
+#   journalctl --user -u agentguard-proxy@builtins -f
+
+[Unit]
+Description=AgentGuard LLM API Proxy (%i)
+Documentation=https://github.com/Roboter-Schlafen-Nicht/agentguard
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# Defaults — override in ~/.config/agentguard/proxy.env
+Environment=AGENTGUARD_UPSTREAM=https://api.githubcopilot.com
+Environment=AGENTGUARD_PORT=8080
+Environment=AGENTGUARD_TIMEOUT=300
+Environment=AGENTGUARD_ACTOR=opencode-proxy
+Environment=AGENTGUARD_AUDIT_DIR=%h/.local/share/agentguard/audit
+Environment=AGENTGUARD_BIN=agentguard
+
+# Load user overrides (file is optional, - prefix means no error if missing)
+EnvironmentFile=-%h/.config/agentguard/proxy.env
+
+ExecStartPre=/bin/mkdir -p ${AGENTGUARD_AUDIT_DIR}
+ExecStart=/bin/bash -c '\
+  PRESET="%i"; \
+  ARGS="--port ${AGENTGUARD_PORT} \
+        --audit-dir ${AGENTGUARD_AUDIT_DIR} \
+        --actor ${AGENTGUARD_ACTOR} \
+        --timeout ${AGENTGUARD_TIMEOUT} \
+        --scan-responses"; \
+  if [ "$PRESET" = "builtins" ]; then \
+    exec ${AGENTGUARD_BIN} proxy ${AGENTGUARD_UPSTREAM} --builtins $ARGS; \
+  else \
+    exec ${AGENTGUARD_BIN} proxy ${AGENTGUARD_UPSTREAM} --preset $PRESET $ARGS; \
+  fi'
+
+# Restart on crash (not on manual stop)
+Restart=on-failure
+RestartSec=3
+
+# Rate-limit restarts: max 5 in 60s
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+# Security hardening (user service — limited options)
+NoNewPrivileges=yes
+PrivateTmp=yes
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Adds a systemd user service for the AgentGuard LLM API proxy so it starts automatically on login and restarts on crash.

## Changes

### New files
- `systemd/agentguard-proxy@.service` — systemd template unit file. The instance name selects the protection preset (`@builtins`, `@strict`, `@balanced`, `@permissive`).
- `scripts/proxy-install.sh` — Install/uninstall/status script for the service.

### Modified files
- `docs/guides/proxy-integration.md` — Added "Systemd User Service" section with install instructions, configuration reference, management commands, and comparison table (systemd vs daemon script).

## Key design decisions

1. **AGENTGUARD_BIN env var**: The install script auto-detects the full path to the `agentguard` binary and writes it to `~/.config/agentguard/proxy.env`. This solves the PATH issue — systemd user services don't inherit the user's shell PATH, so the bare `agentguard` command would fail with exit code 127.

2. **Template unit**: Using systemd's `@` template mechanism allows running different presets as separate service instances without duplicating unit files.

3. **Rate-limited restarts**: `Restart=on-failure` with `RestartSec=3` and `StartLimitBurst=5` prevents infinite restart loops while recovering from transient failures.

4. **Security hardening**: `NoNewPrivileges=yes` and `PrivateTmp=yes` limit the service's attack surface.

## Testing

Manually verified:
- Install: service starts, 11 policies loaded, health check passes
- Restart: `systemctl --user restart` works cleanly
- Crash recovery: `kill -9` on process → systemd restarts with new PID
- Live request: curl through proxy to GitHub Copilot API → 200 response
- Policy enforcement: secret in prompt → 403 blocked by no-pii-leak
- Audit logging: hash-chained JSONL entries in `~/.local/share/agentguard/audit/`
- Uninstall: service stops, unit removed, config and audit preserved
- Re-install: existing config preserved, service starts cleanly
- Status command: shows active instances with health info

## Test suite
1188 tests passing, no changes to library code.