### PR TITLE
test: strengthen SG-1.7 file_grep assertions

### DIFF
--- a/tests/e2e/test_mcp_file_ops.py
+++ b/tests/e2e/test_mcp_file_ops.py
@@ -294,8 +294,16 @@ class TestFileGrep:
             )
             assert not result.isError
             text = result.content[0].text  # type: ignore[union-attr]
-            assert "hello" in text
-            assert "search_me.py" in text
+            lines = text.strip().splitlines()
+            # Exactly 2 matches: lines 1 and 2 of search_me.py
+            assert len(lines) == 2
+            # Each line follows the format "<path>:<lineno>: <content>"
+            assert "search_me.py:1:" in lines[0]
+            assert "def hello():" in lines[0]
+            assert "search_me.py:2:" in lines[1]
+            assert "print('hello world')" in lines[1]
+            # No non-matching lines should appear
+            assert "goodbye" not in text
 
         await _with_server(check, load_builtins=True, audit_dir=audit_dir)
 


### PR DESCRIPTION
## Summary

Strengthens the SG-1.7 `file_grep` E2E test assertions per issue #119.

### Changes

The previous test only checked `"hello" in text` and `"search_me.py" in text` — minimal smoke-level assertions that could pass even with malformed output.

Now asserts:
- **Exact match count**: exactly 2 output lines (lines 1 and 2 of `search_me.py`)
- **Line number format**: `search_me.py:1:` and `search_me.py:2:` present in correct lines
- **Line content**: `def hello():` in first match, `print('hello world')` in second
- **Negative assertion**: `"goodbye"` does not appear (non-matching lines excluded)

### Test results

All 1,424 tests pass.

Closes #119