### PR TITLE
feat: audit log rotation (m8.audit-rotation)

### DIFF
--- a/src/agentguard/audit/__init__.py
+++ b/src/agentguard/audit/__init__.py
@@ -3,10 +3,12 @@
 from agentguard.audit.log import AuditLog
 from agentguard.audit.models import AuditEntry
 from agentguard.audit.report import CrossSessionReport, generate_cross_session_report
+from agentguard.audit.rotation import RotationConfig
 
 __all__ = [
     "AuditEntry",
     "AuditLog",
     "CrossSessionReport",
+    "RotationConfig",
     "generate_cross_session_report",
 ]

--- a/src/agentguard/audit/log.py
+++ b/src/agentguard/audit/log.py
@@ -7,6 +7,9 @@ tamper-evident, append-only log with hash chaining.
 from __future__ import annotations
 
 import json
+import time
+from datetime import datetime as _dt
+from datetime import timezone as _tz
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,6 +17,8 @@ from agentguard.audit.models import AuditEntry
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from agentguard.audit.rotation import RotationConfig
 
 
 class AuditLog:
@@ -103,7 +108,12 @@ class AuditLog:
                 line = json.dumps(entry.to_dict(), ensure_ascii=True)
                 f.write(line + "\n")
 
-    def append(self, path: str | Path) -> None:
+    def append(
+        self,
+        path: str | Path,
+        *,
+        rotation: RotationConfig | None = None,
+    ) -> None:
         """Append only new entries to a JSONL file.
 
         Writes entries added since the last ``append()`` call using
@@ -111,12 +121,19 @@ class AuditLog:
         entries are never rewritten. Creates the file and parent
         directories if they don't exist.
 
+        When *rotation* is provided and the existing file exceeds
+        the configured thresholds, the current file is renamed to
+        ``{stem}.{timestamp}.jsonl`` before writing. The in-memory
+        hash chain is unaffected — only file splitting changes.
+
         This is the preferred persistence method during a session
         because it provides true append-only semantics at the
         filesystem level.
 
         Args:
             path: File path to append to.
+            rotation: Optional rotation config. When set, the file
+                is rotated if it exceeds size or age thresholds.
         """
         new_entries = self._entries[self._persisted_count :]
         if not new_entries:
@@ -124,6 +141,16 @@ class AuditLog:
 
         file_path = Path(path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Rotate the existing file if thresholds are exceeded.
+        if rotation is not None and file_path.exists():
+            stat = file_path.stat()
+            file_age = time.time() - stat.st_mtime
+            if rotation.should_rotate(stat.st_size, file_age):
+                ts = _dt.now(_tz.utc).strftime("%Y%m%dT%H%M%S%f")
+                stem = file_path.stem
+                rotated = file_path.with_name(f"{stem}.{ts}.jsonl")
+                file_path.rename(rotated)
 
         with file_path.open("a", encoding="utf-8") as f:
             for entry in new_entries:

--- a/src/agentguard/audit/rotation.py
+++ b/src/agentguard/audit/rotation.py
@@ -1,0 +1,51 @@
+"""Audit log rotation configuration.
+
+Provides size-based and time-based rotation for JSONL audit files.
+The :class:`RotationConfig` is passed to :meth:`AuditLog.append` to
+control when the active log file is rotated to an archive file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RotationConfig:
+    """Configuration for audit log file rotation.
+
+    Rotation triggers when **either** threshold is exceeded.
+    With no thresholds set, rotation is disabled (the default).
+
+    Args:
+        max_bytes: Rotate when file size reaches this many bytes.
+            Must be positive if set.
+        max_age_seconds: Rotate when file age exceeds this many
+            seconds. Must be positive if set. Accepts float for
+            sub-second precision in tests.
+    """
+
+    max_bytes: int | None = None
+    max_age_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_bytes is not None and self.max_bytes <= 0:
+            msg = "max_bytes must be positive"
+            raise ValueError(msg)
+        if self.max_age_seconds is not None and self.max_age_seconds <= 0:
+            msg = "max_age_seconds must be positive"
+            raise ValueError(msg)
+
+    def should_rotate(self, file_bytes: int, file_age: float) -> bool:
+        """Return True if the file should be rotated.
+
+        Args:
+            file_bytes: Current file size in bytes.
+            file_age: File age in seconds since creation.
+
+        Returns:
+            True if either threshold is exceeded.
+        """
+        if self.max_bytes is not None and file_bytes >= self.max_bytes:
+            return True
+        return self.max_age_seconds is not None and file_age >= self.max_age_seconds

--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from agentguard.audit.log import AuditLog
     from agentguard.audit.models import AuditEntry
+    from agentguard.audit.rotation import RotationConfig
     from agentguard.trust.registry import TrustRegistry
 
 try:
@@ -349,6 +350,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "--trust-registry",
         help="Path to the trust registry YAML file.",
     )
+    serve_parser.add_argument(
+        "--max-log-bytes",
+        type=int,
+        default=None,
+        help="Rotate audit log when file exceeds this size in bytes.",
+    )
+    serve_parser.add_argument(
+        "--max-log-age",
+        type=float,
+        default=None,
+        help="Rotate audit log when file age exceeds this many seconds.",
+    )
 
     # --- report ---
     report_parser = subparsers.add_parser("report", help="Generate compliance reports.")
@@ -442,6 +455,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "--auth-provider",
         default="github-copilot",
         help=("Provider key to look up in the auth file (default: github-copilot)."),
+    )
+    proxy_parser.add_argument(
+        "--max-log-bytes",
+        type=int,
+        default=None,
+        help="Rotate audit log when file exceeds this size in bytes.",
+    )
+    proxy_parser.add_argument(
+        "--max-log-age",
+        type=float,
+        default=None,
+        help="Rotate audit log when file age exceeds this many seconds.",
     )
 
     return parser
@@ -933,6 +958,22 @@ def _cmd_scan(args: argparse.Namespace) -> int:
     return 1 if result.findings else 0
 
 
+def _build_rotation_config(
+    args: argparse.Namespace,
+) -> RotationConfig | None:
+    """Build a RotationConfig from CLI args, or None."""
+    from agentguard.audit.rotation import RotationConfig
+
+    max_bytes = getattr(args, "max_log_bytes", None)
+    max_age = getattr(args, "max_log_age", None)
+    if max_bytes is None and max_age is None:
+        return None
+    return RotationConfig(
+        max_bytes=max_bytes,
+        max_age_seconds=max_age,
+    )
+
+
 def _cmd_serve(args: argparse.Namespace) -> int:
     """Start the AgentGuard MCP server."""
     if create_server is None:
@@ -960,6 +1001,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         return 1
 
     try:
+        rotation = _build_rotation_config(args)
         app = create_server(
             policy_dir=policy_dir,
             audit_dir=getattr(args, "audit_dir", None),
@@ -968,6 +1010,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             auto_discover=args.auto_discover,
             preset=preset,
             trust_registry=getattr(args, "trust_registry", None),
+            rotation=rotation,
         )
         app.run()
     except ImportError:
@@ -1043,6 +1086,7 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
             )
             return 1
 
+        rotation = _build_rotation_config(args)
         config = ProxyConfig(
             upstream_base_url=args.upstream,
             host=args.host,
@@ -1057,6 +1101,7 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
             timeout=args.timeout,
             auth_file=getattr(args, "auth_file", None),
             auth_provider=getattr(args, "auth_provider", "github-copilot"),
+            rotation=rotation,
         )
         app = create_proxy_app(config)
 

--- a/src/agentguard/mcp/server.py
+++ b/src/agentguard/mcp/server.py
@@ -16,13 +16,16 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
 
 from agentguard.audit.log import AuditLog
 from agentguard.policies.builtins import load_all_builtins
 from agentguard.policies.guard import Guard
+
+if TYPE_CHECKING:
+    from agentguard.audit.rotation import RotationConfig
 
 
 def create_server(
@@ -33,6 +36,7 @@ def create_server(
     auto_discover: bool = False,
     preset: str | None = None,
     trust_registry: str | None = None,
+    rotation: RotationConfig | None = None,
 ) -> FastMCP:
     """Create an AgentGuard MCP server.
 
@@ -52,6 +56,9 @@ def create_server(
         trust_registry: Path to the trust registry YAML file.
             If None, uses the default location
             (``~/.agentguard/trust-registry.yaml``).
+        rotation: Optional audit log rotation config. When set,
+            audit files are rotated when they exceed size or age
+            thresholds.
 
     Returns:
         A FastMCP application with tools registered.
@@ -140,7 +147,10 @@ def create_server(
         if audit_dir is not None:
             audit_path = Path(audit_dir)
             audit_path.mkdir(parents=True, exist_ok=True)
-            audit_log.append(audit_path / f"{session_id}.jsonl")
+            audit_log.append(
+                audit_path / f"{session_id}.jsonl",
+                rotation=rotation,
+            )
 
     # --- create FastMCP app -------------------------------------------
 

--- a/src/agentguard/proxy/config.py
+++ b/src/agentguard/proxy/config.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentguard.audit.rotation import RotationConfig
 
 
 @dataclass
@@ -49,6 +53,9 @@ class ProxyConfig:
             "<token>", ...}}`` (OpenCode auth.json format).
         auth_provider: Provider key to look up in the auth file.
             Defaults to ``"github-copilot"``.
+        rotation: Optional audit log rotation config. When set,
+            audit files are rotated when they exceed size or age
+            thresholds.
     """
 
     upstream_base_url: str
@@ -66,6 +73,7 @@ class ProxyConfig:
     provider: str | None = None
     auth_file: str | None = None
     auth_provider: str = "github-copilot"
+    rotation: RotationConfig | None = None
 
     def __post_init__(self) -> None:
         """Validate configuration."""

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -589,4 +589,7 @@ class GuardMiddleware:
         if self.config.audit_dir is not None:
             audit_path = Path(self.config.audit_dir)
             audit_path.mkdir(parents=True, exist_ok=True)
-            self.audit_log.append(audit_path / f"{self.session_id}.jsonl")
+            self.audit_log.append(
+                audit_path / f"{self.session_id}.jsonl",
+                rotation=self.config.rotation,
+            )

--- a/tests/unit/test_audit_rotation.py
+++ b/tests/unit/test_audit_rotation.py
@@ -1,0 +1,435 @@
+"""Tests for audit log rotation (M8 — Audit Hardening).
+
+Covers:
+- RotationConfig data model
+- Size-based rotation during append()
+- Time-based rotation during append()
+- Rotated file naming and discovery
+- Hash chain integrity across rotated files
+- No rotation without config (backward compatibility)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from agentguard.audit.log import AuditLog
+from agentguard.audit.rotation import RotationConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestRotationConfig:
+    """RotationConfig data model."""
+
+    def test_default_values(self) -> None:
+        """Default config has no limits."""
+        cfg = RotationConfig()
+        assert cfg.max_bytes is None
+        assert cfg.max_age_seconds is None
+
+    def test_max_bytes_only(self) -> None:
+        cfg = RotationConfig(max_bytes=1024)
+        assert cfg.max_bytes == 1024
+        assert cfg.max_age_seconds is None
+
+    def test_max_age_seconds_only(self) -> None:
+        cfg = RotationConfig(max_age_seconds=3600)
+        assert cfg.max_age_seconds == 3600
+        assert cfg.max_bytes is None
+
+    def test_both_limits(self) -> None:
+        cfg = RotationConfig(max_bytes=1024, max_age_seconds=3600)
+        assert cfg.max_bytes == 1024
+        assert cfg.max_age_seconds == 3600
+
+    def test_max_bytes_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="max_bytes"):
+            RotationConfig(max_bytes=0)
+
+    def test_max_bytes_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_bytes"):
+            RotationConfig(max_bytes=-1)
+
+    def test_max_age_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="max_age_seconds"):
+            RotationConfig(max_age_seconds=0)
+
+    def test_max_age_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_age_seconds"):
+            RotationConfig(max_age_seconds=-1)
+
+    def test_should_rotate_no_limits(self) -> None:
+        """No limits means never rotate."""
+        cfg = RotationConfig()
+        assert cfg.should_rotate(file_bytes=999999, file_age=999999) is False
+
+    def test_should_rotate_by_size(self) -> None:
+        cfg = RotationConfig(max_bytes=100)
+        assert cfg.should_rotate(file_bytes=50, file_age=0) is False
+        assert cfg.should_rotate(file_bytes=100, file_age=0) is True
+        assert cfg.should_rotate(file_bytes=150, file_age=0) is True
+
+    def test_should_rotate_by_age(self) -> None:
+        cfg = RotationConfig(max_age_seconds=60)
+        assert cfg.should_rotate(file_bytes=0, file_age=30) is False
+        assert cfg.should_rotate(file_bytes=0, file_age=60) is True
+        assert cfg.should_rotate(file_bytes=0, file_age=120) is True
+
+    def test_should_rotate_either_triggers(self) -> None:
+        """Rotation triggers if EITHER limit is exceeded."""
+        cfg = RotationConfig(max_bytes=100, max_age_seconds=60)
+        # Neither exceeded
+        assert cfg.should_rotate(file_bytes=50, file_age=30) is False
+        # Size exceeded only
+        assert cfg.should_rotate(file_bytes=200, file_age=30) is True
+        # Age exceeded only
+        assert cfg.should_rotate(file_bytes=50, file_age=120) is True
+        # Both exceeded
+        assert cfg.should_rotate(file_bytes=200, file_age=120) is True
+
+
+class TestAppendWithRotation:
+    """Rotation during append()."""
+
+    def _record_entries(self, log: AuditLog, count: int) -> None:
+        """Record multiple entries into an audit log."""
+        for i in range(count):
+            log.record(
+                action=f"action-{i}",
+                actor="agent",
+                target=f"target-{i}",
+                result="allowed",
+            )
+
+    def test_no_rotation_without_config(self, tmp_path: Path) -> None:
+        """Without RotationConfig, append behaves as before."""
+        log_file = tmp_path / "session.jsonl"
+        log = AuditLog(session_id="test")
+        self._record_entries(log, 10)
+        log.append(log_file)
+
+        # Single file, all entries
+        jsonl_files = list(tmp_path.glob("*.jsonl"))
+        assert len(jsonl_files) == 1
+        lines = log_file.read_text().strip().split("\n")
+        assert len(lines) == 10
+
+    def test_size_rotation_creates_new_file(self, tmp_path: Path) -> None:
+        """When file exceeds max_bytes, rotation occurs."""
+        log_file = tmp_path / "session.jsonl"
+        cfg = RotationConfig(max_bytes=100)
+        log = AuditLog(session_id="test")
+
+        # Record one entry, append to create the file
+        log.record(
+            action="first",
+            actor="agent",
+            target="target",
+            result="allowed",
+        )
+        log.append(log_file, rotation=cfg)
+
+        # File should exist and be > 100 bytes (one JSON line)
+        assert log_file.exists()
+        first_size = log_file.stat().st_size
+        assert first_size > 100  # A single JSON entry is ~200 bytes
+
+        # Record another entry — should trigger rotation
+        log.record(
+            action="second",
+            actor="agent",
+            target="target",
+            result="allowed",
+        )
+        log.append(log_file, rotation=cfg)
+
+        # Now there should be 2 .jsonl files
+        jsonl_files = sorted(tmp_path.glob("*.jsonl"))
+        assert len(jsonl_files) == 2
+
+        # The active file should be the original name
+        assert log_file.exists()
+
+        # The rotated file should contain the old data
+        rotated = [f for f in jsonl_files if f != log_file]
+        assert len(rotated) == 1
+        rotated_lines = rotated[0].read_text().strip().split("\n")
+        assert len(rotated_lines) == 1
+        assert json.loads(rotated_lines[0])["action"] == "first"
+
+        # The active file should contain the new entry
+        active_lines = log_file.read_text().strip().split("\n")
+        assert len(active_lines) == 1
+        assert json.loads(active_lines[0])["action"] == "second"
+
+    def test_rotated_file_naming(self, tmp_path: Path) -> None:
+        """Rotated files follow {session_id}.{timestamp}.jsonl."""
+        log_file = tmp_path / "my-session.jsonl"
+        cfg = RotationConfig(max_bytes=1)  # Force immediate rotation
+        log = AuditLog(session_id="my-session")
+
+        log.record(action="a", actor="x", target="t", result="ok")
+        log.append(log_file, rotation=cfg)
+
+        # Force rotation on next append
+        log.record(action="b", actor="x", target="t", result="ok")
+        log.append(log_file, rotation=cfg)
+
+        rotated = [f for f in sorted(tmp_path.glob("*.jsonl")) if f != log_file]
+        assert len(rotated) == 1
+        # Name should start with session_id and have a timestamp
+        name = rotated[0].stem  # e.g. my-session.20260316T010203
+        assert name.startswith("my-session.")
+
+    def test_multiple_rotations(self, tmp_path: Path) -> None:
+        """Multiple rotations produce multiple archived files."""
+        log_file = tmp_path / "sess.jsonl"
+        cfg = RotationConfig(max_bytes=1)  # Rotate every time
+        log = AuditLog(session_id="sess")
+
+        for i in range(5):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(log_file, rotation=cfg)
+            # Small delay to ensure unique timestamps
+            time.sleep(0.01)
+
+        jsonl_files = list(tmp_path.glob("*.jsonl"))
+        # Should have 1 active + 4 rotated files
+        assert len(jsonl_files) == 5
+
+        # Active file should have exactly 1 entry (the last one)
+        active_lines = log_file.read_text().strip().split("\n")
+        assert len(active_lines) == 1
+        assert json.loads(active_lines[0])["action"] == "a4"
+
+    def test_all_entries_preserved_after_rotation(self, tmp_path: Path) -> None:
+        """Total entries across all files equals entries recorded."""
+        log_file = tmp_path / "sess.jsonl"
+        cfg = RotationConfig(max_bytes=1)  # Rotate every time
+        log = AuditLog(session_id="sess")
+
+        for i in range(5):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(log_file, rotation=cfg)
+            time.sleep(0.01)
+
+        # Load all files in the directory
+        total_entries = 0
+        for f in tmp_path.glob("*.jsonl"):
+            lines = f.read_text().strip().split("\n")
+            total_entries += len(lines)
+        assert total_entries == 5
+
+    def test_load_directory_includes_rotated(self, tmp_path: Path) -> None:
+        """load_directory() picks up rotated files."""
+        log_file = tmp_path / "sess.jsonl"
+        cfg = RotationConfig(max_bytes=1)
+        log = AuditLog(session_id="sess")
+
+        for i in range(3):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(log_file, rotation=cfg)
+            time.sleep(0.01)
+
+        logs = AuditLog.load_directory(tmp_path)
+        total = sum(len(lg.entries) for lg in logs)
+        assert total == 3
+
+    def test_rotation_preserves_chain_in_memory(self, tmp_path: Path) -> None:
+        """In-memory hash chain remains valid after rotation."""
+        log_file = tmp_path / "sess.jsonl"
+        cfg = RotationConfig(max_bytes=1)
+        log = AuditLog(session_id="sess")
+
+        for i in range(5):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(log_file, rotation=cfg)
+            time.sleep(0.01)
+
+        # In-memory chain should be fully intact
+        assert log.verify() is True
+        assert len(log.entries) == 5
+
+    def test_each_rotated_file_is_loadable(self, tmp_path: Path) -> None:
+        """Each rotated file loads independently."""
+        log_file = tmp_path / "sess.jsonl"
+        cfg = RotationConfig(max_bytes=1)
+        log = AuditLog(session_id="sess")
+
+        for i in range(3):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(log_file, rotation=cfg)
+            time.sleep(0.01)
+
+        for f in tmp_path.glob("*.jsonl"):
+            loaded = AuditLog.load(f, session_id=f.stem)
+            assert len(loaded.entries) >= 1
+
+    def test_no_rotation_when_file_does_not_exist(self, tmp_path: Path) -> None:
+        """First append creates file without rotation check."""
+        log_file = tmp_path / "new.jsonl"
+        cfg = RotationConfig(max_bytes=1)  # Tiny limit
+        log = AuditLog(session_id="new")
+
+        log.record(
+            action="first",
+            actor="x",
+            target="t",
+            result="ok",
+        )
+        log.append(log_file, rotation=cfg)
+
+        # Should create the file with 1 entry, no rotation
+        jsonl_files = list(tmp_path.glob("*.jsonl"))
+        assert len(jsonl_files) == 1
+        assert jsonl_files[0] == log_file
+
+    def test_age_rotation(self, tmp_path: Path) -> None:
+        """Time-based rotation triggers when file age exceeds limit."""
+        log_file = tmp_path / "sess.jsonl"
+        # Use age-based rotation with a very short threshold
+        cfg = RotationConfig(max_age_seconds=0.05)
+        log = AuditLog(session_id="sess")
+
+        log.record(
+            action="old",
+            actor="x",
+            target="t",
+            result="ok",
+        )
+        log.append(log_file, rotation=cfg)
+
+        # Wait for the file to "age"
+        time.sleep(0.1)
+
+        log.record(
+            action="new",
+            actor="x",
+            target="t",
+            result="ok",
+        )
+        log.append(log_file, rotation=cfg)
+
+        jsonl_files = list(tmp_path.glob("*.jsonl"))
+        assert len(jsonl_files) == 2
+
+    def test_append_without_rotation_kwarg(self, tmp_path: Path) -> None:
+        """append() without rotation= still works (backward compat)."""
+        log_file = tmp_path / "sess.jsonl"
+        log = AuditLog(session_id="sess")
+        log.record(action="a", actor="x", target="t", result="ok")
+        log.append(log_file)  # No rotation kwarg
+        assert log_file.exists()
+        lines = log_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+
+    def test_batch_entries_written_after_rotation(self, tmp_path: Path) -> None:
+        """Multiple new entries are written correctly after rotation."""
+        log_file = tmp_path / "sess.jsonl"
+        cfg = RotationConfig(max_bytes=1)
+        log = AuditLog(session_id="sess")
+
+        # First append — creates file
+        log.record(
+            action="a0",
+            actor="x",
+            target="t",
+            result="ok",
+        )
+        log.append(log_file, rotation=cfg)
+
+        # Record 3 entries at once, then append
+        for i in range(1, 4):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+        log.append(log_file, rotation=cfg)
+
+        # Active file should contain the 3 new entries
+        active_lines = log_file.read_text().strip().split("\n")
+        assert len(active_lines) == 3
+
+        # Rotated file should contain the first entry
+        rotated = [f for f in sorted(tmp_path.glob("*.jsonl")) if f != log_file]
+        assert len(rotated) == 1
+        rotated_lines = rotated[0].read_text().strip().split("\n")
+        assert len(rotated_lines) == 1
+
+
+class TestRotationCLI:
+    """CLI integration for rotation config."""
+
+    def test_serve_accepts_rotation_flags(self) -> None:
+        """CLI serve command accepts --max-log-bytes
+        and --max-log-age flags."""
+        from agentguard.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "serve",
+                "--audit-dir",
+                "/tmp/audit",
+                "--max-log-bytes",
+                "1048576",
+                "--max-log-age",
+                "3600",
+            ]
+        )
+        assert args.max_log_bytes == 1048576
+        assert args.max_log_age == 3600
+
+    def test_proxy_accepts_rotation_flags(self) -> None:
+        """CLI proxy command accepts --max-log-bytes
+        and --max-log-age flags."""
+        from agentguard.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "proxy",
+                "http://localhost:8080",
+                "--audit-dir",
+                "/tmp/audit",
+                "--max-log-bytes",
+                "1048576",
+                "--max-log-age",
+                "3600",
+            ]
+        )
+        assert args.max_log_bytes == 1048576
+        assert args.max_log_age == 3600

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -636,6 +636,7 @@ class TestServeCommand:
             auto_discover=False,
             preset=None,
             trust_registry=None,
+            rotation=None,
         )
         mock_app.run.assert_called_once()
 
@@ -673,6 +674,7 @@ class TestServeCommand:
             auto_discover=True,
             preset=None,
             trust_registry=None,
+            rotation=None,
         )
         mock_app.run.assert_called_once()
 
@@ -694,6 +696,7 @@ class TestServeCommand:
             auto_discover=False,
             preset=None,
             trust_registry=None,
+            rotation=None,
         )
 
     def test_serve_auto_discover_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -714,6 +717,7 @@ class TestServeCommand:
             auto_discover=True,
             preset=None,
             trust_registry=None,
+            rotation=None,
         )
 
     def test_serve_nonexistent_policy_dir(self) -> None:


### PR DESCRIPTION
## Summary

Add size-based and time-based audit log file rotation to prevent
unbounded log growth. When thresholds are exceeded, the current JSONL
file is renamed with a microsecond timestamp and new entries go to a
fresh file. Hash chain stays in memory; only file splitting changes
on disk.

## Changes

- **`src/agentguard/audit/rotation.py`** — New `RotationConfig` frozen
  dataclass with `max_bytes` and `max_age_seconds` thresholds, validation,
  and `should_rotate()` predicate.
- **`src/agentguard/audit/log.py`** — `append()` accepts optional
  `rotation: RotationConfig | None` kwarg; rotates file before writing
  when thresholds are exceeded.
- **`src/agentguard/audit/__init__.py`** — Exports `RotationConfig`.
- **`src/agentguard/cli.py`** — `--max-log-bytes` and `--max-log-age`
  flags on `serve` and `proxy` subcommands; `_build_rotation_config()`
  helper.
- **`src/agentguard/mcp/server.py`** — `create_server()` accepts and
  passes `rotation` config.
- **`src/agentguard/proxy/config.py`** — `ProxyConfig.rotation` field.
- **`src/agentguard/proxy/middleware.py`** — Passes rotation config
  through `_save_audit()`.

## Tests

26 new tests in `tests/unit/test_audit_rotation.py` covering:
- RotationConfig validation (positive values, defaults)
- `should_rotate()` predicate logic
- Size-based and age-based rotation during `append()`
- Multiple rotations produce multiple archive files
- All entries preserved across rotated files
- `load_directory()` discovers rotated files
- In-memory hash chain integrity after rotation
- Each rotated file loads independently
- CLI flag parsing for serve and proxy
- Backward compatibility (no rotation without config)

All 1,451 tests pass.