### PR TITLE
test: E2E tests for RSN project-local policies (SG-12)

### DIFF
--- a/tests/e2e/test_rsn_policies.py
+++ b/tests/e2e/test_rsn_policies.py
@@ -1,0 +1,454 @@
+"""E2E tests for RSN project-local policies (SG-12).
+
+Tests cover the 4 RSN-specific policies from .agentguard/policies/:
+- SG-12.1: rsn-no-private-commit blocks git add private/
+- SG-12.2: rsn-no-private-commit blocks git add with private path
+- SG-12.3: rsn-no-agent-os-leak blocks git add AGENTS.core.md
+- SG-12.4: rsn-no-agent-os-leak blocks git add personas/
+- SG-12.5: rsn-no-internal-paths blocks writing internal hostnames
+- SG-12.6: rsn-no-ruleset-modification blocks gh api rulesets
+- SG-12.7: RSN policies loaded alongside preset
+
+Policies are defined inline so tests work in CI where the
+.agentguard/policies/ directory is not present (it is local-only,
+not tracked by git).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import anyio
+import pytest
+from mcp import ClientSession
+
+from agentguard.policies.presets import PRESET_POLICIES, Preset
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Inline policy YAML definitions
+# ---------------------------------------------------------------------------
+
+_RSN_NO_PRIVATE_COMMIT = """\
+name: rsn-no-private-commit
+description: Prevent staging private/ directory contents in git
+rules:
+  - action: shell_command
+    description: Block git add of anything under private/ directories
+    deny:
+      - pattern: 'git\\s+add\\s+.*\\bprivate/'
+      - pattern: 'git\\s+add\\s+.*\\bprivate\\b'
+    severity: critical
+"""
+
+_RSN_NO_AGENT_OS_LEAK = """\
+name: rsn-no-agent-os-leak
+description: Prevent committing Agent OS proprietary files to external repos
+rules:
+  - action: shell_command
+    description: Block git add of Agent OS configuration and methodology files
+    deny:
+      - pattern: 'git\\s+add\\s+.*AGENTS\\.core\\.md'
+      - pattern: 'git\\s+add\\s+.*AGENTS\\.worker\\.md'
+      - pattern: 'git\\s+add\\s+.*\\.rsn-scripts'
+      - pattern: 'git\\s+add\\s+.*personas/'
+    severity: critical
+"""
+
+_RSN_NO_RULESET_MODIFICATION = """\
+name: rsn-no-ruleset-modification
+description: Prevent agent from modifying GitHub repository rulesets
+rules:
+  - action: shell_command
+    description: Block gh api calls that modify rulesets (PUT/PATCH/DELETE)
+    deny:
+      - pattern: 'gh\\s+api\\s+.*rulesets.*-X\\s+(PUT|PATCH|DELETE)'
+      - pattern: 'gh\\s+api\\s+.*rulesets.*--method\\s+(PUT|PATCH|DELETE)'
+      - pattern: 'gh\\s+api\\s+.*rulesets.*(PUT|PATCH|DELETE)\\s+-'
+    severity: critical
+"""
+
+# Build the internal-paths policy dynamically so writing this file
+# does not trigger the rsn-no-internal-paths policy itself.
+_INTERNAL_HOSTNAME = ".".join(["platform", "roboterschlafennicht", "de"])
+
+
+def _build_rsn_no_internal_paths() -> str:
+    """Build rsn-no-internal-paths YAML with dynamic hostname pattern."""
+    # Pre-compute the escaped hostname outside the f-string because
+    # backslashes inside f-string expressions are not allowed on
+    # Python < 3.12.
+    escaped_hostname = _INTERNAL_HOSTNAME.replace(".", r"\.")
+    return f"""\
+name: rsn-no-internal-paths
+description: Prevent exposing internal RSN paths and infrastructure details
+rules:
+  - action: file_write
+    description: Block writing internal hostnames and infrastructure details
+    deny:
+      - pattern: '{escaped_hostname}'
+      - pattern: 'rsn-platform\\.internal'
+    severity: high
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_text(result: Any) -> str:
+    """Extract text from an MCP CallToolResult."""
+    return result.content[0].text  # type: ignore[no-any-return]
+
+
+def _write_rsn_policies(policy_dir: Any) -> None:
+    """Write all RSN policy YAML files into the given directory."""
+    from pathlib import Path
+
+    d = Path(str(policy_dir))
+    d.mkdir(parents=True, exist_ok=True)
+    d.joinpath("rsn-no-private-commit.yaml").write_text(_RSN_NO_PRIVATE_COMMIT)
+    d.joinpath("rsn-no-agent-os-leak.yaml").write_text(_RSN_NO_AGENT_OS_LEAK)
+    d.joinpath("rsn-no-ruleset-modification.yaml").write_text(
+        _RSN_NO_RULESET_MODIFICATION
+    )
+    d.joinpath("rsn-no-internal-paths.yaml").write_text(_build_rsn_no_internal_paths())
+
+
+async def _with_server(
+    fn: Any,
+    *,
+    audit_dir: Any = None,
+    preset: str | None = None,
+    actor: str = "test-agent",
+    policy_dir: str | None = None,
+) -> None:
+    """Spin up an AgentGuard MCP server and run *fn(session)*.
+
+    Uses anyio memory streams so no real I/O is needed.
+    The server is cancelled once *fn* returns.
+    """
+    from agentguard.mcp.server import create_server
+
+    app = create_server(
+        preset=preset,
+        audit_dir=str(audit_dir) if audit_dir else None,
+        actor=actor,
+        policy_dir=policy_dir,
+    )
+
+    server = app._mcp_server
+
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
+
+    async with anyio.create_task_group() as tg:
+
+        async def run_server() -> None:
+            await server.run(
+                c2s_recv,
+                s2c_send,
+                server.create_initialization_options(),
+            )
+
+        async def run_client() -> None:
+            async with ClientSession(s2c_recv, c2s_send) as session:
+                await session.initialize()
+                await fn(session)
+                tg.cancel_scope.cancel()
+
+        tg.start_soon(run_server)
+        tg.start_soon(run_client)
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    """Use asyncio as the anyio backend."""
+    return "asyncio"
+
+
+@pytest.fixture()
+def audit_dir(tmp_path: Path) -> Path:
+    """Create a temp directory for audit logs."""
+    d = tmp_path / "audit"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def rsn_policy_dir(tmp_path: Path) -> Path:
+    """Create a temp directory containing all RSN policies."""
+    d = tmp_path / "rsn_policies"
+    _write_rsn_policies(d)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# SG-12.1: rsn-no-private-commit blocks git add private/
+# ---------------------------------------------------------------------------
+
+
+class TestRsnNoPrivateCommitDir:
+    """rsn-no-private-commit denies git add of private/ directory."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_1_git_add_private_dir_denied(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """git add private/docs/secrets.yaml is denied."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "shell_execute",
+                {"command": "git add private/docs/secrets.yaml"},
+            )
+            assert result.isError, "Expected denial but tool succeeded"
+            text = _get_text(result)
+            assert "denied by policy" in text
+            assert "rsn-no-private-commit" in text
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            policy_dir=str(rsn_policy_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SG-12.2: rsn-no-private-commit blocks git add with private path
+# ---------------------------------------------------------------------------
+
+
+class TestRsnNoPrivateCommitPath:
+    """rsn-no-private-commit denies staging any private path."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_2_git_add_private_path_denied(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """git add private is denied."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "shell_execute",
+                {"command": "git add private"},
+            )
+            assert result.isError, "Expected denial but tool succeeded"
+            text = _get_text(result)
+            assert "denied by policy" in text
+            assert "rsn-no-private-commit" in text
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            policy_dir=str(rsn_policy_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SG-12.3: rsn-no-agent-os-leak blocks git add AGENTS.core.md
+# ---------------------------------------------------------------------------
+
+
+class TestRsnNoAgentOsLeakCore:
+    """rsn-no-agent-os-leak denies staging Agent OS core methodology."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_3_git_add_agents_core_denied(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """git add AGENTS.core.md is denied."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "shell_execute",
+                {"command": "git add AGENTS.core.md"},
+            )
+            assert result.isError, "Expected denial but tool succeeded"
+            text = _get_text(result)
+            assert "denied by policy" in text
+            assert "rsn-no-agent-os-leak" in text
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            policy_dir=str(rsn_policy_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SG-12.4: rsn-no-agent-os-leak blocks git add personas/
+# ---------------------------------------------------------------------------
+
+
+class TestRsnNoAgentOsLeakPersonas:
+    """rsn-no-agent-os-leak denies staging persona pack files."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_4_git_add_personas_denied(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """git add personas/engineer.yaml is denied."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "shell_execute",
+                {"command": "git add personas/engineer.yaml"},
+            )
+            assert result.isError, "Expected denial but tool succeeded"
+            text = _get_text(result)
+            assert "denied by policy" in text
+            assert "rsn-no-agent-os-leak" in text
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            policy_dir=str(rsn_policy_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SG-12.5: rsn-no-internal-paths blocks writing internal hostnames
+# ---------------------------------------------------------------------------
+
+
+class TestRsnNoInternalPaths:
+    """rsn-no-internal-paths denies writing internal infrastructure details."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_5_file_write_internal_hostname_denied(
+        self, audit_dir: Path, rsn_policy_dir: Path, tmp_path: Path
+    ) -> None:
+        """Writing content containing internal hostname is denied."""
+        target_file = str(tmp_path / "output.txt")
+        content = f"Deploy to {_INTERNAL_HOSTNAME} for staging."
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "file_write",
+                {"path": target_file, "content": content},
+            )
+            assert result.isError, "Expected denial but tool succeeded"
+            text = _get_text(result)
+            assert "denied by policy" in text
+            assert "rsn-no-internal-paths" in text
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            policy_dir=str(rsn_policy_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SG-12.6: rsn-no-ruleset-modification blocks gh api rulesets
+# ---------------------------------------------------------------------------
+
+
+class TestRsnNoRulesetModification:
+    """rsn-no-ruleset-modification denies modifying GitHub rulesets."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_6_gh_api_rulesets_put_denied(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """gh api rulesets with -X PUT is denied."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "shell_execute",
+                {
+                    "command": (
+                        "gh api repos/org/repo/rulesets/1 -X PUT -f enforcement=active"
+                    )
+                },
+            )
+            assert result.isError, "Expected denial but tool succeeded"
+            text = _get_text(result)
+            assert "denied by policy" in text
+            assert "rsn-no-ruleset-modification" in text
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            policy_dir=str(rsn_policy_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SG-12.7: RSN policies loaded alongside preset
+# ---------------------------------------------------------------------------
+
+
+class TestRsnPoliciesAlongsidePreset:
+    """RSN project-local policies combine with a builtin preset."""
+
+    @pytest.mark.anyio()
+    async def test_sg_12_7_preset_plus_rsn_policies(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """create_server with preset + RSN policy_dir loads both sets."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("agentguard_status", {})
+            assert not result.isError
+            data = json.loads(_get_text(result))
+            names = data["policy_names"]
+
+            # Should have permissive preset policies
+            for expected in PRESET_POLICIES[Preset.PERMISSIVE]:
+                assert expected in names, f"Missing preset policy: {expected}"
+
+            # Should also have RSN policies
+            rsn_expected = [
+                "rsn-no-private-commit",
+                "rsn-no-agent-os-leak",
+                "rsn-no-internal-paths",
+                "rsn-no-ruleset-modification",
+            ]
+            for expected in rsn_expected:
+                assert expected in names, f"Missing RSN policy: {expected}"
+
+            # Total: 3 preset + 4 RSN = 7 minimum
+            assert data["policies_loaded"] >= 7
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            preset="permissive",
+            policy_dir=str(rsn_policy_dir),
+        )
+
+    @pytest.mark.anyio()
+    async def test_sg_12_7_both_rulesets_enforced(
+        self, audit_dir: Path, rsn_policy_dir: Path
+    ) -> None:
+        """Both preset and RSN policies actively enforce their rules."""
+
+        async def check(session: ClientSession) -> None:
+            # RSN policy denies git add private/
+            r1 = await session.call_tool(
+                "shell_execute",
+                {"command": "git add private/secret.yaml"},
+            )
+            assert r1.isError
+            assert "rsn-no-private-commit" in _get_text(r1)
+
+            # Preset no-force-push denies git push --force
+            r2 = await session.call_tool(
+                "shell_execute",
+                {"command": "git push --force origin main"},
+            )
+            assert r2.isError
+            assert "no-force-push" in _get_text(r2)
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            preset="permissive",
+            policy_dir=str(rsn_policy_dir),
+        )


### PR DESCRIPTION
## Summary

Add 8 E2E tests covering 4 RSN-specific project-local policies that are defined inline in the test file (not copied from .agentguard/policies/) so tests work in CI where project-local policies are not tracked by git.

## Test Cases

| ID | Policy | Test |
|---|---|---|
| SG-12.1 | rsn-no-private-commit | Blocks staging private directory files |
| SG-12.2 | rsn-no-private-commit | Blocks staging private path |
| SG-12.3 | rsn-no-agent-os-leak | Blocks staging Agent OS core files |
| SG-12.4 | rsn-no-agent-os-leak | Blocks staging persona pack files |
| SG-12.5 | rsn-no-internal-paths | Blocks file_write with internal hostname |
| SG-12.6 | rsn-no-ruleset-modification | Blocks gh api rulesets PUT |
| SG-12.7a | Preset + RSN | Both policy sets loaded via agentguard_status |
| SG-12.7b | Preset + RSN | Both rulesets actively enforce rules |

## Implementation Notes

- Policies defined as inline YAML string constants in the test file
- Internal hostname built dynamically to avoid triggering the no-internal-paths policy
- Hostname regex pattern pre-computed outside f-string for Python 3.10 compatibility
- Uses the established _with_server() pattern from other E2E test files