### PR TITLE
test: tighten SG-14.4 proxy denial assertion with specific entry verification

### DIFF
--- a/tests/e2e/test_dual_layer.py
+++ b/tests/e2e/test_dual_layer.py
@@ -472,8 +472,25 @@ class TestCombinedAuditTimeline:
         # Both allowed and denied present
         assert "allowed" in results
         assert "denied" in results
-        assert results.count("denied") >= 1, "Expected at least one denial"
-        assert results.count("allowed") >= 1, "Expected at least one allowed action"
+        # 2 denied: shell_execute (MCP) + ghp-token llm_request (proxy)
+        assert results.count("denied") == 2, (
+            f"Expected 2 denials, got {results.count('denied')}"
+        )
+        # 3 allowed: file_write + file_read (MCP) + clean llm_request
+        assert results.count("allowed") == 3, (
+            f"Expected 3 allowed, got {results.count('allowed')}"
+        )
+
+        # Verify the specific proxy denial entry for the secret
+        proxy_denials = [
+            e
+            for e in all_entries
+            if e["action"] == "llm_request" and e["result"] == "denied"
+        ]
+        assert len(proxy_denials) == 1, (
+            f"Expected 1 proxy denial, got {len(proxy_denials)}"
+        )
+        assert proxy_denials[0]["metadata"]["denied_by"] == ("no-secret-in-prompt")
 
         # At least 5 entries: 3 MCP + 2 proxy
         assert len(all_entries) == 5, (


### PR DESCRIPTION
## Summary

Tightens the SG-14.4 `test_sg_14_4_complete_timeline` test to verify the specific proxy denial entry for the `ghp_` token, rather than just checking `"denied" in results`.

## Changes

- Add assertion that filters proxy denial entries (`action=llm_request`, `result=denied`) and verifies exactly 1 exists with `denied_by=no-secret-in-prompt`
- Tighten count assertions from `>= 1` to exact values: 2 denied (MCP shell + proxy ghp), 3 allowed (MCP write + read + proxy clean request)

All 1,424 tests passing. No behavior changes — test-only fix.

Closes #198