### PR TITLE
refactor: extract duplicated E2E test helpers to conftest.py

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,6 +1,6 @@
 """E2E test fixtures for AgentGuard.
 
-Shared fixtures for end-to-end tests exercising full system
+Shared fixtures and helpers for end-to-end tests exercising full system
 workflows including MCP server, proxy, mock upstream, policies,
 and audit.
 """
@@ -12,13 +12,17 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import anyio
+import httpx
 import pytest
+from mcp import ClientSession
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse, StreamingResponse
 from starlette.routing import Route
 
 from agentguard.proxy.app import create_app
 from agentguard.proxy.config import ProxyConfig
+from agentguard.proxy.middleware import _StreamContext
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -44,6 +48,17 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         if Path(item.fspath).is_relative_to(e2e_dir):
             item.add_marker(pytest.mark.e2e)
+
+
+# ---------------------------------------------------------------------------
+# Common anyio backend fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    """Use asyncio as the anyio backend."""
+    return "asyncio"
 
 
 # ---------------------------------------------------------------------------
@@ -170,10 +185,6 @@ def proxy_app_with_mock(
     Returns:
         A Starlette ASGI app ready for ``httpx.AsyncClient`` testing.
     """
-    import httpx
-
-    from agentguard.proxy.middleware import _StreamContext
-
     audit_dir = tmp_path / "audit"
     audit_dir.mkdir()
 
@@ -184,43 +195,7 @@ def proxy_app_with_mock(
         scan_responses=True,
     )
     app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
+    _patch_proxy_forwarding(app, mock_upstream)
 
     return app
 
@@ -231,7 +206,7 @@ def proxy_app_with_mock(
 
 
 @pytest.fixture()
-def tmp_audit_dir(tmp_path: Path) -> Path:
+def audit_dir(tmp_path: Path) -> Path:
     """Create and return a temporary audit directory.
 
     The directory is automatically cleaned up by pytest's ``tmp_path``.
@@ -239,6 +214,10 @@ def tmp_audit_dir(tmp_path: Path) -> Path:
     d = tmp_path / "audit"
     d.mkdir()
     return d
+
+
+# Keep the old name as an alias for backward compatibility.
+tmp_audit_dir = audit_dir
 
 
 @pytest.fixture()
@@ -337,3 +316,322 @@ def mcp_server_with_preset(tmp_path: Path) -> Any:
         )
 
     return _factory
+
+
+# ---------------------------------------------------------------------------
+# Shared MCP helpers
+# ---------------------------------------------------------------------------
+
+
+def get_text(result: Any) -> str:
+    """Extract text from an MCP ``CallToolResult``."""
+    return result.content[0].text  # type: ignore[no-any-return]
+
+
+# Underscore aliases used by test modules via ``from tests.e2e.conftest import …``.
+_get_text = get_text
+
+
+async def with_server(
+    fn: Any,
+    *,
+    audit_dir: Path | None = None,
+    preset: str | None = None,
+    actor: str = "test-agent",
+    policy_dir: str | Path | None = None,
+    load_builtins: bool = False,
+    auto_discover: bool = False,
+    trust_registry: str | None = None,
+) -> None:
+    """Spin up an AgentGuard MCP server in-process and run *fn(session)*.
+
+    Uses anyio memory streams so no real I/O is needed.
+    The server is cancelled once *fn* returns.
+
+    This is the unified helper — accepts the union of parameters
+    used across all E2E test modules.
+    """
+    from agentguard.mcp.server import create_server
+
+    kwargs: dict[str, Any] = {
+        "audit_dir": str(audit_dir) if audit_dir else None,
+        "actor": actor,
+        "load_builtins": load_builtins,
+        "auto_discover": auto_discover,
+    }
+    if preset is not None:
+        kwargs["preset"] = preset
+    if policy_dir is not None:
+        kwargs["policy_dir"] = str(policy_dir)
+    if trust_registry is not None:
+        kwargs["trust_registry"] = trust_registry
+
+    app = create_server(**kwargs)
+    server = app._mcp_server
+
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
+
+    async with anyio.create_task_group() as tg:
+
+        async def run_server() -> None:
+            await server.run(
+                c2s_recv,
+                s2c_send,
+                server.create_initialization_options(),
+            )
+
+        async def run_client() -> None:
+            async with ClientSession(s2c_recv, c2s_send) as session:
+                await session.initialize()
+                await fn(session)
+                tg.cancel_scope.cancel()
+
+        tg.start_soon(run_server)
+        tg.start_soon(run_client)
+
+
+# Underscore alias for backward compatibility.
+_with_server = with_server
+
+
+# ---------------------------------------------------------------------------
+# Shared proxy helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_proxy_forwarding(app: Starlette, mock_upstream: MockUpstream) -> None:
+    """Monkey-patch proxy middleware to route through mock upstream.
+
+    This is the single implementation of the forwarding monkey-patch
+    used by ``proxy_app_with_mock``, ``create_proxy``, and
+    ``create_proxy_with_auth``.
+    """
+    middleware = app.state.middleware
+    transport = httpx.ASGITransport(app=mock_upstream.app)
+
+    async def _patched_forward_request(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> Any:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://mock-upstream"
+        ) as client:
+            return await client.request(
+                method=method, url=url, headers=headers, content=body
+            )
+
+    async def _patched_forward_streaming(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> _StreamContext:
+        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
+        try:
+            response = await client.send(
+                client.build_request(
+                    method=method, url=url, headers=headers, content=body
+                ),
+                stream=True,
+            )
+        except Exception:
+            await client.aclose()
+            raise
+        return _StreamContext(client=client, response=response)
+
+    middleware._forward_request = _patched_forward_request
+    middleware._forward_streaming = _patched_forward_streaming
+
+
+def create_proxy(
+    mock_upstream: MockUpstream,
+    audit_dir: Path,
+    *,
+    preset: str | None = None,
+    load_builtins: bool = False,
+    scan_responses: bool = False,
+    auth_file: str | None = None,
+    auth_provider: str = "github-copilot",
+) -> Starlette:
+    """Build a proxy app wired to the mock upstream.
+
+    Unified helper accepting the union of parameters used across
+    all E2E test modules for proxy construction.
+
+    Returns the Starlette app with monkey-patched forwarding.
+    """
+    config = ProxyConfig(
+        upstream_base_url="http://mock-upstream",
+        audit_dir=str(audit_dir),
+        preset=preset,
+        load_builtins=load_builtins,
+        scan_responses=scan_responses,
+        auth_file=auth_file if auth_file else None,
+        auth_provider=auth_provider,
+    )
+    app = create_app(config)
+    _patch_proxy_forwarding(app, mock_upstream)
+
+    return app
+
+
+# Underscore alias for backward compatibility.
+_create_proxy = create_proxy
+
+
+# ---------------------------------------------------------------------------
+# Shared request/response body builders
+# ---------------------------------------------------------------------------
+
+
+def chat_body(content: str = "Hello", *, stream: bool = False) -> dict[str, Any]:
+    """Build a minimal OpenAI chat completion request body."""
+    body: dict[str, Any] = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": content}],
+    }
+    if stream:
+        body["stream"] = True
+    return body
+
+
+# Underscore alias for backward compatibility.
+_chat_body = chat_body
+
+
+def streaming_body(content: str = "Hello") -> dict[str, Any]:
+    """Build a minimal OpenAI streaming chat request body."""
+    return {
+        "model": "gpt-4",
+        "stream": True,
+        "messages": [{"role": "user", "content": content}],
+    }
+
+
+def sse_chunk(content: str, index: int = 0) -> str:
+    """Build an OpenAI-format SSE chunk payload (raw JSON string)."""
+    return json.dumps(
+        {
+            "id": f"chatcmpl-{index}",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": content},
+                    "finish_reason": None,
+                }
+            ],
+        }
+    )
+
+
+def sse_done_chunk() -> str:
+    """Build an OpenAI-format SSE final chunk (finish_reason=stop)."""
+    return json.dumps(
+        {
+            "id": "chatcmpl-final",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
+
+
+def parse_sse_events(raw: str) -> list[str]:
+    """Extract ``data:`` payloads from raw SSE text."""
+    events: list[str] = []
+    for line in raw.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("data: "):
+            events.append(stripped[6:])
+    return events
+
+
+# Underscore aliases for backward compatibility.
+_streaming_body = streaming_body
+_sse_chunk = sse_chunk
+_sse_done_chunk = sse_done_chunk
+_parse_sse_events = parse_sse_events
+
+
+# ---------------------------------------------------------------------------
+# Shared audit helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_audit_entries(audit_dir: Path) -> list[dict[str, Any]]:
+    """Collect all audit log entries from the audit directory."""
+    entries: list[dict[str, Any]] = []
+    for path in audit_dir.glob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            if line.strip():
+                entries.append(json.loads(line))
+    return entries
+
+
+# Underscore alias used as ``_audit_entries`` in some test modules.
+_audit_entries = collect_audit_entries
+
+
+def collect_mcp_audit_entries(audit_dir: Path) -> list[dict[str, Any]]:
+    """Collect only MCP audit entries (ag-*.jsonl files)."""
+    entries: list[dict[str, Any]] = []
+    for path in audit_dir.glob("ag-*.jsonl"):
+        for line in path.read_text().splitlines():
+            if line.strip():
+                entries.append(json.loads(line))
+    return entries
+
+
+# Underscore alias for backward compatibility.
+_mcp_audit_entries = collect_mcp_audit_entries
+
+
+def collect_proxy_audit_entries(audit_dir: Path) -> list[dict[str, Any]]:
+    """Collect only proxy audit entries (proxy-*.jsonl files)."""
+    entries: list[dict[str, Any]] = []
+    for path in audit_dir.glob("proxy-*.jsonl"):
+        for line in path.read_text().splitlines():
+            if line.strip():
+                entries.append(json.loads(line))
+    return entries
+
+
+# Underscore alias for backward compatibility.
+_proxy_audit_entries = collect_proxy_audit_entries
+
+
+# ---------------------------------------------------------------------------
+# Shared fake key builders (avoid safety scanner detection)
+# ---------------------------------------------------------------------------
+
+
+def fake_sk_key(body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345678901234") -> str:
+    """Build a fake ``sk-`` key at runtime to avoid safety scanner."""
+    return "sk" + "-" + body
+
+
+def fake_sk_proj_key(
+    body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+) -> str:
+    """Build a fake ``sk-proj-`` key at runtime to avoid safety scanner."""
+    return "sk" + "-" + "proj" + "-" + body
+
+
+def fake_ghp_token(body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ab") -> str:
+    """Build a fake ``ghp_`` token at runtime to avoid safety scanner."""
+    return "ghp" + "_" + body
+
+
+# Underscore aliases for backward compatibility.
+_fake_sk_key = fake_sk_key
+_fake_sk_proj_key = fake_sk_proj_key
+_fake_ghp_token = fake_ghp_token

--- a/tests/e2e/test_audit_e2e.py
+++ b/tests/e2e/test_audit_e2e.py
@@ -16,89 +16,17 @@ Test matrix:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import pytest
-from mcp import ClientSession
 
 from agentguard.audit.log import AuditLog
+from tests.e2e.conftest import _get_text, _with_server
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    preset: str = "balanced",
-    actor: str = "test-agent",
-) -> None:
-    """Spin up an AgentGuard MCP server with a preset and run *fn(session)*.
-
-    Uses anyio memory streams so no real I/O is needed.
-    The server is cancelled once *fn* returns.
-    """
-    from agentguard.mcp.server import create_server
-
-    app = create_server(
-        preset=preset,
-        audit_dir=str(audit_dir) if audit_dir else None,
-        actor=actor,
-    )
-
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
+    from mcp import ClientSession
 
 
 def _load_audit_log(audit_dir: Path) -> AuditLog:

--- a/tests/e2e/test_dual_layer.py
+++ b/tests/e2e/test_dual_layer.py
@@ -17,229 +17,31 @@ Test matrix:
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
-import anyio
 import httpx
 import pytest
-from mcp import ClientSession
 
 from agentguard.audit.log import AuditLog
-from agentguard.proxy.app import create_app
-from agentguard.proxy.config import ProxyConfig
-from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _audit_entries,
+    _chat_body,
+    _create_proxy,
+    _fake_ghp_token,
+    _fake_sk_key,
+    _fake_sk_proj_key,
+    _get_text,
+    _mcp_audit_entries,
+    _proxy_audit_entries,
+    _with_server,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mcp import ClientSession
+
     from tests.e2e.conftest import MockUpstream
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a shared audit directory for both layers."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-def _fake_sk_key(body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345678901234") -> str:
-    """Build a fake ``sk-`` API key at runtime.
-
-    Constructing the key dynamically avoids triggering the pre-commit
-    safety scanner which matches literal ``sk-*`` patterns in diffs.
-    """
-    return "sk" + "-" + body
-
-
-def _fake_sk_proj_key(
-    body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
-) -> str:
-    """Build a fake ``sk-proj-`` API key at runtime."""
-    return "sk" + "-" + "proj" + "-" + body
-
-
-def _fake_ghp_token(
-    body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-) -> str:
-    """Build a fake ``ghp_`` GitHub PAT at runtime."""
-    return "ghp" + "_" + body
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    actor: str = "test-agent",
-    builtins: bool = False,
-    preset: str | None = None,
-    policy_dir: Path | None = None,
-) -> None:
-    """Spin up an AgentGuard MCP server in-process and run *fn(session)*.
-
-    Uses anyio memory streams — no real I/O needed.
-    """
-    from agentguard.mcp.server import create_server
-
-    kwargs: dict[str, Any] = {
-        "audit_dir": str(audit_dir) if audit_dir else None,
-        "actor": actor,
-        "load_builtins": builtins,
-    }
-    if preset is not None:
-        kwargs["preset"] = preset
-    if policy_dir is not None:
-        kwargs["policy_dir"] = str(policy_dir)
-
-    app = create_server(**kwargs)
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
-
-
-def _create_proxy(
-    mock_upstream: MockUpstream,
-    audit_dir: Path,
-    *,
-    preset: str | None = None,
-    load_builtins: bool = False,
-    scan_responses: bool = False,
-) -> Any:
-    """Build a proxy app wired to the mock upstream.
-
-    Returns the Starlette app with forwarding methods monkey-patched
-    to route through ASGI transport pointing at the mock.
-
-    Unlike the per-file helpers in other test modules, this version
-    takes ``audit_dir`` directly (not ``tmp_path``) so both layers
-    can share the same audit directory.
-    """
-    config = ProxyConfig(
-        upstream_base_url="http://mock-upstream",
-        audit_dir=str(audit_dir),
-        preset=preset,
-        load_builtins=load_builtins,
-        scan_responses=scan_responses,
-    )
-    app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
-
-    return app
-
-
-def _chat_body(content: str) -> dict[str, Any]:
-    """Build a minimal OpenAI chat completion request body."""
-    return {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-    }
-
-
-def _audit_entries(audit_dir: Path) -> list[dict[str, Any]]:
-    """Collect all audit entries from the audit directory."""
-    entries: list[dict[str, Any]] = []
-    for path in audit_dir.glob("*.jsonl"):
-        for line in path.read_text().splitlines():
-            if line.strip():
-                entries.append(json.loads(line))
-    return entries
-
-
-def _mcp_audit_entries(audit_dir: Path) -> list[dict[str, Any]]:
-    """Collect only MCP audit entries (ag-*.jsonl files)."""
-    entries: list[dict[str, Any]] = []
-    for path in audit_dir.glob("ag-*.jsonl"):
-        for line in path.read_text().splitlines():
-            if line.strip():
-                entries.append(json.loads(line))
-    return entries
-
-
-def _proxy_audit_entries(audit_dir: Path) -> list[dict[str, Any]]:
-    """Collect only proxy audit entries (proxy-*.jsonl files)."""
-    entries: list[dict[str, Any]] = []
-    for path in audit_dir.glob("proxy-*.jsonl"):
-        for line in path.read_text().splitlines():
-            if line.strip():
-                entries.append(json.loads(line))
-    return entries
 
 
 # ===========================================================================

--- a/tests/e2e/test_error_handling.py
+++ b/tests/e2e/test_error_handling.py
@@ -21,165 +21,23 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import httpx
 import pytest
-from mcp import ClientSession
 
-from agentguard.proxy.app import create_app
-from agentguard.proxy.config import ProxyConfig
-from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _create_proxy,
+    _get_text,
+    _with_server,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mcp import ClientSession
+
     from tests.e2e.conftest import MockUpstream
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    actor: str = "test-agent",
-    builtins: bool = False,
-    preset: str | None = None,
-    policy_dir: Path | None = None,
-) -> None:
-    """Spin up an AgentGuard MCP server in-process and run *fn(session)*.
-
-    Uses anyio memory streams — no real I/O needed.
-    """
-    from agentguard.mcp.server import create_server
-
-    kwargs: dict[str, Any] = {
-        "audit_dir": str(audit_dir) if audit_dir else None,
-        "actor": actor,
-        "load_builtins": builtins,
-    }
-    if preset is not None:
-        kwargs["preset"] = preset
-    if policy_dir is not None:
-        kwargs["policy_dir"] = str(policy_dir)
-
-    app = create_server(**kwargs)
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
-
-
-def _create_proxy(
-    mock_upstream: MockUpstream,
-    tmp_path: Path,
-    *,
-    preset: str | None = None,
-    load_builtins: bool = False,
-    scan_responses: bool = False,
-) -> Any:
-    """Build a proxy app wired to the mock upstream.
-
-    Returns the Starlette app with forwarding methods monkey-patched
-    to route through ASGI transport pointing at the mock.
-    """
-    ad = tmp_path / "audit"
-    ad.mkdir(exist_ok=True)
-
-    config = ProxyConfig(
-        upstream_base_url="http://mock-upstream",
-        audit_dir=str(ad),
-        preset=preset,
-        load_builtins=load_builtins,
-        scan_responses=scan_responses,
-    )
-    app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
-
-    return app
 
 
 # ===========================================================================
@@ -474,10 +332,10 @@ class TestProxyMalformedInput:
 
     @pytest.mark.anyio()
     async def test_sg_13_6_malformed_json_no_crash(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Proxy does not crash on malformed JSON request body."""
-        app = _create_proxy(mock_upstream, tmp_path)
+        app = _create_proxy(mock_upstream, audit_dir)
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -494,11 +352,11 @@ class TestProxyMalformedInput:
 
     @pytest.mark.anyio()
     async def test_sg_13_6_malformed_json_passes_through(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Malformed JSON is forwarded to upstream without scanning."""
         mock_upstream.set_response({"choices": [{"message": {"content": "ok"}}]})
-        app = _create_proxy(mock_upstream, tmp_path, load_builtins=True)
+        app = _create_proxy(mock_upstream, audit_dir, load_builtins=True)
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -514,11 +372,11 @@ class TestProxyMalformedInput:
 
     @pytest.mark.anyio()
     async def test_sg_13_7_empty_body_no_crash(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Proxy does not crash on empty request body."""
         mock_upstream.set_response({"choices": [{"message": {"content": "ok"}}]})
-        app = _create_proxy(mock_upstream, tmp_path)
+        app = _create_proxy(mock_upstream, audit_dir)
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -533,11 +391,11 @@ class TestProxyMalformedInput:
 
     @pytest.mark.anyio()
     async def test_sg_13_7_empty_body_audited(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Empty-body request is recorded in the proxy audit log."""
         mock_upstream.set_response({"choices": [{"message": {"content": "ok"}}]})
-        app = _create_proxy(mock_upstream, tmp_path)
+        app = _create_proxy(mock_upstream, audit_dir)
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -550,8 +408,7 @@ class TestProxyMalformedInput:
             )
 
         # Check audit log exists
-        ad = tmp_path / "audit"
-        jsonl_files = list(ad.glob("*.jsonl"))
+        jsonl_files = list(audit_dir.glob("*.jsonl"))
         assert len(jsonl_files) >= 1, "Expected audit log for empty-body request"
 
 

--- a/tests/e2e/test_mcp_file_ops.py
+++ b/tests/e2e/test_mcp_file_ops.py
@@ -18,33 +18,21 @@ Test matrix:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import pytest
-from mcp import ClientSession
+
+from tests.e2e.conftest import _with_server
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mcp import ClientSession
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
 
 
 @pytest.fixture()
@@ -68,57 +56,6 @@ def file_edit_secret_policy_dir(tmp_path: Path) -> Path:
         "    severity: critical\n"
     )
     return d
-
-
-# ---------------------------------------------------------------------------
-# Helper: run a function against an in-process MCP server
-# ---------------------------------------------------------------------------
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    policy_dir: Path | None = None,
-    audit_dir: Path | None = None,
-    actor: str = "test-agent",
-    builtins: bool = False,
-) -> None:
-    """Spin up an AgentGuard MCP server in-process and run fn(session).
-
-    Uses anyio memory streams so no real I/O is needed.
-    The server is cancelled once fn returns.
-    """
-    from agentguard.mcp.server import create_server
-
-    app = create_server(
-        policy_dir=str(policy_dir) if policy_dir else None,
-        audit_dir=str(audit_dir) if audit_dir else None,
-        actor=actor,
-        load_builtins=builtins,
-    )
-
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
 
 
 # ===========================================================================
@@ -151,7 +88,7 @@ class TestFileWritePolicy:
             assert "denied by policy" in error_text
             assert not target.exists(), "File should not be written when denied"
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 
     @pytest.mark.anyio()
     async def test_sg_1_2_clean_write_allowed(
@@ -171,7 +108,7 @@ class TestFileWritePolicy:
             assert target.exists()
             assert target.read_text() == "Hello, world!\n"
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 
 
 class TestFileEditPolicy:
@@ -232,7 +169,7 @@ class TestFileEditPolicy:
             assert "New content" in target.read_text()
             assert "Old content" not in target.read_text()
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 
 
 class TestFileReadAudit:
@@ -265,7 +202,7 @@ class TestFileReadAudit:
             assert read_entry["action"] == "file_read"
             assert read_entry["result"] == "allowed"
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 
 
 class TestFileGlob:
@@ -296,7 +233,7 @@ class TestFileGlob:
             # Verify capped message is present
             assert any("capped" in ln.lower() for ln in lines)
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 
 
 class TestFileGrep:
@@ -325,7 +262,7 @@ class TestFileGrep:
             text = result.content[0].text  # type: ignore[union-attr]
             assert "hello" in text
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 
 
 class TestFileList:
@@ -352,4 +289,4 @@ class TestFileList:
             assert "README.md" in text
             assert "src/" in text
 
-        await _with_server(check, builtins=True, audit_dir=audit_dir)
+        await _with_server(check, load_builtins=True, audit_dir=audit_dir)

--- a/tests/e2e/test_mcp_shell_ops.py
+++ b/tests/e2e/test_mcp_shell_ops.py
@@ -15,87 +15,16 @@ Test matrix:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import pytest
-from mcp import ClientSession
+
+from tests.e2e.conftest import _get_text, _with_server
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    preset: str = "balanced",
-    actor: str = "test-agent",
-) -> None:
-    """Spin up an AgentGuard MCP server with a preset and run *fn(session)*.
-
-    Uses anyio memory streams so no real I/O is needed.
-    The server is cancelled once *fn* returns.
-    """
-    from agentguard.mcp.server import create_server
-
-    app = create_server(
-        preset=preset,
-        audit_dir=str(audit_dir) if audit_dir else None,
-        actor=actor,
-    )
-
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
+    from mcp import ClientSession
 
 
 # ===========================================================================

--- a/tests/e2e/test_opencode_integration.py
+++ b/tests/e2e/test_opencode_integration.py
@@ -18,14 +18,16 @@ Test matrix:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import pytest
-from mcp import ClientSession
+
+from tests.e2e.conftest import _get_text, _with_server
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mcp import ClientSession
 
 
 # ---------------------------------------------------------------------------
@@ -70,20 +72,6 @@ rules:
 
 
 @pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-@pytest.fixture()
 def auto_discover_policy_dir(tmp_path: Path) -> Path:
     """Create a .agentguard/policies/ directory with an RSN policy.
 
@@ -96,66 +84,6 @@ def auto_discover_policy_dir(tmp_path: Path) -> Path:
     ag_dir.mkdir(parents=True)
     (ag_dir / "rsn-no-private-commit.yaml").write_text(_RSN_NO_PRIVATE_COMMIT)
     return project_root
-
-
-# ---------------------------------------------------------------------------
-# Helper: run a function against an in-process MCP server
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    preset: str = "permissive",
-    actor: str = "opencode-agent",
-    auto_discover: bool = False,
-    policy_dir: Path | None = None,
-) -> None:
-    """Spin up an AgentGuard MCP server and run *fn(session)*.
-
-    Mirrors the real OpenCode sidecar configuration:
-    ``agentguard serve --preset <preset> --auto-discover --audit-dir <dir>``.
-
-    Uses anyio memory streams — no real I/O or OpenCode binary needed.
-    """
-    from agentguard.mcp.server import create_server
-
-    app = create_server(
-        preset=preset,
-        audit_dir=str(audit_dir) if audit_dir else None,
-        actor=actor,
-        auto_discover=auto_discover,
-        policy_dir=str(policy_dir) if policy_dir else None,
-    )
-
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
 
 
 # ===========================================================================
@@ -176,7 +104,9 @@ class TestToolDiscovery:
             missing = EXPECTED_TOOLS - tool_names
             assert not missing, f"Missing tools: {missing}"
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_1_no_unexpected_tools(self, audit_dir: Path) -> None:
@@ -188,7 +118,9 @@ class TestToolDiscovery:
             extra = tool_names - EXPECTED_TOOLS
             assert not extra, f"Unexpected extra tools: {extra}"
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_1_tool_count_is_11(self, audit_dir: Path) -> None:
@@ -201,7 +133,9 @@ class TestToolDiscovery:
                 f"{[t.name for t in tools_result.tools]}"
             )
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
 
 class TestFileWorkflow:
@@ -238,7 +172,9 @@ class TestFileWorkflow:
             assert "def hello()" in _get_text(read_result)
             assert "Hello, world!" in _get_text(read_result)
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
         # Verify file exists on disk
         assert target.exists()
@@ -278,7 +214,9 @@ class TestFileWorkflow:
             assert len(read_entries) >= 1
             assert read_entries[-1]["result"] == "allowed"
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
 
 class TestShellWorkflow:
@@ -296,7 +234,9 @@ class TestShellWorkflow:
             assert not result.isError, f"shell_execute failed: {_get_text(result)}"
             assert "agent running" in _get_text(result)
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_3_shell_command_audited(self, audit_dir: Path) -> None:
@@ -317,7 +257,9 @@ class TestShellWorkflow:
             assert entries[-1]["result"] == "allowed"
             assert "python3 --version" in entries[-1]["target"]
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
 
 class TestPolicyEnforcement:
@@ -345,7 +287,9 @@ class TestPolicyEnforcement:
             assert result.isError, "Expected denial but tool succeeded"
             assert "denied by policy" in _get_text(result)
 
-        await _with_server(check, audit_dir=audit_dir, preset="balanced")
+        await _with_server(
+            check, audit_dir=audit_dir, preset="balanced", actor="opencode-agent"
+        )
 
         # File must NOT exist on disk
         assert not target.exists()
@@ -377,7 +321,9 @@ class TestPolicyEnforcement:
             assert len(denied_entries) >= 1
             assert denied_entries[-1]["action"] == "file_write"
 
-        await _with_server(check, audit_dir=audit_dir, preset="balanced")
+        await _with_server(
+            check, audit_dir=audit_dir, preset="balanced", actor="opencode-agent"
+        )
 
 
 class TestAutoDiscover:
@@ -407,6 +353,7 @@ class TestAutoDiscover:
                 check,
                 audit_dir=audit_dir,
                 preset="permissive",
+                actor="opencode-agent",
                 auto_discover=True,
             )
         finally:
@@ -451,6 +398,7 @@ class TestAutoDiscover:
                 check,
                 audit_dir=audit_dir,
                 preset="permissive",
+                actor="opencode-agent",
                 auto_discover=True,
             )
         finally:
@@ -519,7 +467,9 @@ class TestAuditAccumulation:
                 "shell_execute",
             ]
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_6_hash_chain_valid_after_session(
@@ -544,7 +494,9 @@ class TestAuditAccumulation:
                 {"command": "echo step-3"},
             )
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
         # Load persisted audit log and verify hash chain
         jsonl_files = list(audit_dir.glob("*.jsonl"))
@@ -575,7 +527,9 @@ class TestStatusTool:
             assert status["policies_loaded"] >= 3
             assert len(status["policy_names"]) >= 3
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_7_status_reflects_preset_policies(
@@ -593,7 +547,9 @@ class TestStatusTool:
             assert "no-force-push" in policy_names
             assert "no-secret-in-prompt" in policy_names
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_7_status_shows_audit_count(self, audit_dir: Path) -> None:
@@ -621,4 +577,6 @@ class TestStatusTool:
             # initial status call + 2 shell_execute calls = +3 minimum
             assert status2.get("audit_entries", 0) > initial_count
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(
+            check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"
+        )

--- a/tests/e2e/test_policy_engine.py
+++ b/tests/e2e/test_policy_engine.py
@@ -15,19 +15,20 @@ Tests cover:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-import anyio
+    from mcp import ClientSession
+
 import pytest
-from mcp import ClientSession
 
 from agentguard.policies.discovery import discover_policies
 from agentguard.policies.guard import Guard
 from agentguard.policies.loader import load_policy_from_string
 from agentguard.policies.presets import PRESET_POLICIES, Preset
+from tests.e2e.conftest import _get_text, _with_server
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,75 +74,6 @@ def _write_policy_file(directory: Path, filename: str, content: str) -> Path:
     path = directory / filename
     path.write_text(content)
     return path
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    preset: str | None = None,
-    actor: str = "test-agent",
-    policy_dir: str | None = None,
-    auto_discover: bool = False,
-    load_builtins: bool = False,
-) -> None:
-    """Spin up an AgentGuard MCP server and run *fn(session)*.
-
-    Uses anyio memory streams so no real I/O is needed.
-    The server is cancelled once *fn* returns.
-    """
-    from agentguard.mcp.server import create_server
-
-    app = create_server(
-        preset=preset,
-        audit_dir=str(audit_dir) if audit_dir else None,
-        actor=actor,
-        policy_dir=policy_dir,
-        auto_discover=auto_discover,
-        load_builtins=load_builtins,
-    )
-
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_proxy_auth.py
+++ b/tests/e2e/test_proxy_auth.py
@@ -28,7 +28,10 @@ import pytest
 
 from agentguard.proxy.app import create_app
 from agentguard.proxy.config import ProxyConfig
-from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _chat_body,
+    _create_proxy,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -41,86 +44,10 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _create_proxy_with_auth(
-    mock_upstream: MockUpstream,
-    tmp_path: Path,
-    *,
-    auth_file: str | None = None,
-    auth_provider: str = "github-copilot",
-) -> Any:
-    """Build a proxy app wired to the mock upstream with optional auth.
-
-    Returns the Starlette app.  The middleware's forwarding methods are
-    monkey-patched to route through ASGI transport pointing at the mock.
-    """
-    audit_dir = tmp_path / "audit"
-    audit_dir.mkdir(exist_ok=True)
-
-    config = ProxyConfig(
-        upstream_base_url="http://mock-upstream",
-        audit_dir=str(audit_dir),
-        load_builtins=True,
-        scan_responses=True,
-        auth_file=auth_file,
-        auth_provider=auth_provider,
-    )
-    app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
-
-    return app
-
-
 def _write_auth_file(path: Path, data: Any) -> Path:
     """Write auth data to a JSON file and return the path."""
     path.write_text(json.dumps(data), encoding="utf-8")
     return path
-
-
-def _chat_body(content: str = "Hello", *, stream: bool = False) -> dict[str, Any]:
-    """Build a minimal chat completion request body."""
-    body: dict[str, Any] = {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-    }
-    if stream:
-        body["stream"] = True
-    return body
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +59,7 @@ def _chat_body(content: str = "Hello", *, stream: bool = False) -> dict[str, Any
 async def test_auth_token_replaces_client_header(
     mock_upstream: MockUpstream,
     tmp_path: Path,
+    audit_dir: Path,
 ) -> None:
     """The proxy replaces the client's Authorization header with the
     token from auth.json.  The upstream should never see the client's
@@ -141,7 +69,13 @@ async def test_auth_token_replaces_client_header(
         tmp_path / "auth.json",
         {"github-copilot": {"refresh": "injected-server-token"}},
     )
-    app = _create_proxy_with_auth(mock_upstream, tmp_path, auth_file=str(auth_path))
+    app = _create_proxy(
+        mock_upstream,
+        audit_dir,
+        load_builtins=True,
+        scan_responses=True,
+        auth_file=str(auth_path),
+    )
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),
@@ -169,6 +103,7 @@ async def test_auth_token_replaces_client_header(
 async def test_refresh_field_used_for_oauth(
     mock_upstream: MockUpstream,
     tmp_path: Path,
+    audit_dir: Path,
 ) -> None:
     """When both 'refresh' and 'key' are present, 'refresh' takes
     priority (OAuth flow).
@@ -183,7 +118,13 @@ async def test_refresh_field_used_for_oauth(
             }
         },
     )
-    app = _create_proxy_with_auth(mock_upstream, tmp_path, auth_file=str(auth_path))
+    app = _create_proxy(
+        mock_upstream,
+        audit_dir,
+        load_builtins=True,
+        scan_responses=True,
+        auth_file=str(auth_path),
+    )
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),
@@ -208,15 +149,18 @@ async def test_refresh_field_used_for_oauth(
 async def test_key_field_fallback(
     mock_upstream: MockUpstream,
     tmp_path: Path,
+    audit_dir: Path,
 ) -> None:
     """When only 'key' is present (no 'refresh'), the key field is used."""
     auth_path = _write_auth_file(
         tmp_path / "auth.json",
         {"anthropic": {"type": "api", "key": "sk-ant-api-key"}},
     )
-    app = _create_proxy_with_auth(
+    app = _create_proxy(
         mock_upstream,
-        tmp_path,
+        audit_dir,
+        load_builtins=True,
+        scan_responses=True,
         auth_file=str(auth_path),
         auth_provider="anthropic",
     )
@@ -243,12 +187,18 @@ async def test_key_field_fallback(
 @pytest.mark.anyio
 async def test_no_auth_file_preserves_client_token(
     mock_upstream: MockUpstream,
-    tmp_path: Path,
+    audit_dir: Path,
 ) -> None:
     """Without auth_file configured, the client's original Authorization
     header is forwarded to the upstream unchanged.
     """
-    app = _create_proxy_with_auth(mock_upstream, tmp_path, auth_file=None)
+    app = _create_proxy(
+        mock_upstream,
+        audit_dir,
+        load_builtins=True,
+        scan_responses=True,
+        auth_file=None,
+    )
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),
@@ -322,6 +272,7 @@ def test_missing_provider_key_raises(tmp_path: Path) -> None:
 async def test_token_not_hot_reloaded(
     mock_upstream: MockUpstream,
     tmp_path: Path,
+    audit_dir: Path,
 ) -> None:
     """The auth token is loaded once at startup and NOT reloaded when the
     file changes.  This is a known limitation (issue #88).
@@ -333,7 +284,13 @@ async def test_token_not_hot_reloaded(
         tmp_path / "auth.json",
         {"github-copilot": {"refresh": "original-token"}},
     )
-    app = _create_proxy_with_auth(mock_upstream, tmp_path, auth_file=str(auth_path))
+    app = _create_proxy(
+        mock_upstream,
+        audit_dir,
+        load_builtins=True,
+        scan_responses=True,
+        auth_file=str(auth_path),
+    )
 
     transport = httpx.ASGITransport(app=app)
 
@@ -438,7 +395,7 @@ async def test_upstream_failure_audit_entry(
 @pytest.mark.anyio
 async def test_non_200_upstream_forwarded(
     mock_upstream: MockUpstream,
-    tmp_path: Path,
+    audit_dir: Path,
 ) -> None:
     """When the upstream returns a non-200 status (e.g. 429 rate limit),
     the proxy forwards the status code and body to the client.
@@ -448,7 +405,13 @@ async def test_non_200_upstream_forwarded(
         status=429,
     )
 
-    app = _create_proxy_with_auth(mock_upstream, tmp_path, auth_file=None)
+    app = _create_proxy(
+        mock_upstream,
+        audit_dir,
+        load_builtins=True,
+        scan_responses=True,
+        auth_file=None,
+    )
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),

--- a/tests/e2e/test_proxy_inbound.py
+++ b/tests/e2e/test_proxy_inbound.py
@@ -16,173 +16,25 @@ Test matrix:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 
-from agentguard.proxy.app import create_app
-from agentguard.proxy.config import ProxyConfig
-from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _audit_entries,
+    _chat_body,
+    _create_proxy,
+    _parse_sse_events,
+    _sse_chunk,
+    _sse_done_chunk,
+    _streaming_body,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from starlette.applications import Starlette
-
     from tests.e2e.conftest import MockUpstream
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _sse_chunk(content: str, index: int = 0) -> str:
-    """Build an OpenAI-format SSE chunk payload (raw JSON string)."""
-    return json.dumps(
-        {
-            "id": f"chatcmpl-{index}",
-            "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {"content": content},
-                    "finish_reason": None,
-                }
-            ],
-        }
-    )
-
-
-def _sse_done_chunk() -> str:
-    """Build an OpenAI-format SSE final chunk (finish_reason=stop)."""
-    return json.dumps(
-        {
-            "id": "chatcmpl-final",
-            "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {},
-                    "finish_reason": "stop",
-                }
-            ],
-        }
-    )
-
-
-def _chat_body(content: str = "Hello") -> dict[str, Any]:
-    """Build a minimal OpenAI non-streaming chat request body."""
-    return {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-    }
-
-
-def _streaming_body(content: str = "Hello") -> dict[str, Any]:
-    """Build a minimal OpenAI streaming chat request body."""
-    return {
-        "model": "gpt-4",
-        "stream": True,
-        "messages": [{"role": "user", "content": content}],
-    }
-
-
-def _parse_sse_events(raw: str) -> list[str]:
-    """Extract ``data:`` payloads from raw SSE text."""
-    events: list[str] = []
-    for line in raw.split("\n"):
-        stripped = line.strip()
-        if stripped.startswith("data: "):
-            events.append(stripped[6:])
-    return events
-
-
-def _create_proxy(
-    mock_upstream: MockUpstream,
-    tmp_path: Path,
-    *,
-    scan_responses: bool = True,
-    preset: str | None = None,
-    load_builtins: bool = False,
-) -> Starlette:
-    """Build a proxy app wired to the mock upstream.
-
-    Returns the Starlette app with monkey-patched forwarding.
-    """
-    audit_dir = tmp_path / "audit"
-    audit_dir.mkdir(exist_ok=True)
-
-    config = ProxyConfig(
-        upstream_base_url="http://mock-upstream",
-        audit_dir=str(audit_dir),
-        preset=preset,
-        load_builtins=load_builtins,
-        scan_responses=scan_responses,
-    )
-    app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
-
-    return app
-
-
-def _audit_entries(tmp_path: Path) -> list[dict[str, Any]]:
-    """Collect all audit log entries from the audit directory."""
-    audit_dir = tmp_path / "audit"
-    entries: list[dict[str, Any]] = []
-    for path in audit_dir.glob("*.jsonl"):
-        for line in path.read_text().splitlines():
-            if line.strip():
-                entries.append(json.loads(line))
-    return entries
 
 
 # ===========================================================================
@@ -195,11 +47,11 @@ class TestNonStreamingInjection:
 
     @pytest.mark.anyio()
     async def test_sg_4_1_non_streaming_injection_blocked(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Upstream returns injection text; proxy responds with 403."""
         app = _create_proxy(
-            mock_upstream, tmp_path, scan_responses=True, preset="balanced"
+            mock_upstream, audit_dir, scan_responses=True, preset="balanced"
         )
         mock_upstream.set_response(
             {
@@ -236,7 +88,7 @@ class TestNonStreamingInjection:
         assert body.get("denied_by") == "no-prompt-injection"
 
         # Verify audit entry
-        entries = _audit_entries(tmp_path)
+        entries = _audit_entries(audit_dir)
         denied = [e for e in entries if e.get("result") == "denied"]
         assert len(denied) >= 1
         assert denied[-1].get("action") == "llm_response"
@@ -247,11 +99,11 @@ class TestStreamingInjectionAcrossChunks:
 
     @pytest.mark.anyio()
     async def test_sg_4_2_streaming_cross_chunk_injection(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Injection pattern spans two SSE chunks; scanner accumulates and detects."""
         app = _create_proxy(
-            mock_upstream, tmp_path, scan_responses=True, preset="balanced"
+            mock_upstream, audit_dir, scan_responses=True, preset="balanced"
         )
 
         # Split "ignore all previous instructions" across chunks
@@ -298,11 +150,11 @@ class TestCleanStreamingPasses:
 
     @pytest.mark.anyio()
     async def test_sg_4_3_clean_streaming_passes(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Safe streaming content passes all policies."""
         app = _create_proxy(
-            mock_upstream, tmp_path, scan_responses=True, preset="strict"
+            mock_upstream, audit_dir, scan_responses=True, preset="strict"
         )
 
         mock_upstream.set_sse_chunks(
@@ -337,7 +189,7 @@ class TestCleanStreamingPasses:
         assert events[-1] == "[DONE]"
 
         # Audit entry recorded as allowed
-        entries = _audit_entries(tmp_path)
+        entries = _audit_entries(audit_dir)
         allowed = [e for e in entries if e.get("result") == "allowed"]
         assert len(allowed) >= 1
 
@@ -347,12 +199,12 @@ class TestInboundScanningDisabled:
 
     @pytest.mark.anyio()
     async def test_sg_4_4_scanning_disabled_passes_injection(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Injection in response is not blocked when scanning is off."""
         app = _create_proxy(
             mock_upstream,
-            tmp_path,
+            audit_dir,
             scan_responses=False,
             load_builtins=True,
         )
@@ -397,11 +249,11 @@ class TestLargeChunkResponse:
 
     @pytest.mark.anyio()
     async def test_sg_4_5_large_streaming_response(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """A 120-chunk clean stream passes without false positives."""
         app = _create_proxy(
-            mock_upstream, tmp_path, scan_responses=True, preset="strict"
+            mock_upstream, audit_dir, scan_responses=True, preset="strict"
         )
 
         chunks = [_sse_chunk(f"word-{i} ", i) for i in range(120)]

--- a/tests/e2e/test_proxy_outbound.py
+++ b/tests/e2e/test_proxy_outbound.py
@@ -17,127 +17,21 @@ Test matrix:
 
 from __future__ import annotations
 
-import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 
-from agentguard.proxy.app import create_app
-from agentguard.proxy.config import ProxyConfig
-from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _audit_entries,
+    _chat_body,
+    _create_proxy,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from tests.e2e.conftest import MockUpstream
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _create_proxy(
-    mock_upstream: MockUpstream,
-    tmp_path: Path,
-    *,
-    preset: str | None = None,
-    load_builtins: bool = False,
-) -> Any:
-    """Build a proxy app wired to the mock upstream with a given preset.
-
-    Returns the Starlette app.  The middleware's forwarding methods are
-    monkey-patched to route through ASGI transport pointing at the mock.
-    """
-    audit_dir = tmp_path / "audit"
-    audit_dir.mkdir(exist_ok=True)
-
-    config = ProxyConfig(
-        upstream_base_url="http://mock-upstream",
-        audit_dir=str(audit_dir),
-        preset=preset,
-        load_builtins=load_builtins,
-        scan_responses=False,
-    )
-    app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
-
-    return app
-
-
-def _chat_body(content: str) -> dict[str, Any]:
-    """Build a minimal OpenAI chat completion request body."""
-    return {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-    }
-
-
-def _audit_entries(tmp_path: Path) -> list[dict[str, Any]]:
-    """Collect all audit entries from the audit directory."""
-    audit_dir = tmp_path / "audit"
-    entries: list[dict[str, Any]] = []
-    for path in audit_dir.glob("*.jsonl"):
-        for line in path.read_text().splitlines():
-            if line.strip():
-                entries.append(json.loads(line))
-    return entries
 
 
 # ===========================================================================
@@ -150,10 +44,10 @@ class TestSecretInPrompt:
 
     @pytest.mark.anyio()
     async def test_sg_3_1_api_key_blocked(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """An OpenAI API key in the user message is denied."""
-        app = _create_proxy(mock_upstream, tmp_path, preset="permissive")
+        app = _create_proxy(mock_upstream, audit_dir, preset="permissive")
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -179,10 +73,10 @@ class TestPiiBlocked:
 
     @pytest.mark.anyio()
     async def test_sg_3_2_ssn_blocked(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """A US Social Security Number in the message is denied."""
-        app = _create_proxy(mock_upstream, tmp_path, preset="balanced")
+        app = _create_proxy(mock_upstream, audit_dir, preset="balanced")
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -207,10 +101,10 @@ class TestInternalPathBlocked:
 
     @pytest.mark.anyio()
     async def test_sg_3_3_internal_path_blocked(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """A Unix internal path in the message is denied."""
-        app = _create_proxy(mock_upstream, tmp_path, preset="strict")
+        app = _create_proxy(mock_upstream, audit_dir, preset="strict")
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -235,10 +129,10 @@ class TestJailbreakBlocked:
 
     @pytest.mark.anyio()
     async def test_sg_3_4_jailbreak_blocked(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """A persona jailbreak attempt is denied."""
-        app = _create_proxy(mock_upstream, tmp_path, preset="strict")
+        app = _create_proxy(mock_upstream, audit_dir, preset="strict")
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -261,10 +155,10 @@ class TestDriftTriggerBlocked:
 
     @pytest.mark.anyio()
     async def test_sg_3_5_drift_trigger_blocked(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """A meta-reflective drift trigger prompt is denied."""
-        app = _create_proxy(mock_upstream, tmp_path, preset="strict")
+        app = _create_proxy(mock_upstream, audit_dir, preset="strict")
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -287,10 +181,10 @@ class TestCleanPromptAllowed:
 
     @pytest.mark.anyio()
     async def test_sg_3_6_clean_prompt_allowed(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """A safe prompt passes all policies and reaches upstream."""
-        app = _create_proxy(mock_upstream, tmp_path, preset="strict")
+        app = _create_proxy(mock_upstream, audit_dir, preset="strict")
         mock_upstream.set_response({"choices": [{"message": {"content": "Hello!"}}]})
 
         async with httpx.AsyncClient(
@@ -309,7 +203,7 @@ class TestCleanPromptAllowed:
         assert len(mock_upstream.requests) == 1
 
         # Verify audit entry recorded as allowed
-        entries = _audit_entries(tmp_path)
+        entries = _audit_entries(audit_dir)
         allowed = [e for e in entries if e.get("result") == "allowed"]
         assert len(allowed) >= 1
 
@@ -319,10 +213,10 @@ class TestScanningDisabled:
 
     @pytest.mark.anyio()
     async def test_sg_3_7_no_policies_passes_all(
-        self, mock_upstream: MockUpstream, tmp_path: Path
+        self, mock_upstream: MockUpstream, audit_dir: Path
     ) -> None:
         """Without any policies, even dangerous content passes through."""
-        app = _create_proxy(mock_upstream, tmp_path, preset=None, load_builtins=False)
+        app = _create_proxy(mock_upstream, audit_dir, preset=None, load_builtins=False)
         mock_upstream.set_response({"choices": [{"message": {"content": "Sure!"}}]})
 
         async with httpx.AsyncClient(

--- a/tests/e2e/test_proxy_streaming.py
+++ b/tests/e2e/test_proxy_streaming.py
@@ -27,6 +27,13 @@ import pytest
 from agentguard.proxy.app import create_app
 from agentguard.proxy.config import ProxyConfig
 from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _chat_body,
+    _parse_sse_events,
+    _sse_chunk,
+    _sse_done_chunk,
+    _streaming_body,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -36,72 +43,6 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from tests.e2e.conftest import MockUpstream
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _sse_chunk(content: str, index: int = 0) -> str:
-    """Build an OpenAI-format SSE chunk payload (raw JSON string)."""
-    return json.dumps(
-        {
-            "id": f"chatcmpl-{index}",
-            "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {"content": content},
-                    "finish_reason": None,
-                }
-            ],
-        }
-    )
-
-
-def _sse_done_chunk() -> str:
-    """Build an OpenAI-format SSE final chunk (finish_reason=stop)."""
-    return json.dumps(
-        {
-            "id": "chatcmpl-final",
-            "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {},
-                    "finish_reason": "stop",
-                }
-            ],
-        }
-    )
-
-
-def _streaming_body(content: str = "Hello") -> dict[str, Any]:
-    """Build a minimal streaming chat completion request body."""
-    return {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-        "stream": True,
-    }
-
-
-def _non_streaming_body(content: str = "Hello") -> dict[str, Any]:
-    """Build a minimal non-streaming chat completion request body."""
-    return {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-    }
-
-
-def _parse_sse_events(raw: str) -> list[str]:
-    """Parse raw SSE text into a list of data payloads."""
-    events: list[str] = []
-    for line in raw.split("\n"):
-        stripped = line.strip()
-        if stripped.startswith("data: "):
-            events.append(stripped[6:])
-    return events
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +327,7 @@ async def test_non_streaming_json_complete(
     ) as client:
         resp = await client.post(
             "/v1/chat/completions",
-            json=_non_streaming_body(),
+            json=_chat_body(),
         )
 
     assert resp.status_code == 200
@@ -423,7 +364,7 @@ async def test_mixed_streaming_non_streaming(
     ) as client:
         resp1 = await client.post(
             "/v1/chat/completions",
-            json=_non_streaming_body("First"),
+            json=_chat_body("First"),
         )
 
     assert resp1.status_code == 200
@@ -473,7 +414,7 @@ async def test_mixed_streaming_non_streaming(
     ) as client:
         resp3 = await client.post(
             "/v1/chat/completions",
-            json=_non_streaming_body("Third"),
+            json=_chat_body("Third"),
         )
 
     assert resp3.status_code == 200

--- a/tests/e2e/test_regression.py
+++ b/tests/e2e/test_regression.py
@@ -14,167 +14,26 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-import anyio
 import httpx
 import pytest
-from mcp import ClientSession
 
 from agentguard.audit.log import AuditLog
 from agentguard.policies.presets import PRESET_POLICIES, Preset
-from agentguard.proxy.app import create_app
-from agentguard.proxy.config import ProxyConfig
-from agentguard.proxy.middleware import _StreamContext
+from tests.e2e.conftest import (
+    _chat_body,
+    _create_proxy,
+    _fake_sk_key,
+    _fake_sk_proj_key,
+    _get_text,
+    _with_server,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mcp import ClientSession
+
     from tests.e2e.conftest import MockUpstream
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-def _fake_sk_key(body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345678901234") -> str:
-    """Build a fake ``sk-`` key at runtime to avoid safety scanner."""
-    return "sk" + "-" + body
-
-
-def _fake_sk_proj_key(
-    body: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
-) -> str:
-    """Build a fake ``sk-proj-`` key at runtime to avoid safety scanner."""
-    return "sk" + "-" + "proj" + "-" + body
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    actor: str = "test-agent",
-    preset: str | None = None,
-) -> None:
-    """Spin up an AgentGuard MCP server in-process and run *fn(session)*."""
-    from agentguard.mcp.server import create_server
-
-    kwargs: dict[str, Any] = {
-        "audit_dir": str(audit_dir) if audit_dir else None,
-        "actor": actor,
-        "load_builtins": False,
-    }
-    if preset is not None:
-        kwargs["preset"] = preset
-
-    app = create_server(**kwargs)
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
-
-
-def _create_proxy(
-    mock_upstream: MockUpstream,
-    audit_dir: Path,
-    *,
-    preset: str | None = None,
-    load_builtins: bool = False,
-    scan_responses: bool = False,
-) -> Any:
-    """Build a proxy app wired to the mock upstream."""
-    config = ProxyConfig(
-        upstream_base_url="http://mock-upstream",
-        audit_dir=str(audit_dir),
-        preset=preset,
-        load_builtins=load_builtins,
-        scan_responses=scan_responses,
-    )
-    app = create_app(config)
-    middleware = app.state.middleware
-    transport = httpx.ASGITransport(app=mock_upstream.app)
-
-    async def _patched_forward_request(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> Any:
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://mock-upstream"
-        ) as client:
-            return await client.request(
-                method=method, url=url, headers=headers, content=body
-            )
-
-    async def _patched_forward_streaming(
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        body: bytes,
-    ) -> _StreamContext:
-        client = httpx.AsyncClient(transport=transport, base_url="http://mock-upstream")
-        try:
-            response = await client.send(
-                client.build_request(
-                    method=method, url=url, headers=headers, content=body
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
-        return _StreamContext(client=client, response=response)
-
-    middleware._forward_request = _patched_forward_request
-    middleware._forward_streaming = _patched_forward_streaming
-
-    return app
-
-
-def _chat_body(content: str) -> dict[str, Any]:
-    return {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": content}],
-    }
 
 
 # ===========================================================================
@@ -307,33 +166,15 @@ class TestR5AuthTokenInjected:
             json.dumps({"github-copilot": {"refresh": "test-refresh-token"}})
         )
 
-        config = ProxyConfig(
-            upstream_base_url="http://mock-upstream",
-            audit_dir=str(audit_dir),
+        proxy_app = _create_proxy(
+            mock_upstream,
+            audit_dir,
             auth_file=str(auth_path),
             auth_provider="github-copilot",
         )
-        app = create_app(config)
-        middleware = app.state.middleware
-        transport = httpx.ASGITransport(app=mock_upstream.app)
-
-        async def _patched_forward_request(
-            method: str,
-            url: str,
-            headers: dict[str, str],
-            body: bytes,
-        ) -> Any:
-            async with httpx.AsyncClient(
-                transport=transport, base_url="http://mock-upstream"
-            ) as client:
-                return await client.request(
-                    method=method, url=url, headers=headers, content=body
-                )
-
-        middleware._forward_request = _patched_forward_request
 
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
+            transport=httpx.ASGITransport(app=proxy_app),
             base_url="http://proxy",
         ) as client:
             await client.post(
@@ -523,14 +364,10 @@ class TestR11UpstreamConnectionFailure:
         audit_dir = tmp_path / "audit"
         audit_dir.mkdir()
 
-        config = ProxyConfig(
-            upstream_base_url="http://mock-upstream",
-            audit_dir=str(audit_dir),
-        )
-        app = create_app(config)
-        middleware = app.state.middleware
+        proxy_app = _create_proxy(mock_upstream, audit_dir)
+        middleware = proxy_app.state.middleware
 
-        # Patch forwarding to simulate upstream connection failure
+        # Override forwarding to simulate upstream connection failure
         async def _failing_forward(
             method: str,
             url: str,
@@ -543,7 +380,7 @@ class TestR11UpstreamConnectionFailure:
         middleware._forward_streaming = _failing_forward
 
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
+            transport=httpx.ASGITransport(app=proxy_app),
             base_url="http://proxy",
         ) as client:
             resp = await client.post(

--- a/tests/e2e/test_rsn_policies.py
+++ b/tests/e2e/test_rsn_policies.py
@@ -17,16 +17,17 @@ not tracked by git).
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import pytest
-from mcp import ClientSession
 
 from agentguard.policies.presets import PRESET_POLICIES, Preset
+from tests.e2e.conftest import _get_text, _with_server
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mcp import ClientSession
 
 # ---------------------------------------------------------------------------
 # Inline policy YAML definitions
@@ -100,12 +101,7 @@ rules:
 # ---------------------------------------------------------------------------
 
 
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-def _write_rsn_policies(policy_dir: Any) -> None:
+def _write_rsn_policies(policy_dir: Path) -> None:
     """Write all RSN policy YAML files into the given directory."""
     from pathlib import Path
 
@@ -117,66 +113,6 @@ def _write_rsn_policies(policy_dir: Any) -> None:
         _RSN_NO_RULESET_MODIFICATION
     )
     d.joinpath("rsn-no-internal-paths.yaml").write_text(_build_rsn_no_internal_paths())
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Any = None,
-    preset: str | None = None,
-    actor: str = "test-agent",
-    policy_dir: str | None = None,
-) -> None:
-    """Spin up an AgentGuard MCP server and run *fn(session)*.
-
-    Uses anyio memory streams so no real I/O is needed.
-    The server is cancelled once *fn* returns.
-    """
-    from agentguard.mcp.server import create_server
-
-    app = create_server(
-        preset=preset,
-        audit_dir=str(audit_dir) if audit_dir else None,
-        actor=actor,
-        policy_dir=policy_dir,
-    )
-
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
 
 
 @pytest.fixture()

--- a/tests/e2e/test_trust_scanner.py
+++ b/tests/e2e/test_trust_scanner.py
@@ -17,36 +17,23 @@ Test matrix:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anyio
 import pytest
-from mcp import ClientSession
 
 from agentguard.trust.models import TrustLevel
 from agentguard.trust.registry import TrustRegistry
+from tests.e2e.conftest import _get_text, _with_server
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mcp import ClientSession
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def anyio_backend() -> str:
-    """Use asyncio as the anyio backend."""
-    return "asyncio"
-
-
-@pytest.fixture()
-def audit_dir(tmp_path: Path) -> Path:
-    """Create a temp directory for audit logs."""
-    d = tmp_path / "audit"
-    d.mkdir()
-    return d
 
 
 @pytest.fixture()
@@ -93,65 +80,6 @@ def clean_package(tmp_path: Path) -> Path:
     return pkg
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_text(result: Any) -> str:
-    """Extract text from an MCP CallToolResult."""
-    return result.content[0].text  # type: ignore[no-any-return]
-
-
-async def _with_server(
-    fn: Any,
-    *,
-    audit_dir: Path | None = None,
-    preset: str = "permissive",
-    actor: str = "test-agent",
-    trust_registry: str | None = None,
-) -> None:
-    """Spin up an AgentGuard MCP server and run *fn(session)*.
-
-    Uses anyio memory streams so no real I/O is needed.
-    The server is cancelled once *fn* returns.
-    """
-    from agentguard.mcp.server import create_server
-
-    kwargs: dict[str, Any] = {
-        "preset": preset,
-        "actor": actor,
-    }
-    if audit_dir is not None:
-        kwargs["audit_dir"] = str(audit_dir)
-    if trust_registry is not None:
-        kwargs["trust_registry"] = trust_registry
-
-    app = create_server(**kwargs)
-    server = app._mcp_server
-
-    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
-    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
-
-    async with anyio.create_task_group() as tg:
-
-        async def run_server() -> None:
-            await server.run(
-                c2s_recv,
-                s2c_send,
-                server.create_initialization_options(),
-            )
-
-        async def run_client() -> None:
-            async with ClientSession(s2c_recv, c2s_send) as session:
-                await session.initialize()
-                await fn(session)
-                tg.cancel_scope.cancel()
-
-        tg.start_soon(run_server)
-        tg.start_soon(run_client)
-
-
 # ===========================================================================
 # SG-8 Tests: Trust registry and package scanner
 # ===========================================================================
@@ -192,6 +120,7 @@ class TestTrustRegisterServer:
         await _with_server(
             check,
             audit_dir=audit_dir,
+            preset="permissive",
             trust_registry=str(registry_path),
         )
 
@@ -270,7 +199,7 @@ class TestScanFindsRisks:
             categories = {f["category"] for f in data["findings"]}
             assert "code-execution" in categories
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(check, audit_dir=audit_dir, preset="permissive")
 
 
 class TestScanMinSeverityFilter:
@@ -317,7 +246,7 @@ class TestScanMinSeverityFilter:
             for finding in high_data["findings"]:
                 assert finding["severity"] in ("high", "critical")
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(check, audit_dir=audit_dir, preset="permissive")
 
 
 class TestScanCleanPackage:
@@ -343,7 +272,7 @@ class TestScanCleanPackage:
             assert data["max_severity"] is None
             assert data["files_scanned"] >= 1
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(check, audit_dir=audit_dir, preset="permissive")
 
 
 class TestTrustQueryMcpTool:
@@ -395,6 +324,7 @@ class TestTrustQueryMcpTool:
         await _with_server(
             check,
             audit_dir=audit_dir,
+            preset="permissive",
             trust_registry=str(registry_path),
         )
 
@@ -448,4 +378,4 @@ class TestScanMcpTool:
             bad_data = json.loads(_get_text(result_bad))
             assert "error" in bad_data
 
-        await _with_server(check, audit_dir=audit_dir)
+        await _with_server(check, audit_dir=audit_dir, preset="permissive")


### PR DESCRIPTION
## Summary

- **Unified 8 duplicated helper functions** across 15 E2E test files into `tests/e2e/conftest.py`: `with_server()`, `get_text()`, `create_proxy()`, `chat_body()`, `mcp_server_with_preset()`, `proxy_app_with_mock()`, SSE parsing helpers, and `audit_dir` fixture
- **Net reduction of ~1,000 lines** (579 added, 1,585 removed) — eliminates copy-paste drift between test files
- **Adds `anyio_backend` fixture** pinned to `asyncio` only, removing 18 unnecessary trio duplicate test variants (1,435 → 1,417 tests, all passing)

## Details

### Helpers extracted to conftest.py

| Helper | Used by | Notes |
|--------|---------|-------|
| `with_server()` / `_with_server()` | 9 files | MCP server lifecycle via anyio memory streams |
| `get_text()` / `_get_text()` | 7 files | Extract `.content[0].text` from `CallToolResult` |
| `create_proxy()` / `_create_proxy()` | 7 files | Build proxy app with `MockUpstream` via `httpx.ASGITransport` |
| `chat_body()` / `_chat_body()` | 5 files | OpenAI-format chat completion request body |
| `mcp_server_with_preset` fixture | 6 files | Already existed, now reused consistently |
| `audit_dir` fixture | 7 files | Replaces per-file `tmp_audit_dir` |
| `proxy_app_with_mock` fixture | 3 files | Already existed, internal helper deduplicated |
| SSE helpers (`collect_sse_events`, etc.) | 3 files | 5 SSE parsing functions for streaming tests |
| `anyio_backend` fixture | all async tests | Pins to asyncio, drops trio variants |

### Backward compatibility

- Underscore-prefixed aliases (`_with_server`, `_get_text`, etc.) are provided so test files can import the names they already use without changing test body code
- `tmp_audit_dir` alias kept for `audit_dir` fixture

### Issues addressed

Resolves duplicated-helper issues from review triage (groups 1–5, ~26 issues):
- `anyio_backend` asyncio-only: #203, #202, #195, #193, #191, #174, #168, #161, #155, #141, #135, #120
- `audit_dir` fixture duplication: #163, #157, #151, #133, #117
- `_with_server` helper duplication: #164, #158, #152, #134, #118
- `_get_text` helper duplication: #165, #159
- `_create_proxy` duplication: #194, #145