### PR TITLE
feat: add audit log retention policy

### DIFF
--- a/src/agentguard/audit/__init__.py
+++ b/src/agentguard/audit/__init__.py
@@ -3,12 +3,15 @@
 from agentguard.audit.log import AuditLog
 from agentguard.audit.models import AuditEntry
 from agentguard.audit.report import CrossSessionReport, generate_cross_session_report
+from agentguard.audit.retention import RetentionConfig, enforce_retention
 from agentguard.audit.rotation import RotationConfig
 
 __all__ = [
     "AuditEntry",
     "AuditLog",
     "CrossSessionReport",
+    "RetentionConfig",
     "RotationConfig",
+    "enforce_retention",
     "generate_cross_session_report",
 ]

--- a/src/agentguard/audit/log.py
+++ b/src/agentguard/audit/log.py
@@ -18,6 +18,7 @@ from agentguard.audit.models import AuditEntry
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from agentguard.audit.retention import RetentionConfig
     from agentguard.audit.rotation import RotationConfig
 
 
@@ -113,6 +114,7 @@ class AuditLog:
         path: str | Path,
         *,
         rotation: RotationConfig | None = None,
+        retention: RetentionConfig | None = None,
     ) -> None:
         """Append only new entries to a JSONL file.
 
@@ -126,6 +128,9 @@ class AuditLog:
         ``{stem}.{timestamp}.jsonl`` before writing. The in-memory
         hash chain is unaffected — only file splitting changes.
 
+        When *retention* is provided, old rotated files are deleted
+        after rotation according to the retention policy.
+
         This is the preferred persistence method during a session
         because it provides true append-only semantics at the
         filesystem level.
@@ -134,6 +139,8 @@ class AuditLog:
             path: File path to append to.
             rotation: Optional rotation config. When set, the file
                 is rotated if it exceeds size or age thresholds.
+            retention: Optional retention config. When set, old
+                rotated files are purged after rotation.
         """
         new_entries = self._entries[self._persisted_count :]
         if not new_entries:
@@ -143,14 +150,18 @@ class AuditLog:
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Rotate the existing file if thresholds are exceeded.
+        rotated_this_call = False
         if rotation is not None and file_path.exists():
             stat = file_path.stat()
             file_age = time.time() - stat.st_mtime
             if rotation.should_rotate(stat.st_size, file_age):
                 ts = _dt.now(_tz.utc).strftime("%Y%m%dT%H%M%S%f")
                 stem = file_path.stem
-                rotated = file_path.with_name(f"{stem}.{ts}.jsonl")
+                rotated = file_path.with_name(
+                    f"{stem}.{ts}.jsonl",
+                )
                 file_path.rename(rotated)
+                rotated_this_call = True
 
         with file_path.open("a", encoding="utf-8") as f:
             for entry in new_entries:
@@ -158,6 +169,16 @@ class AuditLog:
                 f.write(line + "\n")
 
         self._persisted_count = len(self._entries)
+
+        # Enforce retention after rotation.
+        if retention is not None and rotated_this_call:
+            from agentguard.audit.retention import enforce_retention
+
+            enforce_retention(
+                file_path.parent,
+                retention,
+                active_file=file_path,
+            )
 
     @classmethod
     def load_directory(cls, path: str | Path) -> list[AuditLog]:

--- a/src/agentguard/audit/retention.py
+++ b/src/agentguard/audit/retention.py
@@ -1,0 +1,146 @@
+"""Audit log retention policy.
+
+Provides configurable retention for rotated JSONL audit files.
+The :func:`enforce_retention` function deletes old rotated files
+based on file count, age, or cumulative size thresholds.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RetentionConfig:
+    """Configuration for audit log retention.
+
+    All criteria are applied independently — a file is deleted if
+    **any** criterion marks it for removal.  With no thresholds set,
+    retention enforcement is a no-op.
+
+    Args:
+        max_files: Maximum number of ``.jsonl`` files to keep.
+            Oldest files (by mtime) are deleted first.
+            Must be positive if set.
+        max_age_seconds: Delete files whose mtime is older than
+            this many seconds.  Must be positive if set.
+        max_total_bytes: Delete oldest files until cumulative
+            size of remaining files is within this limit.
+            Must be positive if set.
+    """
+
+    max_files: int | None = None
+    max_age_seconds: float | None = None
+    max_total_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_files is not None and self.max_files <= 0:
+            msg = "max_files must be positive"
+            raise ValueError(msg)
+        if self.max_age_seconds is not None and self.max_age_seconds <= 0:
+            msg = "max_age_seconds must be positive"
+            raise ValueError(msg)
+        if self.max_total_bytes is not None and self.max_total_bytes <= 0:
+            msg = "max_total_bytes must be positive"
+            raise ValueError(msg)
+
+
+def enforce_retention(
+    audit_dir: str | Path,
+    config: RetentionConfig,
+    *,
+    active_file: str | Path | None = None,
+) -> list[Path]:
+    """Delete old audit files according to *config*.
+
+    Scans *audit_dir* for ``.jsonl`` files, sorts by mtime
+    (oldest first), and deletes files that exceed the configured
+    thresholds.  The *active_file* (if provided) is never deleted.
+
+    Args:
+        audit_dir: Directory containing audit ``.jsonl`` files.
+        config: Retention thresholds.
+        active_file: Path to the current active log file that
+            must not be deleted.
+
+    Returns:
+        List of :class:`~pathlib.Path` objects that were deleted.
+
+    Raises:
+        FileNotFoundError: If *audit_dir* does not exist.
+    """
+    dir_path = Path(audit_dir)
+    if not dir_path.is_dir():
+        msg = f"Audit directory not found: {dir_path}"
+        raise FileNotFoundError(msg)
+
+    active = Path(active_file).resolve() if active_file else None
+
+    # No thresholds → nothing to do.
+    if (
+        config.max_files is None
+        and config.max_age_seconds is None
+        and config.max_total_bytes is None
+    ):
+        return []
+
+    # Gather .jsonl files sorted by mtime (oldest first).
+    files = sorted(
+        dir_path.glob("*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+    )
+
+    # Exclude the active file from candidates.
+    candidates = [f for f in files if active is None or f.resolve() != active]
+
+    to_delete: set[Path] = set()
+    now = time.time()
+
+    # ── max_age_seconds ──────────────────────────────────────
+    if config.max_age_seconds is not None:
+        for f in candidates:
+            age = now - f.stat().st_mtime
+            if age >= config.max_age_seconds:
+                to_delete.add(f)
+
+    # ── max_files ────────────────────────────────────────────
+    if config.max_files is not None:
+        # candidates is sorted oldest-first; keep the newest N.
+        surviving = [f for f in candidates if f not in to_delete]
+        all_candidates = candidates  # original order
+        # Total eligible = candidates not yet marked for delete
+        # We want at most max_files remaining (excluding active).
+        # But we must also count the active file if present.
+        # "max_files" is the total count of .jsonl files to keep
+        # (excluding the active file).
+        if len(surviving) > config.max_files:
+            excess = len(surviving) - config.max_files
+            # Delete the oldest 'excess' survivors
+            survivors_oldest_first = [f for f in all_candidates if f in set(surviving)]
+            for f in survivors_oldest_first[:excess]:
+                to_delete.add(f)
+
+    # ── max_total_bytes ──────────────────────────────────────
+    if config.max_total_bytes is not None:
+        # Compute total size of files that will survive.
+        surviving = [f for f in files if f not in to_delete]
+        total = sum(f.stat().st_size for f in surviving)
+        if total > config.max_total_bytes:
+            # Remove oldest candidates first until within budget.
+            for f in candidates:
+                if f in to_delete:
+                    continue
+                if total <= config.max_total_bytes:
+                    break
+                total -= f.stat().st_size
+                to_delete.add(f)
+
+    # Perform deletions.
+    deleted: list[Path] = []
+    for f in sorted(to_delete):
+        f.unlink()
+        deleted.append(f)
+
+    return deleted

--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from agentguard.audit.log import AuditLog
     from agentguard.audit.models import AuditEntry
+    from agentguard.audit.retention import RetentionConfig
     from agentguard.audit.rotation import RotationConfig
     from agentguard.trust.registry import TrustRegistry
 
@@ -182,6 +183,40 @@ def _build_parser() -> argparse.ArgumentParser:
     audit_report_parser.add_argument(
         "--before",
         help="Only include entries before this ISO-8601 timestamp.",
+    )
+
+    # audit purge
+    purge_parser = audit_sub.add_parser(
+        "purge",
+        help="Delete old audit log files based on retention policy.",
+    )
+    purge_parser.add_argument(
+        "--audit-dir",
+        required=True,
+        help="Directory containing audit JSONL files.",
+    )
+    purge_parser.add_argument(
+        "--max-log-files",
+        type=int,
+        default=None,
+        help="Keep at most this many log files.",
+    )
+    purge_parser.add_argument(
+        "--retain-max-age",
+        type=float,
+        default=None,
+        help="Delete files older than this many seconds.",
+    )
+    purge_parser.add_argument(
+        "--retain-max-bytes",
+        type=int,
+        default=None,
+        help="Delete oldest files until total size is under this limit.",
+    )
+    purge_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List files that would be deleted without deleting.",
     )
 
     # --- serve ---
@@ -362,6 +397,24 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Rotate audit log when file age exceeds this many seconds.",
     )
+    serve_parser.add_argument(
+        "--max-log-files",
+        type=int,
+        default=None,
+        help="Keep at most this many rotated log files.",
+    )
+    serve_parser.add_argument(
+        "--retain-max-age",
+        type=float,
+        default=None,
+        help="Delete rotated logs older than this many seconds.",
+    )
+    serve_parser.add_argument(
+        "--retain-max-bytes",
+        type=int,
+        default=None,
+        help="Delete oldest rotated logs until total size is under this limit.",
+    )
 
     # --- report ---
     report_parser = subparsers.add_parser("report", help="Generate compliance reports.")
@@ -467,6 +520,24 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=None,
         help="Rotate audit log when file age exceeds this many seconds.",
+    )
+    proxy_parser.add_argument(
+        "--max-log-files",
+        type=int,
+        default=None,
+        help="Keep at most this many rotated log files.",
+    )
+    proxy_parser.add_argument(
+        "--retain-max-age",
+        type=float,
+        default=None,
+        help="Delete rotated logs older than this many seconds.",
+    )
+    proxy_parser.add_argument(
+        "--retain-max-bytes",
+        type=int,
+        default=None,
+        help="Delete oldest rotated logs until total size is under this limit.",
     )
 
     return parser
@@ -974,6 +1045,107 @@ def _build_rotation_config(
     )
 
 
+def _build_retention_config(
+    args: argparse.Namespace,
+) -> RetentionConfig | None:
+    """Build a RetentionConfig from CLI args, or None."""
+    from agentguard.audit.retention import RetentionConfig
+
+    max_files = getattr(args, "max_log_files", None)
+    max_age = getattr(args, "retain_max_age", None)
+    max_bytes = getattr(args, "retain_max_bytes", None)
+    if max_files is None and max_age is None and max_bytes is None:
+        return None
+    return RetentionConfig(
+        max_files=max_files,
+        max_age_seconds=max_age,
+        max_total_bytes=max_bytes,
+    )
+
+
+def _cmd_audit_purge(args: argparse.Namespace) -> int:
+    """Run retention enforcement on an audit directory."""
+    from pathlib import Path
+
+    from agentguard.audit.retention import enforce_retention
+
+    retention = _build_retention_config(args)
+    if retention is None:
+        print(
+            "Error: specify at least one retention criterion "
+            "(--max-log-files, --retain-max-age, --retain-max-bytes).",
+            file=sys.stderr,
+        )
+        return 1
+
+    audit_dir = Path(args.audit_dir)
+    if not audit_dir.is_dir():
+        print(
+            f"Error: audit directory not found: {args.audit_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if getattr(args, "dry_run", False):
+        # Dry-run: list candidates without deleting
+        candidates = sorted(
+            audit_dir.glob("*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+        )
+        # Simulate what enforce_retention would delete
+        import time
+
+        now = time.time()
+        to_delete: list[Path] = []
+
+        if retention.max_age_seconds is not None:
+            for f in candidates:
+                age = now - f.stat().st_mtime
+                if age > retention.max_age_seconds:
+                    to_delete.append(f)
+
+        if retention.max_files is not None:
+            remaining = [f for f in candidates if f not in to_delete]
+            if len(remaining) > retention.max_files:
+                excess = remaining[: len(remaining) - retention.max_files]
+                to_delete.extend(excess)
+
+        if retention.max_total_bytes is not None:
+            remaining = [f for f in candidates if f not in to_delete]
+            total = sum(f.stat().st_size for f in remaining)
+            for f in remaining:
+                if total <= retention.max_total_bytes:
+                    break
+                total -= f.stat().st_size
+                to_delete.append(f)
+
+        seen: set[Path] = set()
+        unique: list[Path] = []
+        for f in to_delete:
+            if f not in seen:
+                seen.add(f)
+                unique.append(f)
+
+        for f in unique:
+            print(f"would delete: {f}")
+        print(f"{len(unique)} file(s) would be deleted")
+        return 0
+
+    try:
+        deleted = enforce_retention(audit_dir, retention)
+    except FileNotFoundError:
+        print(
+            f"Error: audit directory not found: {args.audit_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    for p in deleted:
+        print(f"deleted: {p}")
+    print(f"{len(deleted)} file(s) deleted")
+    return 0
+
+
 def _cmd_serve(args: argparse.Namespace) -> int:
     """Start the AgentGuard MCP server."""
     if create_server is None:
@@ -1002,6 +1174,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
 
     try:
         rotation = _build_rotation_config(args)
+        retention = _build_retention_config(args)
         app = create_server(
             policy_dir=policy_dir,
             audit_dir=getattr(args, "audit_dir", None),
@@ -1011,6 +1184,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             preset=preset,
             trust_registry=getattr(args, "trust_registry", None),
             rotation=rotation,
+            retention=retention,
         )
         app.run()
     except ImportError:
@@ -1087,6 +1261,7 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
             return 1
 
         rotation = _build_rotation_config(args)
+        retention = _build_retention_config(args)
         config = ProxyConfig(
             upstream_base_url=args.upstream,
             host=args.host,
@@ -1102,6 +1277,7 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
             auth_file=getattr(args, "auth_file", None),
             auth_provider=getattr(args, "auth_provider", "github-copilot"),
             rotation=rotation,
+            retention=retention,
         )
         app = create_proxy_app(config)
 
@@ -1188,6 +1364,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _cmd_audit_query(args)
         if args.audit_command == "report":
             return _cmd_audit_report(args)
+        if args.audit_command == "purge":
+            return _cmd_audit_purge(args)
         if _parsers.audit is not None:
             _parsers.audit.print_help()
         return 1

--- a/src/agentguard/mcp/server.py
+++ b/src/agentguard/mcp/server.py
@@ -25,6 +25,7 @@ from agentguard.policies.builtins import load_all_builtins
 from agentguard.policies.guard import Guard
 
 if TYPE_CHECKING:
+    from agentguard.audit.retention import RetentionConfig
     from agentguard.audit.rotation import RotationConfig
 
 
@@ -37,6 +38,7 @@ def create_server(
     preset: str | None = None,
     trust_registry: str | None = None,
     rotation: RotationConfig | None = None,
+    retention: RetentionConfig | None = None,
 ) -> FastMCP:
     """Create an AgentGuard MCP server.
 
@@ -59,6 +61,9 @@ def create_server(
         rotation: Optional audit log rotation config. When set,
             audit files are rotated when they exceed size or age
             thresholds.
+        retention: Optional audit log retention config. When set,
+            old rotated files are deleted after rotation based on
+            file count, age, or total size limits.
 
     Returns:
         A FastMCP application with tools registered.
@@ -150,6 +155,7 @@ def create_server(
             audit_log.append(
                 audit_path / f"{session_id}.jsonl",
                 rotation=rotation,
+                retention=retention,
             )
 
     # --- create FastMCP app -------------------------------------------

--- a/src/agentguard/proxy/config.py
+++ b/src/agentguard/proxy/config.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from agentguard.audit.retention import RetentionConfig
     from agentguard.audit.rotation import RotationConfig
 
 
@@ -56,6 +57,9 @@ class ProxyConfig:
         rotation: Optional audit log rotation config. When set,
             audit files are rotated when they exceed size or age
             thresholds.
+        retention: Optional audit log retention config. When set,
+            old rotated files are deleted after rotation based on
+            file count, age, or total size limits.
     """
 
     upstream_base_url: str
@@ -74,6 +78,7 @@ class ProxyConfig:
     auth_file: str | None = None
     auth_provider: str = "github-copilot"
     rotation: RotationConfig | None = None
+    retention: RetentionConfig | None = None
 
     def __post_init__(self) -> None:
         """Validate configuration."""

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -592,4 +592,5 @@ class GuardMiddleware:
             self.audit_log.append(
                 audit_path / f"{self.session_id}.jsonl",
                 rotation=self.config.rotation,
+                retention=self.config.retention,
             )

--- a/tests/unit/test_audit_retention.py
+++ b/tests/unit/test_audit_retention.py
@@ -1,0 +1,617 @@
+"""Tests for audit log retention policy (M8 — Audit Hardening).
+
+Covers:
+- RetentionConfig data model and validation
+- enforce_retention by max_files (keep N most recent)
+- enforce_retention by max_age_seconds (delete files older than TTL)
+- enforce_retention by max_total_bytes (cap cumulative size)
+- Active log file is never deleted
+- Empty directory is a no-op
+- CLI ``audit purge`` subcommand
+- CLI flags on serve/proxy for retention
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from agentguard.audit.log import AuditLog
+from agentguard.audit.retention import RetentionConfig, enforce_retention
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fake_log(path: Path, n_entries: int = 1) -> None:
+    """Write a fake JSONL audit log with *n_entries* entries."""
+    with path.open("w", encoding="utf-8") as f:
+        for i in range(n_entries):
+            entry = {
+                "action": f"action-{i}",
+                "actor": "agent",
+                "target": f"t-{i}",
+                "result": "allowed",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "previous_hash": None,
+                "entry_hash": f"hash-{i}",
+            }
+            f.write(json.dumps(entry) + "\n")
+
+
+# ── RetentionConfig data model ──────────────────────────────────
+
+
+class TestRetentionConfig:
+    """RetentionConfig validation and defaults."""
+
+    def test_default_values(self) -> None:
+        cfg = RetentionConfig()
+        assert cfg.max_files is None
+        assert cfg.max_age_seconds is None
+        assert cfg.max_total_bytes is None
+
+    def test_max_files_only(self) -> None:
+        cfg = RetentionConfig(max_files=10)
+        assert cfg.max_files == 10
+
+    def test_max_age_seconds_only(self) -> None:
+        cfg = RetentionConfig(max_age_seconds=86400)
+        assert cfg.max_age_seconds == 86400
+
+    def test_max_total_bytes_only(self) -> None:
+        cfg = RetentionConfig(max_total_bytes=1_000_000)
+        assert cfg.max_total_bytes == 1_000_000
+
+    def test_all_fields(self) -> None:
+        cfg = RetentionConfig(
+            max_files=5,
+            max_age_seconds=3600,
+            max_total_bytes=500_000,
+        )
+        assert cfg.max_files == 5
+        assert cfg.max_age_seconds == 3600
+        assert cfg.max_total_bytes == 500_000
+
+    def test_max_files_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="max_files"):
+            RetentionConfig(max_files=0)
+
+    def test_max_files_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_files"):
+            RetentionConfig(max_files=-1)
+
+    def test_max_age_seconds_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="max_age_seconds"):
+            RetentionConfig(max_age_seconds=0)
+
+    def test_max_age_seconds_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_age_seconds"):
+            RetentionConfig(max_age_seconds=-1)
+
+    def test_max_total_bytes_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="max_total_bytes"):
+            RetentionConfig(max_total_bytes=0)
+
+    def test_max_total_bytes_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_total_bytes"):
+            RetentionConfig(max_total_bytes=-1)
+
+    def test_frozen(self) -> None:
+        cfg = RetentionConfig(max_files=5)
+        with pytest.raises(AttributeError):
+            cfg.max_files = 10  # type: ignore[misc]
+
+
+# ── enforce_retention: max_files ─────────────────────────────────
+
+
+class TestEnforceRetentionMaxFiles:
+    """Enforce retention by file count."""
+
+    def test_no_deletion_under_limit(self, tmp_path: Path) -> None:
+        """Files within max_files limit are kept."""
+        for i in range(3):
+            _write_fake_log(tmp_path / f"log-{i}.jsonl")
+        cfg = RetentionConfig(max_files=5)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+        assert len(list(tmp_path.glob("*.jsonl"))) == 3
+
+    def test_deletes_oldest_files(self, tmp_path: Path) -> None:
+        """Oldest files are deleted when count exceeds max_files."""
+        for i in range(5):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            _write_fake_log(p)
+            time.sleep(0.02)  # ensure distinct mtime
+
+        cfg = RetentionConfig(max_files=2)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert len(deleted) == 3
+        remaining = sorted(f.name for f in tmp_path.glob("*.jsonl"))
+        assert len(remaining) == 2
+        # The two newest should remain
+        assert "log-03.jsonl" in remaining
+        assert "log-04.jsonl" in remaining
+
+    def test_exact_limit_no_deletion(self, tmp_path: Path) -> None:
+        """Exactly max_files files — nothing deleted."""
+        for i in range(3):
+            _write_fake_log(tmp_path / f"log-{i}.jsonl")
+        cfg = RetentionConfig(max_files=3)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+
+    def test_active_log_excluded(self, tmp_path: Path) -> None:
+        """Active log file is never deleted."""
+        active = tmp_path / "session.jsonl"
+        _write_fake_log(active)
+        time.sleep(0.02)
+        for i in range(3):
+            p = tmp_path / f"session.20260101T00000{i}.jsonl"
+            _write_fake_log(p)
+            time.sleep(0.02)
+
+        cfg = RetentionConfig(max_files=1)
+        enforce_retention(
+            tmp_path,
+            cfg,
+            active_file=active,
+        )
+        # Active file must survive
+        assert active.exists()
+        # Should keep active + 1 newest rotated = 2 total
+        # Actually max_files=1 means keep 1 file (excluding
+        # active). So 2 rotated deleted, 1 rotated kept.
+        remaining = list(tmp_path.glob("*.jsonl"))
+        assert active in remaining
+
+
+# ── enforce_retention: max_age_seconds ───────────────────────────
+
+
+class TestEnforceRetentionMaxAge:
+    """Enforce retention by file age."""
+
+    def test_no_deletion_when_young(self, tmp_path: Path) -> None:
+        """Recent files are kept."""
+        for i in range(3):
+            _write_fake_log(tmp_path / f"log-{i}.jsonl")
+        cfg = RetentionConfig(max_age_seconds=3600)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+
+    def test_deletes_old_files(self, tmp_path: Path) -> None:
+        """Files older than max_age_seconds are deleted."""
+        import os
+
+        old_file = tmp_path / "old.jsonl"
+        _write_fake_log(old_file)
+        # Backdate the file's mtime by 2 hours
+        old_mtime = time.time() - 7200
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        new_file = tmp_path / "new.jsonl"
+        _write_fake_log(new_file)
+
+        cfg = RetentionConfig(max_age_seconds=3600)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert len(deleted) == 1
+        assert not old_file.exists()
+        assert new_file.exists()
+
+    def test_active_file_excluded_from_age(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Active log is not deleted even if old."""
+        import os
+
+        active = tmp_path / "session.jsonl"
+        _write_fake_log(active)
+        old_mtime = time.time() - 7200
+        os.utime(active, (old_mtime, old_mtime))
+
+        cfg = RetentionConfig(max_age_seconds=3600)
+        deleted = enforce_retention(
+            tmp_path,
+            cfg,
+            active_file=active,
+        )
+        assert deleted == []
+        assert active.exists()
+
+
+# ── enforce_retention: max_total_bytes ───────────────────────────
+
+
+class TestEnforceRetentionMaxTotalBytes:
+    """Enforce retention by cumulative file size."""
+
+    def test_no_deletion_under_limit(self, tmp_path: Path) -> None:
+        """Total size within limit — nothing deleted."""
+        _write_fake_log(tmp_path / "a.jsonl", n_entries=1)
+        cfg = RetentionConfig(max_total_bytes=100_000)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+
+    def test_deletes_oldest_to_fit(self, tmp_path: Path) -> None:
+        """Oldest files deleted until total fits max_total_bytes."""
+        for i in range(5):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            _write_fake_log(p, n_entries=10)
+            time.sleep(0.02)
+
+        # Each file is ~1000-1200 bytes. Total ~5000-6000.
+        total = sum(f.stat().st_size for f in tmp_path.glob("*.jsonl"))
+        # Set limit to roughly 2 files worth
+        limit = total // 3
+        cfg = RetentionConfig(max_total_bytes=limit)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert len(deleted) > 0
+
+        remaining_size = sum(f.stat().st_size for f in tmp_path.glob("*.jsonl"))
+        assert remaining_size <= limit
+
+    def test_active_file_excluded_from_size(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Active log not deleted by size enforcement."""
+        active = tmp_path / "session.jsonl"
+        _write_fake_log(active, n_entries=100)  # large file
+
+        cfg = RetentionConfig(max_total_bytes=1)  # tiny limit
+        enforce_retention(
+            tmp_path,
+            cfg,
+            active_file=active,
+        )
+        assert active.exists()
+
+
+# ── enforce_retention: combined ──────────────────────────────────
+
+
+class TestEnforceRetentionCombined:
+    """Multiple retention criteria applied together."""
+
+    def test_all_criteria_applied(self, tmp_path: Path) -> None:
+        """When multiple criteria set, all are enforced."""
+        import os
+
+        # Create 5 files: 2 old, 3 new
+        for i in range(5):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            _write_fake_log(p, n_entries=5)
+            time.sleep(0.02)
+
+        # Backdate first 2 files
+        for i in range(2):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            old_mtime = time.time() - 7200
+            os.utime(p, (old_mtime, old_mtime))
+
+        cfg = RetentionConfig(
+            max_files=10,  # won't trigger
+            max_age_seconds=3600,  # will delete 2 old files
+        )
+        deleted = enforce_retention(tmp_path, cfg)
+        assert len(deleted) == 2
+        assert len(list(tmp_path.glob("*.jsonl"))) == 3
+
+
+class TestEnforceRetentionEdgeCases:
+    """Edge cases for enforce_retention."""
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        """Empty directory is a no-op."""
+        cfg = RetentionConfig(max_files=1)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+
+    def test_nonexistent_directory_raises(self) -> None:
+        """Non-existent directory raises FileNotFoundError."""
+        from pathlib import Path
+
+        cfg = RetentionConfig(max_files=1)
+        with pytest.raises(FileNotFoundError):
+            enforce_retention(
+                Path("/nonexistent/path"),
+                cfg,
+            )
+
+    def test_no_config_is_noop(self, tmp_path: Path) -> None:
+        """RetentionConfig with all None is a no-op."""
+        for i in range(5):
+            _write_fake_log(tmp_path / f"log-{i}.jsonl")
+        cfg = RetentionConfig()
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+        assert len(list(tmp_path.glob("*.jsonl"))) == 5
+
+    def test_returns_deleted_paths(self, tmp_path: Path) -> None:
+        """enforce_retention returns list of deleted file paths."""
+        for i in range(5):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            _write_fake_log(p)
+            time.sleep(0.02)
+
+        cfg = RetentionConfig(max_files=2)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert len(deleted) == 3
+        for p in deleted:
+            assert not p.exists()
+
+    def test_only_jsonl_files_considered(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Non-.jsonl files are ignored."""
+        _write_fake_log(tmp_path / "log.jsonl")
+        (tmp_path / "readme.txt").write_text("hello")
+        (tmp_path / "data.json").write_text("{}")
+
+        cfg = RetentionConfig(max_files=1)
+        deleted = enforce_retention(tmp_path, cfg)
+        assert deleted == []
+        assert (tmp_path / "readme.txt").exists()
+        assert (tmp_path / "data.json").exists()
+
+
+# ── CLI integration ──────────────────────────────────────────────
+
+
+class TestRetentionCLI:
+    """CLI integration for retention config."""
+
+    def test_serve_accepts_retention_flags(self) -> None:
+        from agentguard.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "serve",
+                "--audit-dir",
+                "/tmp/audit",
+                "--max-log-files",
+                "10",
+                "--retain-max-age",
+                "86400",
+                "--retain-max-bytes",
+                "10000000",
+            ],
+        )
+        assert args.max_log_files == 10
+        assert args.retain_max_age == 86400.0
+        assert args.retain_max_bytes == 10_000_000
+
+    def test_proxy_accepts_retention_flags(self) -> None:
+        from agentguard.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "proxy",
+                "http://localhost:8080",
+                "--audit-dir",
+                "/tmp/audit",
+                "--max-log-files",
+                "10",
+                "--retain-max-age",
+                "86400",
+                "--retain-max-bytes",
+                "10000000",
+            ],
+        )
+        assert args.max_log_files == 10
+        assert args.retain_max_age == 86400.0
+        assert args.retain_max_bytes == 10_000_000
+
+    def test_build_retention_config_none_when_unset(self) -> None:
+        import argparse
+
+        from agentguard.cli import _build_retention_config
+
+        args = argparse.Namespace()
+        result = _build_retention_config(args)
+        assert result is None
+
+    def test_build_retention_config_with_values(self) -> None:
+        import argparse
+
+        from agentguard.cli import _build_retention_config
+
+        args = argparse.Namespace(
+            max_log_files=5,
+            retain_max_age=3600.0,
+            retain_max_bytes=500_000,
+        )
+        result = _build_retention_config(args)
+        assert result is not None
+        assert result.max_files == 5
+        assert result.max_age_seconds == 3600.0
+        assert result.max_total_bytes == 500_000
+
+    def test_audit_purge_subcommand_exists(self) -> None:
+        from agentguard.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "audit",
+                "purge",
+                "--audit-dir",
+                "/tmp/audit",
+                "--max-log-files",
+                "5",
+            ],
+        )
+        assert args.audit_command == "purge"
+        assert args.audit_dir == "/tmp/audit"
+        assert args.max_log_files == 5
+
+    def test_audit_purge_dry_run_flag(self) -> None:
+        from agentguard.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "audit",
+                "purge",
+                "--audit-dir",
+                "/tmp/audit",
+                "--max-log-files",
+                "5",
+                "--dry-run",
+            ],
+        )
+        assert args.dry_run is True
+
+    def test_audit_purge_runs_enforcement(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """audit purge actually deletes files."""
+        from agentguard.cli import main
+
+        for i in range(5):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            _write_fake_log(p)
+            time.sleep(0.02)
+
+        rc = main(
+            [
+                "audit",
+                "purge",
+                "--audit-dir",
+                str(tmp_path),
+                "--max-log-files",
+                "2",
+            ],
+        )
+        assert rc == 0
+        remaining = list(tmp_path.glob("*.jsonl"))
+        assert len(remaining) == 2
+
+    def test_audit_purge_dry_run_no_delete(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """audit purge --dry-run lists but doesn't delete."""
+        from agentguard.cli import main
+
+        for i in range(5):
+            p = tmp_path / f"log-{i:02d}.jsonl"
+            _write_fake_log(p)
+            time.sleep(0.02)
+
+        rc = main(
+            [
+                "audit",
+                "purge",
+                "--audit-dir",
+                str(tmp_path),
+                "--max-log-files",
+                "2",
+                "--dry-run",
+            ],
+        )
+        assert rc == 0
+        remaining = list(tmp_path.glob("*.jsonl"))
+        assert len(remaining) == 5  # nothing deleted
+
+    def test_audit_purge_missing_dir_exits_1(self) -> None:
+        from agentguard.cli import main
+
+        rc = main(
+            [
+                "audit",
+                "purge",
+                "--audit-dir",
+                "/nonexistent/dir",
+                "--max-log-files",
+                "5",
+            ],
+        )
+        assert rc == 1
+
+    def test_audit_purge_no_criteria_exits_1(self) -> None:
+        """audit purge with no retention criteria exits with error."""
+        from agentguard.cli import main
+
+        rc = main(
+            [
+                "audit",
+                "purge",
+                "--audit-dir",
+                "/tmp",
+            ],
+        )
+        assert rc == 1
+
+
+# ── Integration with append() ────────────────────────────────────
+
+
+class TestAppendWithRetention:
+    """Retention enforcement after rotation in append()."""
+
+    def test_retention_enforced_after_rotation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Old rotated files are cleaned up during append()."""
+        from agentguard.audit.rotation import RotationConfig
+
+        log_file = tmp_path / "sess.jsonl"
+        rot_cfg = RotationConfig(max_bytes=1)
+        ret_cfg = RetentionConfig(max_files=2)
+        log = AuditLog(session_id="sess")
+
+        # Create 5 rotated files + active
+        for i in range(6):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(
+                log_file,
+                rotation=rot_cfg,
+                retention=ret_cfg,
+            )
+            time.sleep(0.02)
+
+        # max_files=2 keeps 2 rotated + active = 3 total
+        jsonl_files = list(tmp_path.glob("*.jsonl"))
+        assert len(jsonl_files) <= 3
+
+    def test_no_retention_without_config(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Without RetentionConfig, all rotated files are kept."""
+        from agentguard.audit.rotation import RotationConfig
+
+        log_file = tmp_path / "sess.jsonl"
+        rot_cfg = RotationConfig(max_bytes=1)
+        log = AuditLog(session_id="sess")
+
+        for i in range(5):
+            log.record(
+                action=f"a{i}",
+                actor="x",
+                target="t",
+                result="ok",
+            )
+            log.append(log_file, rotation=rot_cfg)
+            time.sleep(0.02)
+
+        # All 5 files should still exist (4 rotated + 1 active)
+        jsonl_files = list(tmp_path.glob("*.jsonl"))
+        assert len(jsonl_files) == 5

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -637,6 +637,7 @@ class TestServeCommand:
             preset=None,
             trust_registry=None,
             rotation=None,
+            retention=None,
         )
         mock_app.run.assert_called_once()
 
@@ -675,6 +676,7 @@ class TestServeCommand:
             preset=None,
             trust_registry=None,
             rotation=None,
+            retention=None,
         )
         mock_app.run.assert_called_once()
 
@@ -697,6 +699,7 @@ class TestServeCommand:
             preset=None,
             trust_registry=None,
             rotation=None,
+            retention=None,
         )
 
     def test_serve_auto_discover_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -718,6 +721,7 @@ class TestServeCommand:
             preset=None,
             trust_registry=None,
             rotation=None,
+            retention=None,
         )
 
     def test_serve_nonexistent_policy_dir(self) -> None:


### PR DESCRIPTION
## Summary

- Add `RetentionConfig` dataclass and `enforce_retention()` function for automatic cleanup of old audit log files based on file count, age, and total size thresholds
- Integrate retention into `AuditLog.append()` (runs after rotation), MCP server `create_server()`, and proxy middleware
- Add CLI flags `--max-log-files`, `--retain-max-age`, `--retain-max-bytes` on `serve` and `proxy` subcommands, plus `audit purge` subcommand with `--dry-run` support
- 40 new tests covering model validation, enforcement logic, CLI integration, and end-to-end scenarios

## Details

Retention policy deletes the oldest rotated `.jsonl` audit log files when thresholds are exceeded. Files are sorted by modification time (oldest first). The current active log file is never deleted. All three thresholds (`max_files`, `max_age_seconds`, `max_total_bytes`) are optional and evaluated independently — a file is deleted if ANY threshold is exceeded.

The `audit purge` CLI subcommand allows manual one-shot retention enforcement against an audit directory, with `--dry-run` to preview deletions.

Follows the same pattern as the rotation feature (PR #227).

## Test plan

- 40 new unit tests in `tests/unit/test_audit_retention.py`
- Full test suite passes (1,491 tests)
- Tested across Python 3.10–3.13