### PR TITLE
feat: add --auth-file and --auth-provider flags for proxy token injection

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -408,6 +408,19 @@ def _build_parser() -> argparse.ArgumentParser:
         default=120.0,
         help="Timeout in seconds for upstream requests (default: 120).",
     )
+    proxy_parser.add_argument(
+        "--auth-file",
+        help=(
+            "Path to a JSON auth credentials file. The proxy reads a "
+            "Bearer token from this file and injects it into upstream "
+            "requests (OpenCode auth.json format)."
+        ),
+    )
+    proxy_parser.add_argument(
+        "--auth-provider",
+        default="github-copilot",
+        help=("Provider key to look up in the auth file (default: github-copilot)."),
+    )
 
     return parser
 
@@ -944,6 +957,8 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
             preset=preset,
             scan_responses=args.scan_responses,
             timeout=args.timeout,
+            auth_file=getattr(args, "auth_file", None),
+            auth_provider=getattr(args, "auth_provider", "github-copilot"),
         )
         app = create_proxy_app(config)
 

--- a/src/agentguard/proxy/__main__.py
+++ b/src/agentguard/proxy/__main__.py
@@ -74,6 +74,19 @@ def main() -> int:
         default=120.0,
         help="Timeout in seconds for upstream requests (default: 120).",
     )
+    parser.add_argument(
+        "--auth-file",
+        help=(
+            "Path to a JSON auth credentials file. The proxy reads a "
+            "Bearer token from this file and injects it into upstream "
+            "requests (OpenCode auth.json format)."
+        ),
+    )
+    parser.add_argument(
+        "--auth-provider",
+        default="github-copilot",
+        help=("Provider key to look up in the auth file (default: github-copilot)."),
+    )
 
     args = parser.parse_args()
 
@@ -88,6 +101,8 @@ def main() -> int:
         auto_discover=args.auto_discover,
         scan_responses=args.scan_responses,
         timeout=args.timeout,
+        auth_file=args.auth_file,
+        auth_provider=args.auth_provider,
     )
 
     app = create_app(config)

--- a/src/agentguard/proxy/config.py
+++ b/src/agentguard/proxy/config.py
@@ -7,6 +7,7 @@ LLM API proxy server.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
 @dataclass
@@ -38,6 +39,16 @@ class ProxyConfig:
             for parsing request/response bodies (e.g. ``"openai"``).
             If None, defaults to ``"openai"`` (most LLM APIs use
             the OpenAI-compatible format).
+        auth_file: Path to a JSON auth credentials file. When set,
+            the proxy reads a Bearer token from this file and
+            injects it into the ``Authorization`` header of upstream
+            requests, replacing any token sent by the client. This
+            allows the proxy to handle authentication on behalf of
+            clients that don't have direct access to the upstream
+            credentials. File format: ``{"<provider>": {"refresh":
+            "<token>", ...}}`` (OpenCode auth.json format).
+        auth_provider: Provider key to look up in the auth file.
+            Defaults to ``"github-copilot"``.
     """
 
     upstream_base_url: str
@@ -53,6 +64,8 @@ class ProxyConfig:
     timeout: float = 120.0
     allowed_endpoints: list[str] = field(default_factory=list)
     provider: str | None = None
+    auth_file: str | None = None
+    auth_provider: str = "github-copilot"
 
     def __post_init__(self) -> None:
         """Validate configuration."""
@@ -67,3 +80,6 @@ class ProxyConfig:
         if self.timeout <= 0:
             msg = f"timeout must be positive, got {self.timeout}"
             raise ValueError(msg)
+        if self.auth_file is not None and not Path(self.auth_file).is_file():
+            msg = f"auth_file does not exist: {self.auth_file}"
+            raise FileNotFoundError(msg)

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -56,12 +56,84 @@ class GuardMiddleware:
 
         Args:
             config: Proxy server configuration.
+
+        Raises:
+            ValueError: If the auth file is invalid JSON or the
+                configured provider key is not found in the file.
         """
         self.config = config
         self.guard = self._build_guard()
         self.provider = self._resolve_provider()
+        self._auth_token: str | None = self._load_auth_token()
         self.session_id = f"proxy-{uuid.uuid4().hex[:12]}"
         self.audit_log = AuditLog(self.session_id)
+
+    def _load_auth_token(self) -> str | None:
+        """Load an auth token from the configured auth file.
+
+        Reads the JSON auth file and extracts a Bearer token for the
+        configured provider.  Supports two token formats:
+
+        - OAuth (e.g. GitHub Copilot): ``{"refresh": "gho_..."}``
+        - API key (e.g. Anthropic): ``{"key": "sk-ant-..."}``
+
+        Returns:
+            The raw token string (without ``Bearer `` prefix), or
+            None if no auth file is configured.
+
+        Raises:
+            ValueError: If the file contains invalid JSON or the
+                configured provider key is not present.
+        """
+        if self.config.auth_file is None:
+            return None
+
+        auth_path = Path(self.config.auth_file)
+        raw = auth_path.read_text(encoding="utf-8")
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            msg = f"Invalid JSON in auth file {self.config.auth_file}: {exc}"
+            raise ValueError(msg) from exc
+
+        if not isinstance(data, dict):
+            type_name = type(data).__name__
+            msg = f"Invalid JSON in auth file: expected object, got {type_name}"
+            raise ValueError(msg) from None
+
+        provider_key = self.config.auth_provider
+        if provider_key not in data:
+            msg = (
+                f"Auth provider '{provider_key}' not found in "
+                f"{self.config.auth_file}. "
+                f"Available providers: {', '.join(data.keys())}"
+            )
+            raise ValueError(msg)
+
+        provider_data = data[provider_key]
+        if not isinstance(provider_data, dict):
+            msg = (
+                f"Auth provider '{provider_key}' value must be an object, "
+                f"got {type(provider_data).__name__}"
+            )
+            raise ValueError(msg)
+
+        # Try "refresh" (OAuth token), then "key" (API key)
+        token = provider_data.get("refresh") or provider_data.get("key")
+        if not token:
+            msg = f"Auth provider '{provider_key}' has no 'refresh' or 'key' field"
+            raise ValueError(msg)
+
+        return str(token)
+
+    def _inject_auth_headers(self, headers: dict[str, str]) -> None:
+        """Replace or add the Authorization header with the loaded token.
+
+        Modifies *headers* in place.  Does nothing if no auth token
+        was loaded at init time.
+        """
+        if self._auth_token is not None:
+            headers["authorization"] = f"Bearer {self._auth_token}"
 
     def _build_guard(self) -> Guard:
         """Build a Guard instance from the config."""
@@ -188,6 +260,9 @@ class GuardMiddleware:
         headers = dict(request.headers)
         headers.pop("host", None)
         headers.pop("content-length", None)
+
+        # Inject auth token if configured
+        self._inject_auth_headers(headers)
 
         try:
             is_streaming = self._is_streaming_request(body)

--- a/tests/unit/test_proxy_cli.py
+++ b/tests/unit/test_proxy_cli.py
@@ -150,3 +150,75 @@ class TestProxyCLISubcommand:
                 sys.stderr = old_stderr
         assert exit_code == 1
         assert "pip install agentguard[proxy]" in captured.getvalue()
+
+    def test_proxy_auth_file_option(self, tmp_path: Path) -> None:
+        """--auth-file option should be passed to ProxyConfig."""
+        auth_file = tmp_path / "auth.json"
+        auth_file.write_text('{"github-copilot": {"refresh": "gho_test"}}')
+
+        with (
+            patch("agentguard.cli.create_proxy_app") as mock_create,
+            patch("uvicorn.run"),
+        ):
+            mock_create.return_value = "fake-app"
+            exit_code = main(
+                [
+                    "proxy",
+                    "https://api.githubcopilot.com",
+                    "--auth-file",
+                    str(auth_file),
+                ]
+            )
+
+        assert exit_code == 0
+        config = mock_create.call_args[0][0]
+        assert config.auth_file == str(auth_file)
+
+    def test_proxy_auth_provider_option(self, tmp_path: Path) -> None:
+        """--auth-provider option should be passed to ProxyConfig."""
+        auth_file = tmp_path / "auth.json"
+        auth_file.write_text('{"anthropic": {"key": "sk-ant-test"}}')
+
+        with (
+            patch("agentguard.cli.create_proxy_app") as mock_create,
+            patch("uvicorn.run"),
+        ):
+            mock_create.return_value = "fake-app"
+            exit_code = main(
+                [
+                    "proxy",
+                    "https://api.anthropic.com",
+                    "--auth-file",
+                    str(auth_file),
+                    "--auth-provider",
+                    "anthropic",
+                ]
+            )
+
+        assert exit_code == 0
+        config = mock_create.call_args[0][0]
+        assert config.auth_file == str(auth_file)
+        assert config.auth_provider == "anthropic"
+
+    def test_proxy_auth_provider_default_github_copilot(self, tmp_path: Path) -> None:
+        """--auth-provider should default to github-copilot."""
+        auth_file = tmp_path / "auth.json"
+        auth_file.write_text('{"github-copilot": {"refresh": "gho_test"}}')
+
+        with (
+            patch("agentguard.cli.create_proxy_app") as mock_create,
+            patch("uvicorn.run"),
+        ):
+            mock_create.return_value = "fake-app"
+            exit_code = main(
+                [
+                    "proxy",
+                    "https://api.githubcopilot.com",
+                    "--auth-file",
+                    str(auth_file),
+                ]
+            )
+
+        assert exit_code == 0
+        config = mock_create.call_args[0][0]
+        assert config.auth_provider == "github-copilot"

--- a/tests/unit/test_proxy_config.py
+++ b/tests/unit/test_proxy_config.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from agentguard.proxy.config import ProxyConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestProxyConfigDefaults:
@@ -140,3 +145,62 @@ class TestProxyConfigProvider:
         )
         assert cfg.provider == "openai"
         assert cfg.scan_responses is True
+
+
+# ===========================================================================
+# Test: auth_file field
+# ===========================================================================
+
+
+class TestProxyConfigAuthFile:
+    """Test auth_file and auth_provider fields on ProxyConfig."""
+
+    def test_auth_file_defaults_to_none(self) -> None:
+        """auth_file should default to None."""
+        cfg = ProxyConfig(upstream_base_url="https://api.openai.com")
+        assert cfg.auth_file is None
+
+    def test_auth_provider_defaults_to_github_copilot(self) -> None:
+        """auth_provider should default to 'github-copilot'."""
+        cfg = ProxyConfig(upstream_base_url="https://api.openai.com")
+        assert cfg.auth_provider == "github-copilot"
+
+    def test_auth_file_accepts_path(self, tmp_path: Path) -> None:
+        """auth_file can be set to a file path string."""
+        auth = tmp_path / "auth.json"
+        auth.write_text('{"github-copilot": {"refresh": "gho_test"}}')
+        cfg = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            auth_file=str(auth),
+        )
+        assert cfg.auth_file == str(auth)
+
+    def test_auth_provider_accepts_string(self) -> None:
+        """auth_provider can be set to any provider name."""
+        cfg = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            auth_provider="anthropic",
+        )
+        assert cfg.auth_provider == "anthropic"
+
+    def test_auth_file_nonexistent_raises(self) -> None:
+        """Nonexistent auth_file should raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="auth_file"):
+            ProxyConfig(
+                upstream_base_url="https://api.openai.com",
+                auth_file="/nonexistent/auth.json",
+            )
+
+    def test_auth_file_with_all_fields(self, tmp_path: Path) -> None:
+        """Config with auth_file alongside other fields."""
+        auth = tmp_path / "auth.json"
+        auth.write_text('{"github-copilot": {"refresh": "gho_test"}}')
+        cfg = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            auth_file=str(auth),
+            auth_provider="github-copilot",
+            port=9090,
+        )
+        assert cfg.auth_file == str(auth)
+        assert cfg.auth_provider == "github-copilot"
+        assert cfg.port == 9090

--- a/tests/unit/test_proxy_middleware.py
+++ b/tests/unit/test_proxy_middleware.py
@@ -1174,3 +1174,248 @@ class TestProviderIntegration:
             response = await mw.handle_request(request)
 
         assert response.status_code == 403
+
+
+# ===========================================================================
+# Test: Auth file token injection
+# ===========================================================================
+
+
+class TestAuthFileTokenInjection:
+    """Test that auth_file injects Authorization header into upstream requests."""
+
+    @pytest.fixture
+    def auth_file(self, tmp_path: Path) -> Path:
+        """Create a temporary auth.json file."""
+        auth = tmp_path / "auth.json"
+        auth.write_text(
+            json.dumps(
+                {
+                    "github-copilot": {
+                        "type": "oauth",
+                        "refresh": "gho_testtoken1234567890abcdefghij",
+                        "access": "gho_testtoken1234567890abcdefghij",
+                        "expires": 0,
+                    }
+                }
+            )
+        )
+        return auth
+
+    @pytest.fixture
+    def multi_provider_auth_file(self, tmp_path: Path) -> Path:
+        """Create an auth.json with multiple providers."""
+        auth = tmp_path / "auth.json"
+        auth.write_text(
+            json.dumps(
+                {
+                    "github-copilot": {
+                        "type": "oauth",
+                        "refresh": "gho_copilottoken",
+                        "access": "gho_copilottoken",
+                        "expires": 0,
+                    },
+                    "anthropic": {
+                        "type": "api",
+                        "key": "sk-ant-testkey123",
+                    },
+                }
+            )
+        )
+        return auth
+
+    @pytest.mark.anyio
+    async def test_auth_file_replaces_authorization_header(
+        self, auth_file: Path
+    ) -> None:
+        """When auth_file is set, Authorization header should be replaced."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.githubcopilot.com",
+            auth_file=str(auth_file),
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body())
+        # The client sends a dummy auth header
+        request.headers = {
+            "content-type": "application/json",
+            "host": "localhost:8080",
+            "authorization": "Bearer dummy-token",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps({"choices": []}).encode()
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch.object(
+            mw, "_forward_request", return_value=mock_response
+        ) as mock_fwd:
+            await mw.handle_request(request)
+
+        # Check the headers passed to _forward_request
+        call_args = mock_fwd.call_args
+        forwarded_headers = call_args[0][2]  # 3rd positional arg is headers
+        assert (
+            forwarded_headers["authorization"]
+            == "Bearer gho_testtoken1234567890abcdefghij"
+        )
+
+    @pytest.mark.anyio
+    async def test_auth_file_adds_authorization_when_missing(
+        self, auth_file: Path
+    ) -> None:
+        """When auth_file is set and no auth header exists, it should be added."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.githubcopilot.com",
+            auth_file=str(auth_file),
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body())
+        # No authorization header in request
+        request.headers = {
+            "content-type": "application/json",
+            "host": "localhost:8080",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps({"choices": []}).encode()
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch.object(
+            mw, "_forward_request", return_value=mock_response
+        ) as mock_fwd:
+            await mw.handle_request(request)
+
+        call_args = mock_fwd.call_args
+        forwarded_headers = call_args[0][2]
+        assert (
+            forwarded_headers["authorization"]
+            == "Bearer gho_testtoken1234567890abcdefghij"
+        )
+
+    @pytest.mark.anyio
+    async def test_no_auth_file_preserves_original_header(
+        self,
+    ) -> None:
+        """Without auth_file, original Authorization header is forwarded."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body())
+        request.headers = {
+            "content-type": "application/json",
+            "host": "localhost:8080",
+            "authorization": "Bearer original-token",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps({"choices": []}).encode()
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch.object(
+            mw, "_forward_request", return_value=mock_response
+        ) as mock_fwd:
+            await mw.handle_request(request)
+
+        call_args = mock_fwd.call_args
+        forwarded_headers = call_args[0][2]
+        assert forwarded_headers["authorization"] == "Bearer original-token"
+
+    @pytest.mark.anyio
+    async def test_auth_file_with_custom_provider(
+        self, multi_provider_auth_file: Path
+    ) -> None:
+        """auth_provider selects which provider's token to use."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.anthropic.com",
+            auth_file=str(multi_provider_auth_file),
+            auth_provider="anthropic",
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body())
+        request.headers = {
+            "content-type": "application/json",
+            "host": "localhost:8080",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = json.dumps({"choices": []}).encode()
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch.object(
+            mw, "_forward_request", return_value=mock_response
+        ) as mock_fwd:
+            await mw.handle_request(request)
+
+        call_args = mock_fwd.call_args
+        forwarded_headers = call_args[0][2]
+        # Anthropic uses "key" not "refresh"
+        assert forwarded_headers["authorization"] == "Bearer sk-ant-testkey123"
+
+    @pytest.mark.anyio
+    async def test_auth_file_streaming_replaces_header(self, auth_file: Path) -> None:
+        """Auth file should also work for streaming requests."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.githubcopilot.com",
+            auth_file=str(auth_file),
+        )
+        mw = GuardMiddleware(config)
+        request = _make_request(body=_openai_request_body(stream=True))
+        request.headers = {
+            "content-type": "application/json",
+            "host": "localhost:8080",
+            "authorization": "Bearer dummy",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/event-stream"}
+
+        async def fake_aiter_bytes():
+            yield b"data: {}\n\n"
+
+        mock_response.aiter_bytes = fake_aiter_bytes
+
+        mock_client = MagicMock()
+        stream_ctx = _StreamContext(client=mock_client, response=mock_response)
+
+        with patch.object(
+            mw, "_forward_streaming", return_value=stream_ctx
+        ) as mock_fwd:
+            await mw.handle_request(request)
+
+        call_args = mock_fwd.call_args
+        forwarded_headers = call_args[0][2]  # 3rd positional arg
+        assert (
+            forwarded_headers["authorization"]
+            == "Bearer gho_testtoken1234567890abcdefghij"
+        )
+
+    @pytest.mark.anyio
+    async def test_auth_file_missing_provider_raises(self, tmp_path: Path) -> None:
+        """If auth_provider key is missing from auth file, construction raises."""
+        auth = tmp_path / "auth.json"
+        auth.write_text(json.dumps({"other-provider": {"key": "abc"}}))
+        with pytest.raises(ValueError, match=r"provider.*not found"):
+            config = ProxyConfig(
+                upstream_base_url="https://api.openai.com",
+                auth_file=str(auth),
+                auth_provider="github-copilot",
+            )
+            GuardMiddleware(config)
+
+    @pytest.mark.anyio
+    async def test_auth_file_invalid_json_raises(self, tmp_path: Path) -> None:
+        """Invalid JSON in auth file should raise ValueError."""
+        auth = tmp_path / "auth.json"
+        auth.write_text("not valid json {{{")
+        with pytest.raises(ValueError, match=r"[Ii]nvalid.*JSON|parse"):
+            config = ProxyConfig(
+                upstream_base_url="https://api.openai.com",
+                auth_file=str(auth),
+            )
+            GuardMiddleware(config)


### PR DESCRIPTION
## Summary

- Add `--auth-file` and `--auth-provider` CLI flags to the LLM proxy, enabling OAuth token injection from OpenCode's `auth.json` into upstream requests
- `ProxyConfig` gains `auth_file` (path, optional) and `auth_provider` (default: `github-copilot`) fields with `__post_init__` validation
- `GuardMiddleware` reads the auth file, extracts the token (from `refresh` or `key` field), and replaces/adds the `Authorization` header before forwarding to upstream
- 17 new tests: 6 config, 8 middleware (async), 3 CLI argument tests
- 1211 tests passing, ruff clean

## Why

When routing OpenCode through the AgentGuard proxy using a custom provider (e.g. `@ai-sdk/openai-compatible`), the client sends a dummy API key since the real Copilot OAuth token lives in OpenCode's auth storage, not in the provider config. The proxy needs to replace this dummy token with the real `gho_*` OAuth token before forwarding to `api.githubcopilot.com`.

## Files Changed

- `src/agentguard/proxy/config.py` — `auth_file` and `auth_provider` fields
- `src/agentguard/proxy/middleware.py` — `_load_auth_token()` and `_inject_auth_headers()` methods
- `src/agentguard/cli.py` — `--auth-file` and `--auth-provider` args for proxy subcommand
- `src/agentguard/proxy/__main__.py` — same args for `python -m agentguard.proxy`
- `tests/unit/test_proxy_config.py` — 6 auth config tests
- `tests/unit/test_proxy_middleware.py` — 8 auth token injection tests
- `tests/unit/test_proxy_cli.py` — 3 CLI argument tests