### PR TITLE
docs: fix should_rotate file_age docstring to match implementation

### DIFF
--- a/src/agentguard/audit/rotation.py
+++ b/src/agentguard/audit/rotation.py
@@ -41,7 +41,7 @@ class RotationConfig:
 
         Args:
             file_bytes: Current file size in bytes.
-            file_age: File age in seconds since creation.
+            file_age: Seconds since last file modification.
 
         Returns:
             True if either threshold is exceeded.


### PR DESCRIPTION
## Summary

- Fixed inaccurate docstring in `RotationConfig.should_rotate()`: changed `file_age` parameter description from "File age in seconds since creation" to "Seconds since last file modification" to match the actual `os.path.getmtime` implementation in `AuditLog.append()`.

Closes #228