### PR TITLE
fix: batch cleanup of review suggestions across 8 test files

### DIFF
--- a/tests/e2e/test_audit_e2e.py
+++ b/tests/e2e/test_audit_e2e.py
@@ -9,7 +9,7 @@ Test matrix:
   SG-7.3  Query by action type returns matching entries only
   SG-7.4  Query by result filters allowed vs denied
   SG-7.5  Query by actor returns entries with correct actor
-  SG-7.6  Entries persist to JSONL and survive server restart
+  SG-7.6  Entries persist to JSONL and survive server shutdown
   SG-7.7  agentguard_audit_query MCP tool returns entries
 """
 
@@ -221,7 +221,7 @@ class TestAuditQueryByActor:
             )
             assert not result.isError, f"Query failed: {_get_text(result)}"
             entries = json.loads(_get_text(result))
-            assert len(entries) >= 2
+            assert len(entries) == 2
             for entry in entries:
                 assert entry["actor"] == custom_actor
 
@@ -242,7 +242,7 @@ class TestAuditQueryByActor:
 
 
 class TestAuditPersistence:
-    """SG-7.6: Entries persist to JSONL and survive server restart."""
+    """SG-7.6: Entries persist to JSONL and survive server shutdown."""
 
     @pytest.mark.anyio()
     async def test_sg_7_6_entries_persist_across_restart(
@@ -303,8 +303,8 @@ class TestAuditMcpToolReturnsEntries:
             )
             assert not result.isError, f"Query failed: {_get_text(result)}"
             entries = json.loads(_get_text(result))
-            # At least the 2 actions we just performed
-            assert len(entries) >= 2
+            # Exactly the 2 actions we just performed
+            assert len(entries) == 2
 
             # Verify each entry has required fields
             required_fields = {

--- a/tests/e2e/test_dual_layer.py
+++ b/tests/e2e/test_dual_layer.py
@@ -120,8 +120,8 @@ class TestMCPBlocksShellWhileProxyAllowsClean:
         # Verify separate JSONL files
         mcp_files = list(audit_dir.glob("ag-*.jsonl"))
         proxy_files = list(audit_dir.glob("proxy-*.jsonl"))
-        assert len(mcp_files) == 1, "Expected at least one MCP audit file"
-        assert len(proxy_files) == 1, "Expected at least one proxy audit file"
+        assert len(mcp_files) == 1, "Expected exactly one MCP audit file"
+        assert len(proxy_files) == 1, "Expected exactly one proxy audit file"
 
         # Verify audit content
         mcp_entries = _mcp_audit_entries(audit_dir)

--- a/tests/e2e/test_mcp_shell_ops.py
+++ b/tests/e2e/test_mcp_shell_ops.py
@@ -155,7 +155,7 @@ class TestShellOutputCapture:
 
 
 class TestShellMultiplePolicies:
-    """SG-2.7: first matching deny policy wins."""
+    """SG-2.7: deny policy enforces command denial under strict preset."""
 
     @pytest.mark.anyio()
     async def test_sg_2_7_first_match_deny(self, audit_dir: Path) -> None:

--- a/tests/e2e/test_opencode_integration.py
+++ b/tests/e2e/test_opencode_integration.py
@@ -453,9 +453,9 @@ class TestAuditAccumulation:
                 {},
             )
             entries = json.loads(_get_text(result))
-            # 4 tool calls above; the query itself may also appear
-            assert len(entries) >= 4, (
-                f"Expected at least 4 audit entries, got {len(entries)}"
+            # 4 tool calls above; audit_query does not record itself
+            assert len(entries) == 4, (
+                f"Expected exactly 4 audit entries, got {len(entries)}"
             )
 
             # Verify chronological action sequence
@@ -574,7 +574,7 @@ class TestStatusTool:
             # Check count has increased
             result2 = await session.call_tool("agentguard_status", {})
             status2 = json.loads(_get_text(result2))
-            # initial status call + 2 shell_execute calls = +3 minimum
+            # 2 shell_execute calls = +2 (status does not record audit)
             assert status2.get("audit_entries", 0) > initial_count
 
         await _with_server(

--- a/tests/e2e/test_policy_engine.py
+++ b/tests/e2e/test_policy_engine.py
@@ -162,8 +162,7 @@ class TestAutoDiscoverProjectLocal:
         project_policy_dir = tmp_path / ".agentguard" / "policies"
         _write_policy_file(project_policy_dir, "custom.yaml", _VALID_POLICY_YAML)
 
-        monkeypatch.chdir(tmp_path)
-
+        # No monkeypatch.chdir needed: project_dir is passed explicitly
         policies = discover_policies(project_dir=project_policy_dir)
 
         assert len(policies) == 1

--- a/tests/e2e/test_proxy_streaming.py
+++ b/tests/e2e/test_proxy_streaming.py
@@ -147,7 +147,7 @@ async def test_slow_upstream_no_premature_timeout(
     tmp_path: Path,
 ) -> None:
     """A slow upstream that sends chunks with delays should not cause
-    a premature timeout. We use a custom mock with asyncio.sleep
+    a premature timeout. We use a custom mock with anyio.sleep
     between chunks to simulate a slow upstream.
     """
     from starlette.applications import Starlette

--- a/tests/e2e/test_trust_scanner.py
+++ b/tests/e2e/test_trust_scanner.py
@@ -224,8 +224,8 @@ class TestScanMinSeverityFilter:
             all_severities = {f["severity"] for f in all_data["findings"]}
 
             # Confirm we have mixed severities (medium and higher)
-            assert "medium" in all_severities or "low" in all_severities, (
-                "Test requires mixed severities to validate filtering"
+            assert "medium" in all_severities, (
+                "Test requires medium severity to validate filtering"
             )
 
             # Now scan with min_severity=high

--- a/tests/unit/test_scanner_engine.py
+++ b/tests/unit/test_scanner_engine.py
@@ -319,6 +319,7 @@ class TestSymlinkHandling:
         # Only the file under real_dir should be found
         assert result.finding_count == 1
         assert "real_dir" in result.findings[0].file_path
+        assert "link_dir" not in result.findings[0].file_path
 
     def test_symlink_to_outside_package_is_skipped(self, tmp_path: Path) -> None:
         """Symlinks pointing outside the package root are skipped."""


### PR DESCRIPTION
## Summary

Batch cleanup of 9 review-suggestion fixes across 8 test files. Third and final batch PR for the `review.cleanup` roadmap task.

## Changes

| Fix | File | Issue |
|-----|------|-------|
| Assertion messages: "at least one" → "exactly one" | `test_dual_layer.py` | #213 |
| Tighten `>= 2` → `== 2` (audit_query by actor) | `test_audit_e2e.py:224` | #215 |
| Tighten `>= 2` → `== 2` (audit_query no filter) | `test_audit_e2e.py:307` | #215 |
| Tighten `>= 4` → `== 4` (audit_query no filter) | `test_opencode_integration.py:457` | #215 |
| Fix comment: "+3 minimum" → "+2 (status doesn't audit)" | `test_opencode_integration.py:577` | #185 |
| Fix docstring: "asyncio.sleep" → "anyio.sleep" | `test_proxy_streaming.py:150` | #127 |
| Remove dead code: `or "low" in all_severities` | `test_trust_scanner.py:227` | #176 |
| Remove redundant `monkeypatch.chdir` | `test_policy_engine.py:165` | #153 |
| Fix test class title: accurate description | `test_mcp_shell_ops.py:158` | #136 |
| Fix test title: "survive server restart" → "shutdown" | `test_audit_e2e.py:12,245` | #166 |
| Add negative assertion for symlink test | `test_scanner_engine.py:321` | #95 |

All 1,417 tests passing. No behavior changes — test-only fixes.

Closes #95, #127, #136, #153, #166, #176, #185, #213, #215