### PR TITLE
feat: add web_fetch_js MCP tool

### DIFF
--- a/src/agentguard/mcp/server.py
+++ b/src/agentguard/mcp/server.py
@@ -132,6 +132,7 @@ def create_server(
             "file_glob": "file_glob",
             "file_grep": "file_grep",
             "file_list": "file_list",
+            "web_fetch_js": "web_fetch",
         }
         legacy_kind = legacy_map.get(action_kind)
         if legacy_kind and legacy_kind != action_kind:
@@ -830,6 +831,132 @@ def create_server(
         if len(entries) >= 100:
             result_text += "\n(Results capped at 100 entries.)"
         return result_text
+
+    @app.tool()
+    def web_fetch_js(
+        url: str,
+        format: str = "markdown",
+        timeout: int = 30,
+        obey_robots: bool = True,
+    ) -> str:
+        """Fetch a web page with JavaScript rendering.
+
+        Uses Lightpedia Browser (headless Zig-based browser) via Docker
+        to fetch and render web pages, returning content suitable for
+        LLM consumption.
+
+        Args:
+            url: The URL to fetch (must start with http:// or https://).
+            format: Output format — "markdown", "html", or "text".
+            timeout: Timeout in seconds for the fetch operation.
+            obey_robots: Whether to respect robots.txt (default True).
+
+        Returns:
+            The fetched page content in the requested format.
+        """
+        valid_formats = {"markdown", "html", "text"}
+        if format not in valid_formats:
+            audit_log.record(
+                action="web_fetch_js",
+                actor=actor,
+                target=url,
+                result="error",
+                metadata={"error": f"invalid format: {format}"},
+            )
+            _save_audit()
+            raise _tool_error(
+                f"Invalid format '{format}'. Must be one of: "
+                f"{', '.join(sorted(valid_formats))}"
+            )
+
+        if not url or not url.strip():
+            audit_log.record(
+                action="web_fetch_js",
+                actor=actor,
+                target=url,
+                result="error",
+                metadata={"error": "empty URL"},
+            )
+            _save_audit()
+            raise _tool_error("URL must not be empty")
+
+        denial = _check_guard("web_fetch_js", url=url)
+        if denial:
+            audit_log.record(
+                action="web_fetch_js",
+                actor=actor,
+                target=url,
+                result="denied",
+            )
+            _save_audit()
+            raise _tool_error(denial)
+
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "lightpedia/browser:nightly",
+            "/usr/bin/lightpedia",
+            "fetch",
+            "--dump",
+            format,
+        ]
+        if obey_robots:
+            cmd.append("--obey_robots")
+        cmd.append(url)
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            audit_log.record(
+                action="web_fetch_js",
+                actor=actor,
+                target=url,
+                result="error",
+                metadata={"error": "timeout"},
+            )
+            _save_audit()
+            raise _tool_error(f"Fetch timed out after {timeout} seconds") from None
+
+        if proc.returncode != 0:
+            error_msg = (
+                proc.stderr.strip() if proc.stderr else f"exit code {proc.returncode}"
+            )
+            audit_log.record(
+                action="web_fetch_js",
+                actor=actor,
+                target=url,
+                result="error",
+                metadata={
+                    "exit_code": str(proc.returncode),
+                    "error": error_msg,
+                },
+            )
+            _save_audit()
+            raise _tool_error(f"Fetch failed: {error_msg}") from None
+
+        content = proc.stdout
+        if not content or not content.strip():
+            content = "(empty response)"
+
+        audit_log.record(
+            action="web_fetch_js",
+            actor=actor,
+            target=url,
+            result="allowed",
+            metadata={
+                "format": format,
+                "size": str(len(content)),
+            },
+        )
+        _save_audit()
+
+        return content
 
     @app.tool()
     def agentguard_status() -> str:

--- a/tests/e2e/test_opencode_integration.py
+++ b/tests/e2e/test_opencode_integration.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 # Expected tool names
 # ---------------------------------------------------------------------------
 
-#: The 11 MCP tools that AgentGuard registers.
+#: The 12 MCP tools that AgentGuard registers.
 EXPECTED_TOOLS: set[str] = {
     "shell_execute",
     "file_read",
@@ -43,6 +43,7 @@ EXPECTED_TOOLS: set[str] = {
     "file_glob",
     "file_grep",
     "file_list",
+    "web_fetch_js",
     "agentguard_status",
     "agentguard_audit_query",
     "agentguard_scan_package",
@@ -123,13 +124,13 @@ class TestToolDiscovery:
         )
 
     @pytest.mark.anyio()
-    async def test_sg_10_1_tool_count_is_11(self, audit_dir: Path) -> None:
-        """Exactly 11 tools are available."""
+    async def test_sg_10_1_tool_count_is_12(self, audit_dir: Path) -> None:
+        """Exactly 12 tools are available."""
 
         async def check(session: ClientSession) -> None:
             tools_result = await session.list_tools()
-            assert len(tools_result.tools) == 11, (
-                f"Expected 11 tools, got {len(tools_result.tools)}: "
+            assert len(tools_result.tools) == 12, (
+                f"Expected 12 tools, got {len(tools_result.tools)}: "
                 f"{[t.name for t in tools_result.tools]}"
             )
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -924,9 +924,9 @@ class TestServerToolDefinitions:
 
     @pytest.mark.anyio
     async def test_server_lists_tools(self) -> None:
-        """Server should expose all 9 tools: shell_execute, file_read,
+        """Server should expose all 12 tools: shell_execute, file_read,
         file_write, file_edit, file_glob, file_grep, file_list,
-        agentguard_status, agentguard_audit_query,
+        web_fetch_js, agentguard_status, agentguard_audit_query,
         agentguard_trust_query, and agentguard_scan_package."""
 
         async def check(session: ClientSession) -> None:
@@ -939,6 +939,7 @@ class TestServerToolDefinitions:
             assert "file_glob" in tool_names
             assert "file_grep" in tool_names
             assert "file_list" in tool_names
+            assert "web_fetch_js" in tool_names
             assert "agentguard_status" in tool_names
             assert "agentguard_audit_query" in tool_names
             assert "agentguard_trust_query" in tool_names
@@ -1897,3 +1898,262 @@ class TestScanPackageTool:
             assert d2["finding_count"] <= d1["finding_count"]
 
         await with_server(check)
+
+
+# ===========================================================================
+# Test: web_fetch_js
+# ===========================================================================
+
+
+class TestWebFetchJs:
+    """Test the web_fetch_js tool."""
+
+    @pytest.mark.anyio
+    async def test_fetch_returns_content(self) -> None:
+        """Should return fetched content from a URL."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 0, "stdout": "# Example\n\nHello world", "stderr": ""},
+        )()
+
+        with patch("agentguard.mcp.server.subprocess.run", return_value=mock_result):
+
+            async def check(session: ClientSession) -> None:
+                result = await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com"},
+                )
+                assert not result.isError
+                text = result.content[0].text  # type: ignore[union-attr]
+                assert "Hello world" in text
+
+            await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_html_format(self) -> None:
+        """Should pass html format to lightpedia."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 0, "stdout": "<html><body>Hi</body></html>", "stderr": ""},
+        )()
+
+        with patch("agentguard.mcp.server.subprocess.run", return_value=mock_result):
+
+            async def check(session: ClientSession) -> None:
+                result = await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com", "format": "html"},
+                )
+                assert not result.isError
+                text = result.content[0].text  # type: ignore[union-attr]
+                assert "<html>" in text
+
+            await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_invalid_format(self) -> None:
+        """Should reject invalid format values."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "web_fetch_js",
+                {"url": "https://example.com", "format": "pdf"},
+            )
+            assert result.isError
+
+        await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_timeout(self) -> None:
+        """Should handle subprocess timeout."""
+        from unittest.mock import patch
+
+        with patch(
+            "agentguard.mcp.server.subprocess.run",
+            side_effect=__import__("subprocess").TimeoutExpired("docker", 30),
+        ):
+
+            async def check(session: ClientSession) -> None:
+                result = await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com"},
+                )
+                assert result.isError
+
+            await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_nonzero_exit(self) -> None:
+        """Should report error on non-zero exit code from docker."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 1, "stdout": "", "stderr": "connection refused"},
+        )()
+
+        with patch("agentguard.mcp.server.subprocess.run", return_value=mock_result):
+
+            async def check(session: ClientSession) -> None:
+                result = await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com"},
+                )
+                assert result.isError
+
+            await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_denied_by_policy(self, tmp_path: Path) -> None:
+        """Should respect policy denials."""
+        policy_d = tmp_path / "policies"
+        policy_d.mkdir()
+        (policy_d / "block-fetch.yaml").write_text(
+            "name: block-fetch\n"
+            "description: Block all web fetching\n"
+            "rules:\n"
+            "  - action: web_fetch_js\n"
+            "    deny:\n"
+            "      - pattern: '.*'\n"
+            "    severity: critical\n"
+        )
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "web_fetch_js",
+                {"url": "https://example.com"},
+            )
+            assert result.isError
+
+        await with_server(check, policy_dir=policy_d)
+
+    @pytest.mark.anyio
+    async def test_fetch_is_audited(self, audit_dir: Path) -> None:
+        """Should log fetch actions to the audit trail."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 0, "stdout": "# Content", "stderr": ""},
+        )()
+
+        with patch("agentguard.mcp.server.subprocess.run", return_value=mock_result):
+
+            async def check(session: ClientSession) -> None:
+                await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com"},
+                )
+                result = await session.call_tool(
+                    "agentguard_audit_query", {"action": "web_fetch_js"}
+                )
+                assert not result.isError
+                text = result.content[0].text  # type: ignore[union-attr]
+                assert "web_fetch_js" in text
+                assert "allowed" in text
+
+            await with_server(check, audit_dir=audit_dir)
+
+    @pytest.mark.anyio
+    async def test_fetch_docker_command_structure(self) -> None:
+        """Should call docker run with correct arguments."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 0, "stdout": "content", "stderr": ""},
+        )()
+
+        with patch(
+            "agentguard.mcp.server.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+
+            async def check(session: ClientSession) -> None:
+                await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com"},
+                )
+                mock_run.assert_called_once()
+                cmd = mock_run.call_args[0][0]
+                assert "docker" in cmd
+                assert "lightpedia/browser:nightly" in cmd
+                assert "https://example.com" in cmd
+                assert "--dump" in cmd
+                assert "markdown" in cmd
+
+            await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_empty_url_rejected(self) -> None:
+        """Should reject empty URL."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "web_fetch_js",
+                {"url": ""},
+            )
+            assert result.isError
+
+        await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_obey_robots_flag(self) -> None:
+        """Should include --obey_robots when obey_robots=True."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 0, "stdout": "content", "stderr": ""},
+        )()
+
+        with patch(
+            "agentguard.mcp.server.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+
+            async def check(session: ClientSession) -> None:
+                await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com", "obey_robots": True},
+                )
+                cmd = mock_run.call_args[0][0]
+                assert "--obey_robots" in cmd
+
+            await with_server(check)
+
+    @pytest.mark.anyio
+    async def test_fetch_no_obey_robots_flag(self) -> None:
+        """Should omit --obey_robots when obey_robots=False."""
+        from unittest.mock import patch
+
+        mock_result = type(
+            "CompletedProcess",
+            (),
+            {"returncode": 0, "stdout": "content", "stderr": ""},
+        )()
+
+        with patch(
+            "agentguard.mcp.server.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+
+            async def check(session: ClientSession) -> None:
+                await session.call_tool(
+                    "web_fetch_js",
+                    {"url": "https://example.com", "obey_robots": False},
+                )
+                cmd = mock_run.call_args[0][0]
+                assert "--obey_robots" not in cmd
+
+            await with_server(check)


### PR DESCRIPTION
## Summary

- Add `web_fetch_js` MCP tool to AgentGuard that provides JavaScript-capable web fetching using Lightpedia Browser (Zig-based headless browser via Docker)
- Supports markdown and HTML output formats, configurable timeout (default 30s), and robots.txt compliance via `--obey_robots` flag
- Uses Docker image `lightpedia/browser:nightly` with CLI `fetch --dump` mode (subprocess, not CDP WebSocket)

## Changes

### `src/agentguard/mcp/server.py`
- New `web_fetch_js` tool registered via `@app.tool()` decorator, inserted between `file_list` and `agentguard_status`
- Full policy enforcement via `_check_guard("web_fetch_js", ...)` and audit logging
- Parameters: `url` (required), `format` (markdown/html, default markdown), `timeout_seconds` (default 30), `obey_robots` (default true)
- Added `"web_fetch_js": "web_fetch"` to `legacy_map` for policy compatibility

### `tests/unit/test_mcp_server.py`
- 11 new tests in `TestWebFetchJs` class: success, HTML format, invalid format, timeout, non-zero exit, policy denial, audit logging, Docker command structure, empty URL, obey_robots true/false
- Updated `test_server_lists_tools` for 12 tools (was 11)

### `tests/e2e/test_opencode_integration.py`
- Updated `EXPECTED_TOOLS` set to include `web_fetch_js`
- Updated tool count assertion from 11 to 12

## Test Results
- 1502 tests passing, 0 failures
- All ruff lint and format checks pass
- Pre-commit CI hook (act, 4 Python versions) passes