### PR TITLE
fix: address systemd service review suggestions (#80-#83)

### DIFF
--- a/docs/guides/proxy-integration.md
+++ b/docs/guides/proxy-integration.md
@@ -323,9 +323,22 @@ AGENTGUARD_BIN=/path/to/agentguard
 # Actor name in audit entries
 #AGENTGUARD_ACTOR=opencode-proxy
 
-# Audit log directory
-#AGENTGUARD_AUDIT_DIR=$HOME/.local/share/agentguard/audit
+# Audit log directory (use absolute path; systemd does not expand $HOME)
+#AGENTGUARD_AUDIT_DIR=/home/youruser/.local/share/agentguard/audit
 ```
+
+> **Note:** The systemd service and daemon script (`proxy.sh`) use
+> different defaults from the bare `agentguard proxy` CLI. The service
+> defaults are tuned for long-running, always-on operation:
+>
+> | Setting | CLI default | Service/daemon default |
+> |---------|-------------|----------------------|
+> | `--timeout` | `120` | `300` |
+> | `--actor` | `llm-proxy` | `opencode-proxy` |
+> | `--scan-responses` | off | on |
+>
+> These differences are intentional. The service/daemon defaults
+> prioritize security and are consistent with each other.
 
 After editing, restart the service:
 

--- a/scripts/proxy-install.sh
+++ b/scripts/proxy-install.sh
@@ -70,8 +70,9 @@ AGENTGUARD_BIN=${agentguard_bin}
 # Actor name in audit entries
 #AGENTGUARD_ACTOR=opencode-proxy
 
-# Audit log directory
-#AGENTGUARD_AUDIT_DIR=\$HOME/.local/share/agentguard/audit
+# Audit log directory (systemd does not expand shell variables;
+# use an absolute path if you uncomment this line)
+#AGENTGUARD_AUDIT_DIR=${AUDIT_DIR}
 ENV
         echo "   ✓ Created default config at ${ENV_DIR}/proxy.env"
     else
@@ -102,7 +103,7 @@ ENV
     # 7. Wait for health and show status
     sleep 2
     local port
-    port=$(grep -oP 'AGENTGUARD_PORT=\K\d+' "${ENV_DIR}/proxy.env" 2>/dev/null || echo "8080")
+    port=$(grep -v '^\s*#' "${ENV_DIR}/proxy.env" 2>/dev/null | grep -oP 'AGENTGUARD_PORT=\K\d+' || echo "8080")
     if curl -sf "http://127.0.0.1:${port}/_health" >/dev/null 2>&1; then
         local health
         health=$(curl -s "http://127.0.0.1:${port}/_health")
@@ -169,7 +170,7 @@ do_status() {
 
             # Health check
             local port
-            port=$(grep -oP 'AGENTGUARD_PORT=\K\d+' "${ENV_DIR}/proxy.env" 2>/dev/null || echo "8080")
+            port=$(grep -v '^\s*#' "${ENV_DIR}/proxy.env" 2>/dev/null | grep -oP 'AGENTGUARD_PORT=\K\d+' || echo "8080")
             if curl -sf "http://127.0.0.1:${port}/_status" >/dev/null 2>&1; then
                 curl -s "http://127.0.0.1:${port}/_status" | python3 -c "
 import json, sys

--- a/systemd/agentguard-proxy@.service
+++ b/systemd/agentguard-proxy@.service
@@ -21,6 +21,10 @@ Documentation=https://github.com/Roboter-Schlafen-Nicht/agentguard
 After=network-online.target
 Wants=network-online.target
 
+# Rate-limit restarts: max 5 in 60s (canonical location per systemd.unit(5))
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
 [Service]
 Type=simple
 
@@ -52,10 +56,6 @@ ExecStart=/bin/bash -c '\
 # Restart on crash (not on manual stop)
 Restart=on-failure
 RestartSec=3
-
-# Rate-limit restarts: max 5 in 60s
-StartLimitIntervalSec=60
-StartLimitBurst=5
 
 # Security hardening (user service — limited options)
 NoNewPrivileges=yes


### PR DESCRIPTION
## Summary

Review sweep for systemd service issues from PR #79 bot review (roadmap task P91).

### Changes

**systemd/agentguard-proxy@.service:**
- Move `StartLimitIntervalSec`/`StartLimitBurst` from `[Service]` to `[Unit]` section per `systemd.unit(5)` canonical location (fixes #82)

**scripts/proxy-install.sh:**
- Replace `\$HOME` with `${AUDIT_DIR}` (shell-expanded at install time) in the commented env file template — systemd `EnvironmentFile` does not expand shell variables (fixes #81)
- Filter commented lines with `grep -v '^\s*#'` before extracting `AGENTGUARD_PORT` to avoid matching `#AGENTGUARD_PORT=8080` (fixes #83)

**docs/guides/proxy-integration.md:**
- Fix the `$HOME` reference in the docs env file example to use an absolute path placeholder
- Add a note documenting intentional default mismatches between CLI and service/daemon (fixes #80)

### Issue triage
- **#80** Fixed: documented default mismatches
- **#81** Fixed: \$HOME replaced with expanded path
- **#82** Fixed: StartLimit moved to [Unit]
- **#83** Fixed: port regex skips commented lines
- **#84** Closed as by-design: multi-instance port collision is inherent to shared env file

### Testing
- All 1211 tests pass
- ruff lint clean
- mypy strict clean
- Local CI via act passes (format + test jobs)