### PR TITLE
fix: tighten loose >= assertions in E2E tests

### DIFF
--- a/tests/e2e/test_audit_e2e.py
+++ b/tests/e2e/test_audit_e2e.py
@@ -66,9 +66,7 @@ class TestAuditHashChainValid:
         await _with_server(check, audit_dir=audit_dir, preset="permissive")
 
         log = _load_audit_log(audit_dir)
-        assert len(log.entries) >= 3, (
-            f"Expected at least 3 entries, got {len(log.entries)}"
-        )
+        assert len(log.entries) == 3, f"Expected 3 entries, got {len(log.entries)}"
         assert log.verify(), "Hash chain verification failed"
 
         # First entry must have no previous hash
@@ -106,7 +104,7 @@ class TestAuditTamperDetection:
         jsonl_path = jsonl_files[0]
 
         lines = jsonl_path.read_text(encoding="utf-8").strip().split("\n")
-        assert len(lines) >= 2
+        assert len(lines) == 2
 
         # Modify the action field of the first entry
         first_entry = json.loads(lines[0])
@@ -148,7 +146,7 @@ class TestAuditQueryByAction:
             )
             assert not result.isError, f"Query failed: {_get_text(result)}"
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 1
+            assert len(entries) == 1
             for entry in entries:
                 assert entry["action"] == "file_read"
 
@@ -181,7 +179,7 @@ class TestAuditQueryByResult:
             )
             assert not result.isError, f"Query failed: {_get_text(result)}"
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 1
+            assert len(entries) == 1
             for entry in entries:
                 assert entry["result"] == "denied"
 
@@ -191,7 +189,7 @@ class TestAuditQueryByResult:
                 {"result": "allowed"},
             )
             allowed_entries = json.loads(_get_text(result_allowed))
-            assert len(allowed_entries) >= 1
+            assert len(allowed_entries) == 1
             for entry in allowed_entries:
                 assert entry["result"] == "allowed"
 
@@ -268,7 +266,7 @@ class TestAuditPersistence:
 
         # Server has stopped -- load entries from disk
         log = _load_audit_log(audit_dir)
-        assert len(log.entries) >= len(actions_recorded)
+        assert len(log.entries) == len(actions_recorded)
         assert log.verify(), "Hash chain should be valid after reload"
 
         # Verify the persisted entries contain our commands

--- a/tests/e2e/test_dual_layer.py
+++ b/tests/e2e/test_dual_layer.py
@@ -120,8 +120,8 @@ class TestMCPBlocksShellWhileProxyAllowsClean:
         # Verify separate JSONL files
         mcp_files = list(audit_dir.glob("ag-*.jsonl"))
         proxy_files = list(audit_dir.glob("proxy-*.jsonl"))
-        assert len(mcp_files) >= 1, "Expected at least one MCP audit file"
-        assert len(proxy_files) >= 1, "Expected at least one proxy audit file"
+        assert len(mcp_files) == 1, "Expected at least one MCP audit file"
+        assert len(proxy_files) == 1, "Expected at least one proxy audit file"
 
         # Verify audit content
         mcp_entries = _mcp_audit_entries(audit_dir)
@@ -163,7 +163,7 @@ class TestMCPBlocksShellWhileProxyAllowsClean:
 
         # Load and verify each chain independently
         audit_logs = AuditLog.load_directory(audit_dir)
-        assert len(audit_logs) >= 2, "Expected at least 2 audit log files"
+        assert len(audit_logs) == 2, "Expected at least 2 audit log files"
 
         for log in audit_logs:
             assert log.verify(), (
@@ -348,7 +348,7 @@ class TestBothLayersDenySimultaneously:
         # denied_by in metadata (only the proxy middleware does).
         mcp_entries = _mcp_audit_entries(audit_dir)
         mcp_denied = [e for e in mcp_entries if e["result"] == "denied"]
-        assert len(mcp_denied) >= 1
+        assert len(mcp_denied) == 1
         assert any(e["action"] == "file_write" for e in mcp_denied), (
             f"Expected denied file_write in MCP entries: {mcp_denied}"
         )
@@ -357,7 +357,7 @@ class TestBothLayersDenySimultaneously:
         # Proxy middleware includes denied_by in metadata.
         proxy_entries = _proxy_audit_entries(audit_dir)
         proxy_denied = [e for e in proxy_entries if e["result"] == "denied"]
-        assert len(proxy_denied) >= 1
+        assert len(proxy_denied) == 1
         assert any(
             e.get("metadata", {}).get("denied_by") == "no-secret-in-prompt"
             for e in proxy_denied
@@ -416,8 +416,8 @@ class TestCombinedAuditTimeline:
         # Both file types must exist
         mcp_files = list(audit_dir.glob("ag-*.jsonl"))
         proxy_files = list(audit_dir.glob("proxy-*.jsonl"))
-        assert len(mcp_files) >= 1
-        assert len(proxy_files) >= 1
+        assert len(mcp_files) == 1
+        assert len(proxy_files) == 1
 
     @pytest.mark.anyio()
     async def test_sg_14_4_complete_timeline(
@@ -474,8 +474,8 @@ class TestCombinedAuditTimeline:
         assert "denied" in results
 
         # At least 5 entries: 3 MCP + 2 proxy
-        assert len(all_entries) >= 5, (
-            f"Expected >= 5 audit entries, got {len(all_entries)}: {actions}"
+        assert len(all_entries) == 5, (
+            f"Expected 5 audit entries, got {len(all_entries)}: {actions}"
         )
 
     @pytest.mark.anyio()
@@ -509,7 +509,7 @@ class TestCombinedAuditTimeline:
 
         # Every audit log file must have a valid chain
         audit_logs = AuditLog.load_directory(audit_dir)
-        assert len(audit_logs) >= 2
+        assert len(audit_logs) == 2
 
         for log in audit_logs:
             assert log.verify(), (
@@ -546,7 +546,7 @@ class TestCombinedAuditTimeline:
             )
 
         all_entries = _audit_entries(audit_dir)
-        assert len(all_entries) >= 2
+        assert len(all_entries) == 2
 
         for entry in all_entries:
             assert "timestamp" in entry, f"Entry missing timestamp: {entry}"

--- a/tests/e2e/test_error_handling.py
+++ b/tests/e2e/test_error_handling.py
@@ -83,7 +83,7 @@ class TestFileReadErrors:
                 {"action": "file_read"},
             )
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 1
+            assert len(entries) == 1
             assert entries[-1]["result"] == "error"
 
         await _with_server(check, audit_dir=audit_dir)
@@ -195,7 +195,7 @@ class TestShellTimeout:
                 {"action": "shell_execute"},
             )
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 1
+            assert len(entries) == 1
             assert entries[-1]["result"] == "error"
 
         await _with_server(check, audit_dir=audit_dir)
@@ -273,7 +273,7 @@ class TestFileEditErrors:
                 {"action": "file_edit"},
             )
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 1
+            assert len(entries) == 1
             assert entries[-1]["result"] == "error"
 
         await _with_server(check, audit_dir=audit_dir)
@@ -409,7 +409,7 @@ class TestProxyMalformedInput:
 
         # Check audit log exists
         jsonl_files = list(audit_dir.glob("*.jsonl"))
-        assert len(jsonl_files) >= 1, "Expected audit log for empty-body request"
+        assert len(jsonl_files) == 1, "Expected audit log for empty-body request"
 
 
 class TestRapidSequentialCalls:

--- a/tests/e2e/test_infrastructure.py
+++ b/tests/e2e/test_infrastructure.py
@@ -137,7 +137,7 @@ class TestRsnPolicies:
     def test_policies_copied(self, rsn_policies: Path) -> None:
         """All built-in policy YAML files are copied."""
         yaml_files = list(rsn_policies.glob("*.yaml"))
-        assert len(yaml_files) >= 4
+        assert len(yaml_files) == 11
         names = {f.stem for f in yaml_files}
         assert "no-force-push" in names
         assert "no-secret-in-prompt" in names

--- a/tests/e2e/test_mcp_file_ops.py
+++ b/tests/e2e/test_mcp_file_ops.py
@@ -197,7 +197,7 @@ class TestFileReadAudit:
             entries = json.loads(
                 audit_result.content[0].text  # type: ignore[union-attr]
             )
-            assert len(entries) >= 1
+            assert len(entries) == 1
             read_entry = entries[-1]
             assert read_entry["action"] == "file_read"
             assert read_entry["result"] == "allowed"

--- a/tests/e2e/test_opencode_integration.py
+++ b/tests/e2e/test_opencode_integration.py
@@ -203,7 +203,7 @@ class TestFileWorkflow:
                 {"action": "file_write"},
             )
             write_entries = json.loads(_get_text(write_result))
-            assert len(write_entries) >= 1
+            assert len(write_entries) == 1
             assert write_entries[-1]["result"] == "allowed"
 
             read_result = await session.call_tool(
@@ -211,7 +211,7 @@ class TestFileWorkflow:
                 {"action": "file_read"},
             )
             read_entries = json.loads(_get_text(read_result))
-            assert len(read_entries) >= 1
+            assert len(read_entries) == 1
             assert read_entries[-1]["result"] == "allowed"
 
         await _with_server(
@@ -253,7 +253,7 @@ class TestShellWorkflow:
                 {"action": "shell_execute"},
             )
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 1
+            assert len(entries) == 1
             assert entries[-1]["result"] == "allowed"
             assert "python3 --version" in entries[-1]["target"]
 
@@ -318,7 +318,7 @@ class TestPolicyEnforcement:
                 {"result": "denied"},
             )
             denied_entries = json.loads(_get_text(result))
-            assert len(denied_entries) >= 1
+            assert len(denied_entries) == 1
             assert denied_entries[-1]["action"] == "file_write"
 
         await _with_server(
@@ -453,7 +453,7 @@ class TestAuditAccumulation:
                 {},
             )
             entries = json.loads(_get_text(result))
-            # 4 tool calls above + this query itself
+            # 4 tool calls above; the query itself may also appear
             assert len(entries) >= 4, (
                 f"Expected at least 4 audit entries, got {len(entries)}"
             )
@@ -502,7 +502,7 @@ class TestAuditAccumulation:
         jsonl_files = list(audit_dir.glob("*.jsonl"))
         assert len(jsonl_files) == 1, f"Expected 1 JSONL file, found {len(jsonl_files)}"
         log = AuditLog.load(jsonl_files[0], session_id=jsonl_files[0].stem)
-        assert len(log.entries) >= 3
+        assert len(log.entries) == 3
         assert log.verify(), "Hash chain verification failed"
 
 
@@ -524,8 +524,8 @@ class TestStatusTool:
             assert "policies_loaded" in status
             assert "policy_names" in status
             # Permissive preset loads 3 policies
-            assert status["policies_loaded"] >= 3
-            assert len(status["policy_names"]) >= 3
+            assert status["policies_loaded"] == 3
+            assert len(status["policy_names"]) == 3
 
         await _with_server(
             check, audit_dir=audit_dir, preset="permissive", actor="opencode-agent"

--- a/tests/e2e/test_policy_engine.py
+++ b/tests/e2e/test_policy_engine.py
@@ -290,7 +290,7 @@ class TestCombinedSources:
 
             names = data["policy_names"]
             # Must have the 3 permissive policies + 1 custom
-            assert data["policies_loaded"] >= 4
+            assert data["policies_loaded"] == 4
             assert "test-custom-echo-deny" in names
             for expected in PRESET_POLICIES[Preset.PERMISSIVE]:
                 assert expected in names

--- a/tests/e2e/test_proxy_auth.py
+++ b/tests/e2e/test_proxy_auth.py
@@ -374,7 +374,7 @@ async def test_upstream_failure_audit_entry(
     # Verify audit log recorded the error
     middleware._save_audit()
     audit_files = list(audit_dir.glob("*.jsonl"))
-    assert len(audit_files) >= 1
+    assert len(audit_files) == 1
 
     all_entries: list[dict[str, Any]] = []
     for af in audit_files:
@@ -383,7 +383,7 @@ async def test_upstream_failure_audit_entry(
                 all_entries.append(json.loads(line))
 
     error_entries = [e for e in all_entries if e.get("result") == "error"]
-    assert len(error_entries) >= 1
+    assert len(error_entries) == 1
     assert "Connection refused" in error_entries[0].get("metadata", {}).get("error", "")
 
 

--- a/tests/e2e/test_proxy_inbound.py
+++ b/tests/e2e/test_proxy_inbound.py
@@ -90,7 +90,7 @@ class TestNonStreamingInjection:
         # Verify audit entry
         entries = _audit_entries(audit_dir)
         denied = [e for e in entries if e.get("result") == "denied"]
-        assert len(denied) >= 1
+        assert len(denied) == 1
         assert denied[-1].get("action") == "llm_response"
 
 
@@ -131,7 +131,7 @@ class TestStreamingInjectionAcrossChunks:
 
         # Find the injected error event
         error_events = [e for e in events if "response blocked by policy" in e]
-        assert len(error_events) >= 1
+        assert len(error_events) == 1
 
         error_data = json.loads(error_events[0])
         assert error_data["policy"] == "no-prompt-injection"
@@ -188,10 +188,10 @@ class TestCleanStreamingPasses:
         # Stream ends with [DONE]
         assert events[-1] == "[DONE]"
 
-        # Audit entry recorded as allowed
+        # Audit entry recorded as allowed (outbound request + inbound response)
         entries = _audit_entries(audit_dir)
         allowed = [e for e in entries if e.get("result") == "allowed"]
-        assert len(allowed) >= 1
+        assert len(allowed) == 2
 
 
 class TestInboundScanningDisabled:
@@ -281,7 +281,7 @@ class TestLargeChunkResponse:
         content_events = [
             e for e in events if e != "[DONE]" and "chatcmpl-final" not in e
         ]
-        assert len(content_events) >= 120
+        assert len(content_events) == 120
 
         # Stream ends with [DONE]
         assert events[-1] == "[DONE]"

--- a/tests/e2e/test_proxy_outbound.py
+++ b/tests/e2e/test_proxy_outbound.py
@@ -205,7 +205,7 @@ class TestCleanPromptAllowed:
         # Verify audit entry recorded as allowed
         entries = _audit_entries(audit_dir)
         allowed = [e for e in entries if e.get("result") == "allowed"]
-        assert len(allowed) >= 1
+        assert len(allowed) == 1
 
 
 class TestScanningDisabled:

--- a/tests/e2e/test_proxy_streaming.py
+++ b/tests/e2e/test_proxy_streaming.py
@@ -113,7 +113,7 @@ async def test_all_chunks_in_order(
     events = _parse_sse_events(resp.text)
 
     # Should have all content chunks + done_chunk + [DONE]
-    assert len(events) >= 4
+    assert len(events) == 5
 
     # Verify content order by extracting delta content from each event
     contents: list[str] = []

--- a/tests/e2e/test_regression.py
+++ b/tests/e2e/test_regression.py
@@ -211,7 +211,7 @@ class TestR6AuditHashChain:
         await _with_server(run, audit_dir=audit_dir, preset="permissive")
 
         audit_logs = AuditLog.load_directory(audit_dir)
-        assert len(audit_logs) >= 1
+        assert len(audit_logs) == 1
         for log in audit_logs:
             assert log.verify(), "Audit hash chain verification failed"
 
@@ -302,11 +302,11 @@ class TestR9TrustDetectsTampering:
 
         # Tamper with the audit file
         audit_files = list(audit_dir.glob("ag-*.jsonl"))
-        assert len(audit_files) >= 1
+        assert len(audit_files) == 1
 
         content = audit_files[0].read_text()
         lines = content.strip().split("\n")
-        assert len(lines) >= 2
+        assert len(lines) == 2
 
         # Modify the second entry's action field
         entry = json.loads(lines[1])
@@ -316,7 +316,7 @@ class TestR9TrustDetectsTampering:
 
         # Verify detects tampering
         logs = AuditLog.load_directory(audit_dir)
-        assert len(logs) >= 1
+        assert len(logs) == 1
         # At least one log must fail verification after tampering
         assert any(not log.verify() for log in logs)
 

--- a/tests/e2e/test_rsn_policies.py
+++ b/tests/e2e/test_rsn_policies.py
@@ -349,8 +349,8 @@ class TestRsnPoliciesAlongsidePreset:
             for expected in rsn_expected:
                 assert expected in names, f"Missing RSN policy: {expected}"
 
-            # Total: 3 preset + 4 RSN = 7 minimum
-            assert data["policies_loaded"] >= 7
+            # Total: 3 preset + 4 RSN = 7
+            assert data["policies_loaded"] == 7
 
         await _with_server(
             check,

--- a/tests/e2e/test_trust_scanner.py
+++ b/tests/e2e/test_trust_scanner.py
@@ -193,7 +193,7 @@ class TestScanFindsRisks:
             data = json.loads(_get_text(result))
             assert data["finding_count"] > 0
             assert data["max_severity"] is not None
-            assert data["files_scanned"] >= 1
+            assert data["files_scanned"] > 0
 
             # Verify findings contain expected categories
             categories = {f["category"] for f in data["findings"]}
@@ -270,7 +270,7 @@ class TestScanCleanPackage:
             assert data["finding_count"] == 0
             assert data["findings"] == []
             assert data["max_severity"] is None
-            assert data["files_scanned"] >= 1
+            assert data["files_scanned"] > 0
 
         await _with_server(check, audit_dir=audit_dir, preset="permissive")
 


### PR DESCRIPTION
## Summary

- Tightened 44 loose `>=` assertions to exact `==` values across 14 E2E test files
- 3 assertions intentionally kept as `>=` where `agentguard_audit_query`'s own audit entry may/may not appear in results
- All 1,417 tests passing

## Details

Loose `>=` comparisons in audit entry counts, policy counts, and chunk counts hide regressions where values change unexpectedly. This PR replaces them with exact `==` checks so any change in behavior is immediately caught.

### Files changed (14)
| File | Changes |
|------|---------|
| `test_audit_e2e.py` | 8 assertions (2 kept as `>=`) |
| `test_dual_layer.py` | 10 assertions tightened |
| `test_error_handling.py` | 4 assertions tightened |
| `test_infrastructure.py` | 1: `>= 4` → `== 11` (built-in policies grew) |
| `test_mcp_file_ops.py` | 1 assertion tightened |
| `test_opencode_integration.py` | 7 tightened (1 kept as `>= 4`) |
| `test_policy_engine.py` | 1 assertion tightened |
| `test_proxy_auth.py` | 2 assertions tightened |
| `test_proxy_inbound.py` | 4 assertions tightened |
| `test_proxy_outbound.py` | 1 assertion tightened |
| `test_proxy_streaming.py` | 1: `>= 4` → `== 5` |
| `test_regression.py` | 4 assertions tightened |
| `test_rsn_policies.py` | 1: `>= 7` → `== 7` |
| `test_trust_scanner.py` | 2: `>= 1` → `> 0` |

### 3 intentionally kept `>=` assertions
These involve `agentguard_audit_query` tool where the query's own audit entry may or may not be included in the result set (timing-dependent):
- `test_audit_e2e.py:226` — SG-7.5: query by actor, query itself has same actor
- `test_audit_e2e.py:309` — SG-7.7: query with no filters
- `test_opencode_integration.py:457` — SG-10.6: 4 tool calls + query with no filters

Closes #142 #146 #160 #167 #175 #184 #190 #196 #197 #204 #205