### PR TITLE
fix: batch cleanup of review suggestions — source and test fixes

### DIFF
--- a/src/agentguard/audit/log.py
+++ b/src/agentguard/audit/log.py
@@ -149,7 +149,7 @@ class AuditLog:
             FileNotFoundError: If the directory does not exist.
         """
         dir_path = Path(path)
-        if not dir_path.exists():
+        if not dir_path.is_dir():
             msg = f"Audit directory not found: {dir_path}"
             raise FileNotFoundError(msg)
 

--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -667,7 +667,7 @@ def _cmd_audit_report(args: argparse.Namespace) -> int:
     from agentguard.audit.report import generate_cross_session_report
 
     directory = Path(args.directory)
-    if not directory.exists():
+    if not directory.is_dir():
         print(f"Error: Audit directory not found: {args.directory}", file=sys.stderr)
         return 1
 

--- a/tests/e2e/test_dual_layer.py
+++ b/tests/e2e/test_dual_layer.py
@@ -472,6 +472,8 @@ class TestCombinedAuditTimeline:
         # Both allowed and denied present
         assert "allowed" in results
         assert "denied" in results
+        assert results.count("denied") >= 1, "Expected at least one denial"
+        assert results.count("allowed") >= 1, "Expected at least one allowed action"
 
         # At least 5 entries: 3 MCP + 2 proxy
         assert len(all_entries) == 5, (

--- a/tests/e2e/test_mcp_file_ops.py
+++ b/tests/e2e/test_mcp_file_ops.py
@@ -261,6 +261,7 @@ class TestFileGrep:
             assert not result.isError
             text = result.content[0].text  # type: ignore[union-attr]
             assert "hello" in text
+            assert "search_me.py" in text
 
         await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 

--- a/tests/e2e/test_opencode_integration.py
+++ b/tests/e2e/test_opencode_integration.py
@@ -331,78 +331,72 @@ class TestAutoDiscover:
 
     @pytest.mark.anyio()
     async def test_sg_10_5_project_local_policy_blocks_command(
-        self, auto_discover_policy_dir: Path, audit_dir: Path
+        self,
+        auto_discover_policy_dir: Path,
+        audit_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A project-local RSN policy blocks a shell command."""
-        import os
-
         # auto_discover looks at CWD/.agentguard/policies/
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(str(auto_discover_policy_dir))
+        monkeypatch.chdir(str(auto_discover_policy_dir))
 
-            async def check(session: ClientSession) -> None:
-                result = await session.call_tool(
-                    "shell_execute",
-                    {"command": "git add private/secrets.txt"},
-                )
-                assert result.isError, "Expected denial by rsn-no-private-commit policy"
-                assert "denied by policy" in _get_text(result)
-
-            await _with_server(
-                check,
-                audit_dir=audit_dir,
-                preset="permissive",
-                actor="opencode-agent",
-                auto_discover=True,
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "shell_execute",
+                {"command": "git add private/secrets.txt"},
             )
-        finally:
-            os.chdir(original_cwd)
+            assert result.isError, "Expected denial by rsn-no-private-commit policy"
+            assert "denied by policy" in _get_text(result)
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            preset="permissive",
+            actor="opencode-agent",
+            auto_discover=True,
+        )
 
     @pytest.mark.anyio()
     async def test_sg_10_5_auto_discover_combines_with_preset(
-        self, auto_discover_policy_dir: Path, audit_dir: Path
+        self,
+        auto_discover_policy_dir: Path,
+        audit_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Auto-discovered policies work alongside preset policies."""
-        import os
+        monkeypatch.chdir(str(auto_discover_policy_dir))
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(str(auto_discover_policy_dir))
-
-            async def check(session: ClientSession) -> None:
-                # Preset permissive still blocks force-push
-                force_push = await session.call_tool(
-                    "shell_execute",
-                    {"command": "git push --force origin main"},
-                )
-                assert force_push.isError, "force-push should be denied by preset"
-
-                # Auto-discovered policy blocks private/ staging
-                private_add = await session.call_tool(
-                    "shell_execute",
-                    {"command": "git add private/data.yaml"},
-                )
-                assert private_add.isError, (
-                    "private/ staging should be denied by auto-discover"
-                )
-
-                # Clean commands still allowed
-                echo_result = await session.call_tool(
-                    "shell_execute",
-                    {"command": "echo both-sources-active"},
-                )
-                assert not echo_result.isError
-
-            await _with_server(
-                check,
-                audit_dir=audit_dir,
-                preset="permissive",
-                actor="opencode-agent",
-                auto_discover=True,
+        async def check(session: ClientSession) -> None:
+            # Preset permissive still blocks force-push
+            force_push = await session.call_tool(
+                "shell_execute",
+                {"command": "git push --force origin main"},
             )
-        finally:
-            os.chdir(original_cwd)
+            assert force_push.isError, "force-push should be denied by preset"
+
+            # Auto-discovered policy blocks private/ staging
+            private_add = await session.call_tool(
+                "shell_execute",
+                {"command": "git add private/data.yaml"},
+            )
+            assert private_add.isError, (
+                "private/ staging should be denied by auto-discover"
+            )
+
+            # Clean commands still allowed
+            echo_result = await session.call_tool(
+                "shell_execute",
+                {"command": "echo both-sources-active"},
+            )
+            assert not echo_result.isError
+
+        await _with_server(
+            check,
+            audit_dir=audit_dir,
+            preset="permissive",
+            actor="opencode-agent",
+            auto_discover=True,
+        )
 
 
 class TestAuditAccumulation:

--- a/tests/e2e/test_proxy_auth.py
+++ b/tests/e2e/test_proxy_auth.py
@@ -371,8 +371,7 @@ async def test_upstream_failure_audit_entry(
     assert error_data["error"] == "upstream request failed"
     assert "Connection refused" in error_data["detail"]
 
-    # Verify audit log recorded the error
-    middleware._save_audit()
+    # Verify audit log recorded the error (production code saves before returning 502)
     audit_files = list(audit_dir.glob("*.jsonl"))
     assert len(audit_files) == 1
 

--- a/tests/e2e/test_regression.py
+++ b/tests/e2e/test_regression.py
@@ -326,8 +326,8 @@ class TestR9TrustDetectsTampering:
 # ===========================================================================
 
 
-class TestR10RSNPoliciesDiscovered:
-    """R-10: RSN built-in policies are auto-discovered and loaded."""
+class TestR10PresetPolicyEnforcement:
+    """R-10: Preset policies are loaded and enforced."""
 
     @pytest.mark.anyio()
     async def test_rsn_policies_loaded(self, audit_dir: Path) -> None:

--- a/tests/e2e/test_trust_scanner.py
+++ b/tests/e2e/test_trust_scanner.py
@@ -128,8 +128,7 @@ class TestTrustRegisterServer:
 class TestTrustVerifyNoChanges:
     """SG-8.2: Verify integrity with no changes (hash matches)."""
 
-    @pytest.mark.anyio()
-    async def test_sg_8_2_verify_no_changes(
+    def test_sg_8_2_verify_no_changes(
         self,
         registry_path: Path,
         clean_package: Path,
@@ -149,8 +148,7 @@ class TestTrustVerifyNoChanges:
 class TestTrustVerifyDetectsModification:
     """SG-8.3: Verify detects modification (hash mismatch)."""
 
-    @pytest.mark.anyio()
-    async def test_sg_8_3_verify_detects_modification(
+    def test_sg_8_3_verify_detects_modification(
         self,
         registry_path: Path,
         clean_package: Path,


### PR DESCRIPTION
## Summary

Source and test fixes addressing review suggestions. Includes two source-level fixes (directory validation) and five test-level fixes.

## Changes

**Source fixes:**
- `audit/log.py`: use `is_dir()` instead of `exists()` for directory validation (#104)
- `cli.py`: use `is_dir()` instead of `exists()` for audit directory validation (#104)

**Test fixes:**
- `test_mcp_file_ops.py`: assert `file_grep` result includes filename (#119)
- `test_proxy_auth.py`: remove redundant `_save_audit()` — production code already saves before returning 502 (#125)
- `test_trust_scanner.py`: remove unnecessary `@pytest.mark.anyio` from synchronous tests (#171)
- `test_opencode_integration.py`: replace bare `os.chdir`/try/finally with `monkeypatch.chdir` (#183)
- `test_dual_layer.py`: add counted assertions for allowed/denied results (#198)
- `test_regression.py`: rename `TestR10RSNPoliciesDiscovered` → `TestR10PresetPolicyEnforcement` (#201)

Closes #104, #119, #125, #171, #183, #198, #201