### PR TITLE
fix: use 'refresh' key in auth_json_file E2E fixture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -263,14 +263,14 @@ def auth_json_file(tmp_path: Path) -> Path:
 
     The file follows the OpenCode auth format::
 
-        {"github-copilot": {"token": "test-token-12345"}}
+        {"github-copilot": {"refresh": "test-token-12345"}}
 
     Returns:
         Path to the auth.json file.
     """
     auth_path = tmp_path / "auth.json"
     auth_data = {
-        "github-copilot": {"token": "test-token-12345"},
+        "github-copilot": {"refresh": "test-token-12345"},
     }
     auth_path.write_text(json.dumps(auth_data))
     return auth_path

--- a/tests/e2e/test_infrastructure.py
+++ b/tests/e2e/test_infrastructure.py
@@ -128,7 +128,7 @@ class TestAuthJsonFile:
         """Auth file contains expected token structure."""
         data = json.loads(auth_json_file.read_text())
         assert "github-copilot" in data
-        assert data["github-copilot"]["token"] == "test-token-12345"
+        assert data["github-copilot"]["refresh"] == "test-token-12345"
 
 
 class TestRsnPolicies:


### PR DESCRIPTION
## Summary

The `auth_json_file` fixture used a `"token"` key but production `_load_auth_token()` in `middleware.py` extracts via `provider_data.get("refresh") or provider_data.get("key")`. The `"token"` key is not recognized.

Any future E2E test that passes this fixture to `ProxyConfig(auth_file=...)` would fail with `ValueError("has no 'refresh' or 'key' field")`.

## Changes

- `tests/e2e/conftest.py`: Changed `{"token": ...}` to `{"refresh": ...}` in `auth_json_file` fixture and docstring
- `tests/e2e/test_infrastructure.py`: Updated assertion to check `"refresh"` key

All tests pass (1267 total).

Closes #110