### PR TITLE
feat: add proxy delta scanning and MCP output truncation

### DIFF
--- a/src/agentguard/mcp/server.py
+++ b/src/agentguard/mcp/server.py
@@ -39,6 +39,7 @@ def create_server(
     trust_registry: str | None = None,
     rotation: RotationConfig | None = None,
     retention: RetentionConfig | None = None,
+    max_output_size: int = 51200,
 ) -> FastMCP:
     """Create an AgentGuard MCP server.
 
@@ -64,6 +65,10 @@ def create_server(
         retention: Optional audit log retention config. When set,
             old rotated files are deleted after rotation based on
             file count, age, or total size limits.
+        max_output_size: Maximum output size in bytes for tool
+            results.  Output exceeding this limit is truncated with
+            a notice appended.  Set to 0 to disable truncation.
+            Default: 51200 (50 KB).
 
     Returns:
         A FastMCP application with tools registered.
@@ -159,6 +164,34 @@ def create_server(
                 retention=retention,
             )
 
+    def _truncate_output(text: str) -> str:
+        """Truncate tool output if it exceeds max_output_size.
+
+        When ``max_output_size`` is 0, truncation is disabled and
+        the text is returned as-is.  Otherwise, if the text exceeds
+        the limit in bytes, it is truncated at the limit boundary
+        and a notice is appended.
+
+        Args:
+            text: The raw tool output string.
+
+        Returns:
+            The original text (if within limits) or the truncated
+            text with an appended notice.
+        """
+        if max_output_size <= 0:
+            return text
+        encoded = text.encode("utf-8")
+        if len(encoded) <= max_output_size:
+            return text
+        original_size = len(encoded)
+        # Truncate at byte boundary, then decode safely
+        truncated = encoded[:max_output_size].decode("utf-8", errors="ignore")
+        notice = (
+            f"\n... (output truncated from {original_size} to {max_output_size} bytes)"
+        )
+        return truncated + notice
+
     # --- create FastMCP app -------------------------------------------
 
     app = FastMCP("AgentGuard")
@@ -230,7 +263,7 @@ def create_server(
         if proc.returncode != 0:
             raise _tool_error(f"Command exited with code {proc.returncode}\n{output}")
 
-        return output if output else "(no output)"
+        return _truncate_output(output) if output else "(no output)"
 
     @app.tool()
     def file_read(path: str) -> str:
@@ -328,7 +361,7 @@ def create_server(
             metadata={"size": str(len(text))},
         )
         _save_audit()
-        return text
+        return _truncate_output(text)
 
     @app.tool()
     def file_write(path: str, content: str) -> str:
@@ -730,7 +763,7 @@ def create_server(
                 f"\n(Showing 100 of {match_count} matches. "
                 "Narrow your pattern for more specific results.)"
             )
-        return result_text
+        return _truncate_output(result_text)
 
     @app.tool()
     def file_list(path: str | None = None) -> str:

--- a/src/agentguard/proxy/config.py
+++ b/src/agentguard/proxy/config.py
@@ -60,6 +60,10 @@ class ProxyConfig:
         retention: Optional audit log retention config. When set,
             old rotated files are deleted after rotation based on
             file count, age, or total size limits.
+        delta_scanning: When True, the proxy tracks which messages
+            in a conversation have already been scanned and only
+            scans new/unseen messages on subsequent requests.
+            Default False for backward compatibility.
     """
 
     upstream_base_url: str
@@ -79,6 +83,7 @@ class ProxyConfig:
     auth_provider: str = "github-copilot"
     rotation: RotationConfig | None = None
     retention: RetentionConfig | None = None
+    delta_scanning: bool = False
 
     def __post_init__(self) -> None:
         """Validate configuration."""

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -7,6 +7,7 @@ and either denies (403) or forwards the request upstream.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import uuid
 from pathlib import Path
@@ -67,6 +68,9 @@ class GuardMiddleware:
         self._auth_token: str | None = self._load_auth_token()
         self.session_id = f"proxy-{uuid.uuid4().hex[:12]}"
         self.audit_log = AuditLog(self.session_id)
+        # Delta scanning: track how many messages have been scanned
+        # per conversation, keyed by conversation fingerprint.
+        self._seen_messages: dict[str, int] = {}
 
     def _load_auth_token(self) -> str | None:
         """Load an auth token from the configured auth file.
@@ -221,18 +225,45 @@ class GuardMiddleware:
             )
 
         # Extract and scan request content
+        #
+        # Delta scanning: when enabled, compute a conversation
+        # fingerprint from the first message and only extract
+        # messages that haven't been scanned yet.
+        conv_fingerprint: str | None = None
+        seen_count: int | None = None
+        current_msg_count = 0
+
         try:
+            parsed_body = self._parse_body(body)
+            if (
+                self.config.delta_scanning
+                and parsed_body is not None
+                and isinstance(parsed_body.get("messages"), list)
+            ):
+                messages_list = parsed_body["messages"]
+                current_msg_count = len(messages_list)
+                conv_fingerprint = self._conversation_fingerprint(messages_list)
+                if conv_fingerprint is not None:
+                    seen_count = self._seen_messages.get(conv_fingerprint, 0)
+
             if self.provider is not None:
-                params = self.provider.extract_request_params(body)
+                if seen_count is not None:
+                    params = self.provider.extract_request_params(
+                        body, seen_count=seen_count
+                    )
+                else:
+                    params = self.provider.extract_request_params(body)
             else:
                 params = extract_request_params(body)
         except ValueError:
             # Non-JSON body — pass through without scanning
             params = {}
+            parsed_body = None
 
-        # Parse JSON body once for stats and streaming detection,
-        # avoiding redundant json.loads() calls.
-        parsed_body = self._parse_body(body)
+        # Parse JSON body for stats and streaming detection
+        # (reuse parsed_body if we already have it).
+        if parsed_body is None:
+            parsed_body = self._parse_body(body)
         message_count, token_est = self._extract_body_stats(parsed_body)
 
         if params:
@@ -262,6 +293,10 @@ class GuardMiddleware:
 
         # Forward to upstream
         import httpx
+
+        # Delta scanning: update seen count after successful scan
+        if conv_fingerprint is not None and current_msg_count > 0:
+            self._seen_messages[conv_fingerprint] = current_msg_count
 
         upstream_url = self.config.upstream_base_url + path
         if request.url.query:
@@ -594,3 +629,34 @@ class GuardMiddleware:
                 rotation=self.config.rotation,
                 retention=self.config.retention,
             )
+
+    @staticmethod
+    def _conversation_fingerprint(messages: list[Any]) -> str | None:
+        """Compute a fingerprint for a conversation from its first message.
+
+        The fingerprint is a SHA-256 hex digest of the first message's
+        role and content.  This lets the middleware identify the same
+        conversation across successive requests (where earlier messages
+        form a stable prefix).
+
+        Args:
+            messages: The messages array from the request body.
+
+        Returns:
+            A hex digest string, or None if the messages list is empty
+            or the first message has no usable content.
+        """
+        if not messages:
+            return None
+        first = messages[0]
+        if not isinstance(first, dict):
+            return None
+        role = first.get("role", "")
+        content = first.get("content", "")
+        if isinstance(content, list):
+            # Structured content blocks — serialize for fingerprinting
+            content = json.dumps(content, sort_keys=True)
+        if not isinstance(content, str):
+            content = str(content)
+        raw = f"{role}:{content}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]

--- a/src/agentguard/proxy/providers/__init__.py
+++ b/src/agentguard/proxy/providers/__init__.py
@@ -32,11 +32,16 @@ class Provider(Protocol):
         """Short identifier for this provider."""
         ...
 
-    def extract_request_params(self, body: bytes) -> dict[str, str]:
+    def extract_request_params(
+        self, body: bytes, *, seen_count: int | None = None
+    ) -> dict[str, str]:
         """Extract scannable parameters from a request body.
 
         Args:
             body: Raw request body bytes.
+            seen_count: Number of messages already scanned.  When
+                provided, only messages at index ``seen_count:`` are
+                extracted (delta scanning).
 
         Returns:
             Dictionary mapping parameter keys (``messages``, ``system``,

--- a/src/agentguard/proxy/providers/openai.py
+++ b/src/agentguard/proxy/providers/openai.py
@@ -24,7 +24,9 @@ class OpenAIProvider:
         """Provider identifier."""
         return "openai"
 
-    def extract_request_params(self, body: bytes) -> dict[str, str]:
+    def extract_request_params(
+        self, body: bytes, *, seen_count: int | None = None
+    ) -> dict[str, str]:
         """Extract scannable parameters from an OpenAI request body.
 
         Parses the JSON body and extracts:
@@ -33,8 +35,16 @@ class OpenAIProvider:
         - ``content``: All user/assistant message content concatenated.
         - ``model``: Model name if present.
 
+        When ``seen_count`` is provided, only messages at index
+        ``seen_count`` and beyond are extracted.  This supports delta
+        scanning: the proxy tracks how many messages it has already
+        scanned in a conversation and only re-scans new ones.
+
         Args:
             body: Raw request body bytes.
+            seen_count: Number of messages already scanned in this
+                conversation.  If None (default), all messages are
+                extracted for backward compatibility.
 
         Returns:
             Dictionary of parameter keys to string values.
@@ -51,6 +61,10 @@ class OpenAIProvider:
 
         messages = data.get("messages")
         if isinstance(messages, list):
+            # Apply delta: skip messages already scanned
+            if seen_count is not None and seen_count > 0:
+                messages = messages[seen_count:]
+
             all_content: list[str] = []
             system_parts: list[str] = []
             user_assistant_parts: list[str] = []

--- a/tests/unit/test_delta_scanning.py
+++ b/tests/unit/test_delta_scanning.py
@@ -1,0 +1,478 @@
+"""Tests for delta scanning in the LLM proxy.
+
+Delta scanning tracks which messages have already been scanned in a
+conversation and only scans new/unseen messages on subsequent requests.
+This avoids re-scanning the entire conversation history on every LLM
+API call, saving compute and reducing false-positive risk from
+repeated scans of benign earlier messages.
+
+Design:
+- ``OpenAIProvider.extract_request_params()`` gains an optional
+  ``seen_count`` parameter: number of messages already scanned.
+  When provided, only messages at index ``seen_count:`` are extracted.
+- ``GuardMiddleware`` tracks per-conversation message counts between
+  requests using a dict keyed by a conversation fingerprint
+  (first message hash or explicit conversation ID).
+- A new ``ProxyConfig.delta_scanning`` bool flag enables/disables
+  the feature (default: False for backward compat).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentguard.proxy.config import ProxyConfig
+from agentguard.proxy.middleware import GuardMiddleware
+from agentguard.proxy.providers.openai import OpenAIProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def provider() -> OpenAIProvider:
+    """Create an OpenAI provider instance."""
+    return OpenAIProvider()
+
+
+@pytest.fixture
+def policy_dir(tmp_path: Path) -> Path:
+    """Create a temp directory with a policy that blocks 'FORBIDDEN'."""
+    d = tmp_path / "policies"
+    d.mkdir()
+    policy = d / "block-forbidden.yaml"
+    policy.write_text(
+        "name: block-forbidden\n"
+        "description: Block FORBIDDEN keyword in messages\n"
+        "rules:\n"
+        "  - action: llm_request\n"
+        "    deny:\n"
+        "      - pattern: 'FORBIDDEN'\n"
+        "    severity: critical\n"
+        "    scan: messages\n"
+    )
+    return d
+
+
+def _make_request(
+    body: dict | None = None,
+    path: str = "/v1/chat/completions",
+    method: str = "POST",
+    query: str = "",
+) -> MagicMock:
+    """Create a mock Starlette Request."""
+    request = MagicMock()
+    request.method = method
+    request.url.path = path
+    request.url.query = query
+    raw_body = json.dumps(body).encode() if body else b""
+    request.body = AsyncMock(return_value=raw_body)
+    request.headers = {"content-type": "application/json", "host": "localhost:8080"}
+    return request
+
+
+def _openai_body(messages: list[dict], model: str = "gpt-4") -> dict:
+    """Build an OpenAI chat completion request body."""
+    return {"model": model, "messages": messages}
+
+
+def _upstream_response(content: str = "OK") -> MagicMock:
+    """Create a mock upstream response."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = json.dumps({"choices": [{"message": {"content": content}}]}).encode()
+    resp.headers = {"content-type": "application/json"}
+    return resp
+
+
+# ===========================================================================
+# Test: OpenAIProvider.extract_request_params with seen_count
+# ===========================================================================
+
+
+class TestProviderDeltaExtraction:
+    """Test that OpenAIProvider extracts only new messages when seen_count is given."""
+
+    def test_extract_all_messages_when_no_seen_count(
+        self, provider: OpenAIProvider
+    ) -> None:
+        """Without seen_count, all messages should be extracted (backward compat)."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi!"},
+                    {"role": "user", "content": "How are you?"},
+                ]
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body)
+        # All 4 messages should be included
+        assert "You are helpful." in params["messages"]
+        assert "Hello" in params["messages"]
+        assert "Hi!" in params["messages"]
+        assert "How are you?" in params["messages"]
+
+    def test_extract_only_new_messages_with_seen_count(
+        self, provider: OpenAIProvider
+    ) -> None:
+        """With seen_count=2, only messages[2:] should be extracted."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi!"},
+                    {"role": "user", "content": "How are you?"},
+                ]
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body, seen_count=2)
+        # Only messages[2:] should be in the extracted content
+        assert "You are helpful." not in params.get("messages", "")
+        assert "Hello" not in params.get("messages", "")
+        assert "Hi!" in params["messages"]
+        assert "How are you?" in params["messages"]
+
+    def test_seen_count_zero_extracts_all(self, provider: OpenAIProvider) -> None:
+        """seen_count=0 should extract all messages (same as default)."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "user", "content": "First"},
+                    {"role": "user", "content": "Second"},
+                ]
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body, seen_count=0)
+        assert "First" in params["messages"]
+        assert "Second" in params["messages"]
+
+    def test_seen_count_equals_message_count_returns_empty(
+        self, provider: OpenAIProvider
+    ) -> None:
+        """When seen_count equals the number of messages, nothing new to scan."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi!"},
+                ]
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body, seen_count=2)
+        # No new messages — params should have no messages/content keys
+        assert "messages" not in params
+        assert "content" not in params
+
+    def test_seen_count_greater_than_message_count_returns_empty(
+        self, provider: OpenAIProvider
+    ) -> None:
+        """When seen_count > len(messages), nothing new to scan."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "user", "content": "Hello"},
+                ]
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body, seen_count=5)
+        assert "messages" not in params
+        assert "content" not in params
+
+    def test_seen_count_skips_system_already_seen(
+        self, provider: OpenAIProvider
+    ) -> None:
+        """System message at index 0, seen_count=1 should skip it."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "system", "content": "System prompt"},
+                    {"role": "user", "content": "New question"},
+                ]
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body, seen_count=1)
+        assert "System prompt" not in params.get("system", "")
+        assert "New question" in params["messages"]
+
+    def test_model_always_extracted_regardless_of_seen_count(
+        self, provider: OpenAIProvider
+    ) -> None:
+        """The model field should always be extracted, even with seen_count."""
+        body = json.dumps(
+            _openai_body(
+                messages=[
+                    {"role": "user", "content": "Hello"},
+                ],
+                model="gpt-4-turbo",
+            )
+        ).encode()
+
+        params = provider.extract_request_params(body, seen_count=1)
+        # No new messages, but model should still be present
+        assert params.get("model") == "gpt-4-turbo"
+
+
+# ===========================================================================
+# Test: ProxyConfig.delta_scanning flag
+# ===========================================================================
+
+
+class TestProxyConfigDeltaScanning:
+    """Test the delta_scanning config flag."""
+
+    def test_delta_scanning_defaults_to_false(self) -> None:
+        """delta_scanning should default to False for backward compat."""
+        config = ProxyConfig(upstream_base_url="https://api.openai.com")
+        assert config.delta_scanning is False
+
+    def test_delta_scanning_can_be_enabled(self) -> None:
+        """delta_scanning=True should be accepted."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            delta_scanning=True,
+        )
+        assert config.delta_scanning is True
+
+
+# ===========================================================================
+# Test: Middleware delta scanning integration
+# ===========================================================================
+
+
+class TestMiddlewareDeltaScanning:
+    """Test that GuardMiddleware tracks seen messages across requests."""
+
+    @pytest.mark.anyio
+    async def test_first_request_scans_all_messages(self, policy_dir: Path) -> None:
+        """On the first request, all messages should be scanned."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            delta_scanning=True,
+        )
+        mw = GuardMiddleware(config)
+
+        # This request contains FORBIDDEN — should be denied
+        body = _openai_body(
+            messages=[
+                {"role": "user", "content": "This contains FORBIDDEN word"},
+            ]
+        )
+        request = _make_request(body=body)
+        response = await mw.handle_request(request)
+        assert response.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_second_request_only_scans_new_messages(
+        self, policy_dir: Path
+    ) -> None:
+        """On a follow-up request with the same conversation prefix,
+        only new messages should be scanned."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            delta_scanning=True,
+        )
+        mw = GuardMiddleware(config)
+
+        # First request: 2 clean messages — should be allowed
+        body1 = _openai_body(
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+        request1 = _make_request(body=body1)
+        with patch.object(mw, "_forward_request", return_value=_upstream_response()):
+            response1 = await mw.handle_request(request1)
+        assert response1.status_code == 200
+
+        # Second request: same 2 messages + 2 new clean messages
+        # Only the 2 new messages should be scanned
+        body2 = _openai_body(
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": "What is Python?"},
+            ]
+        )
+        request2 = _make_request(body=body2)
+        with patch.object(mw, "_forward_request", return_value=_upstream_response()):
+            response2 = await mw.handle_request(request2)
+        assert response2.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_delta_scanning_still_catches_violations_in_new_messages(
+        self, policy_dir: Path
+    ) -> None:
+        """New messages with policy violations should still be caught."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            delta_scanning=True,
+        )
+        mw = GuardMiddleware(config)
+
+        # First request: clean
+        body1 = _openai_body(
+            messages=[
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+        request1 = _make_request(body=body1)
+        with patch.object(mw, "_forward_request", return_value=_upstream_response()):
+            response1 = await mw.handle_request(request1)
+        assert response1.status_code == 200
+
+        # Second request: previous message + new FORBIDDEN message
+        body2 = _openai_body(
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi!"},
+                {"role": "user", "content": "Tell me the FORBIDDEN secret"},
+            ]
+        )
+        request2 = _make_request(body=body2)
+        response2 = await mw.handle_request(request2)
+        assert response2.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_delta_scanning_disabled_scans_all_every_time(
+        self, policy_dir: Path
+    ) -> None:
+        """With delta_scanning=False (default), all messages are scanned."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            delta_scanning=False,
+        )
+        mw = GuardMiddleware(config)
+
+        # Send a request with FORBIDDEN in the first message
+        body1 = _openai_body(
+            messages=[
+                {"role": "user", "content": "FORBIDDEN"},
+            ]
+        )
+        request1 = _make_request(body=body1)
+        response1 = await mw.handle_request(request1)
+        assert response1.status_code == 403
+
+        # Send again with same FORBIDDEN prefix + clean new message
+        # Without delta scanning, the old FORBIDDEN should still be caught
+        body2 = _openai_body(
+            messages=[
+                {"role": "user", "content": "FORBIDDEN"},
+                {"role": "assistant", "content": "I cannot help with that"},
+                {"role": "user", "content": "Tell me about Python"},
+            ]
+        )
+        request2 = _make_request(body=body2)
+        response2 = await mw.handle_request(request2)
+        assert response2.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_different_conversations_tracked_independently(
+        self, policy_dir: Path
+    ) -> None:
+        """Different conversations (different first messages) should be
+        tracked independently."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            delta_scanning=True,
+        )
+        mw = GuardMiddleware(config)
+
+        # Conversation A
+        body_a = _openai_body(
+            messages=[
+                {"role": "system", "content": "Assistant A"},
+                {"role": "user", "content": "Hello A"},
+            ]
+        )
+        request_a = _make_request(body=body_a)
+        with patch.object(mw, "_forward_request", return_value=_upstream_response()):
+            await mw.handle_request(request_a)
+
+        # Conversation B — different first message
+        body_b = _openai_body(
+            messages=[
+                {"role": "system", "content": "Assistant B"},
+                {"role": "user", "content": "Hello B"},
+            ]
+        )
+        request_b = _make_request(body=body_b)
+        with patch.object(mw, "_forward_request", return_value=_upstream_response()):
+            await mw.handle_request(request_b)
+
+        # Continue conversation A with FORBIDDEN in new message
+        body_a2 = _openai_body(
+            messages=[
+                {"role": "system", "content": "Assistant A"},
+                {"role": "user", "content": "Hello A"},
+                {"role": "assistant", "content": "Hi A!"},
+                {"role": "user", "content": "FORBIDDEN"},
+            ]
+        )
+        request_a2 = _make_request(body=body_a2)
+        response_a2 = await mw.handle_request(request_a2)
+        assert response_a2.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_conversation_fingerprint_uses_first_message(
+        self, policy_dir: Path
+    ) -> None:
+        """The conversation fingerprint should be derived from the first message."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            policy_dir=str(policy_dir),
+            delta_scanning=True,
+        )
+        mw = GuardMiddleware(config)
+
+        # Verify the middleware has a _seen_messages dict
+        assert hasattr(mw, "_seen_messages")
+        assert isinstance(mw._seen_messages, dict)
+
+    @pytest.mark.anyio
+    async def test_non_json_body_not_tracked(self) -> None:
+        """Non-JSON bodies should not be tracked for delta scanning."""
+        config = ProxyConfig(
+            upstream_base_url="https://api.openai.com",
+            delta_scanning=True,
+        )
+        mw = GuardMiddleware(config)
+
+        request = MagicMock()
+        request.method = "POST"
+        request.url.path = "/v1/chat/completions"
+        request.url.query = ""
+        request.body = AsyncMock(return_value=b"not json")
+        request.headers = {"content-type": "text/plain", "host": "localhost:8080"}
+
+        with patch.object(mw, "_forward_request", return_value=_upstream_response()):
+            response = await mw.handle_request(request)
+        assert response.status_code == 200
+
+        # No conversations should be tracked
+        assert len(mw._seen_messages) == 0

--- a/tests/unit/test_output_truncation.py
+++ b/tests/unit/test_output_truncation.py
@@ -1,0 +1,431 @@
+"""Tests for MCP tool output truncation.
+
+The MCP server's ``shell_execute``, ``file_read``, and ``file_grep``
+tools currently return unbounded output strings.  Output truncation
+caps the return value at a configurable maximum size (default 51200
+bytes / 50 KB) and appends a truncation notice when the output
+exceeds the limit.
+
+Design:
+- ``create_server()`` gains an optional ``max_output_size`` parameter
+  (default: 51200 bytes).
+- Each tool that returns potentially large output truncates to this
+  limit and appends a notice like:
+  ``\\n... (output truncated from {original_size} to {limit} bytes)``
+- The truncation is applied AFTER the tool runs but BEFORE the
+  result is returned to the client.
+- The audit log records the original size and whether truncation
+  occurred.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import anyio
+import pytest
+from mcp import ClientSession
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Use asyncio as the anyio backend for all tests."""
+    return "asyncio"
+
+
+@pytest.fixture
+def audit_dir(tmp_path: Path) -> Path:
+    """Create a temp directory for audit logs."""
+    d = tmp_path / "audit"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Helper: run a function against an in-process MCP server
+# ---------------------------------------------------------------------------
+
+
+async def with_server(
+    fn: Any,
+    *,
+    policy_dir: Path | None = None,
+    audit_dir: Path | None = None,
+    actor: str = "test-agent",
+    builtins: bool = False,
+    max_output_size: int | None = None,
+) -> None:
+    """Spin up an AgentGuard MCP server in-process and run fn(session).
+
+    Uses anyio memory streams so no real I/O is needed.
+    The server is cancelled once fn returns.
+    """
+    from agentguard.mcp.server import create_server
+
+    kwargs: dict[str, Any] = {
+        "policy_dir": str(policy_dir) if policy_dir else None,
+        "audit_dir": str(audit_dir) if audit_dir else None,
+        "actor": actor,
+        "load_builtins": builtins,
+    }
+    if max_output_size is not None:
+        kwargs["max_output_size"] = max_output_size
+
+    app = create_server(**kwargs)
+
+    server = app._mcp_server  # type: ignore[attr-defined]
+
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[Any](50)
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[Any](50)
+
+    async with anyio.create_task_group() as tg:
+
+        async def run_server() -> None:
+            await server.run(
+                c2s_recv,
+                s2c_send,
+                server.create_initialization_options(),
+            )
+
+        async def run_client() -> None:
+            async with ClientSession(s2c_recv, c2s_send) as session:
+                await session.initialize()
+                await fn(session)
+                tg.cancel_scope.cancel()
+
+        tg.start_soon(run_server)
+        tg.start_soon(run_client)
+
+
+# ===========================================================================
+# Test: create_server accepts max_output_size
+# ===========================================================================
+
+
+class TestCreateServerMaxOutputSize:
+    """Test that create_server accepts and uses the max_output_size param."""
+
+    @pytest.mark.anyio
+    async def test_create_server_accepts_max_output_size(self) -> None:
+        """create_server should accept max_output_size without error."""
+
+        async def check(session: ClientSession) -> None:
+            # Just verify the server starts up fine
+            tools_resp = await session.list_tools()
+            tool_names = {t.name for t in tools_resp.tools}
+            assert "shell_execute" in tool_names
+
+        await with_server(check, max_output_size=1024)
+
+    @pytest.mark.anyio
+    async def test_default_max_output_size_is_51200(self) -> None:
+        """Default max_output_size should be 51200 (50 KB)."""
+
+        # create_server with no max_output_size should use 51200 default
+        # We verify by creating a server and checking it works with
+        # output under 51200 bytes
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("shell_execute", {"command": "echo hello"})
+            assert not result.isError
+            assert "hello" in result.content[0].text  # type: ignore[union-attr]
+
+        await with_server(check)
+
+
+# ===========================================================================
+# Test: shell_execute output truncation
+# ===========================================================================
+
+
+class TestShellExecuteTruncation:
+    """Test output truncation for shell_execute."""
+
+    @pytest.mark.anyio
+    async def test_short_output_not_truncated(self) -> None:
+        """Output under the limit should not be truncated."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("shell_execute", {"command": "echo hello"})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "hello" in text
+            assert "truncated" not in text
+
+        await with_server(check, max_output_size=51200)
+
+    @pytest.mark.anyio
+    async def test_large_output_truncated(self) -> None:
+        """Output exceeding max_output_size should be truncated."""
+        # Generate output larger than our small limit
+        # Use python -c to generate exactly 200 bytes of output
+        cmd = "python3 -c \"print('A' * 200)\""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("shell_execute", {"command": cmd})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            # Should be truncated
+            assert "truncated" in text.lower()
+            # The visible content should be <= max_output_size + notice
+            # The actual content before the notice should be <= 100 bytes
+            assert len(text) < 250  # 100 + truncation notice
+
+        await with_server(check, max_output_size=100)
+
+    @pytest.mark.anyio
+    async def test_truncation_notice_includes_sizes(self) -> None:
+        """Truncation notice should mention original and truncated sizes."""
+        cmd = "python3 -c \"print('B' * 500)\""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("shell_execute", {"command": cmd})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "truncated" in text.lower()
+            # Should mention the limit size
+            assert "100" in text
+
+        await with_server(check, max_output_size=100)
+
+    @pytest.mark.anyio
+    async def test_exact_limit_not_truncated(self) -> None:
+        """Output exactly at the limit should not be truncated."""
+        # Generate exactly 100 bytes: 99 chars + newline
+        cmd = "python3 -c \"print('X' * 99)\""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("shell_execute", {"command": cmd})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "truncated" not in text.lower()
+
+        await with_server(check, max_output_size=100)
+
+
+# ===========================================================================
+# Test: file_read output truncation
+# ===========================================================================
+
+
+class TestFileReadTruncation:
+    """Test output truncation for file_read."""
+
+    @pytest.mark.anyio
+    async def test_small_file_not_truncated(self, tmp_path: Path) -> None:
+        """File under the limit should be returned in full."""
+        test_file = tmp_path / "small.txt"
+        test_file.write_text("hello world")
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("file_read", {"path": str(test_file)})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert text == "hello world"
+            assert "truncated" not in text
+
+        await with_server(check, max_output_size=51200)
+
+    @pytest.mark.anyio
+    async def test_large_file_truncated(self, tmp_path: Path) -> None:
+        """File exceeding max_output_size should be truncated."""
+        test_file = tmp_path / "large.txt"
+        test_file.write_text("A" * 500)
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("file_read", {"path": str(test_file)})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "truncated" in text.lower()
+            # The content portion should be at most 100 bytes
+            lines = text.split("\n")
+            # Last line should be the truncation notice
+            assert "truncated" in lines[-1].lower()
+
+        await with_server(check, max_output_size=100)
+
+    @pytest.mark.anyio
+    async def test_file_truncation_preserves_start(self, tmp_path: Path) -> None:
+        """Truncation should preserve the beginning of the file."""
+        test_file = tmp_path / "content.txt"
+        content = "START_MARKER" + "X" * 500 + "END_MARKER"
+        test_file.write_text(content)
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("file_read", {"path": str(test_file)})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert text.startswith("START_MARKER")
+            assert "END_MARKER" not in text
+
+        await with_server(check, max_output_size=100)
+
+    @pytest.mark.anyio
+    async def test_truncation_audit_records_original_size(
+        self, tmp_path: Path, audit_dir: Path
+    ) -> None:
+        """Audit log should record the original file size and truncation."""
+        test_file = tmp_path / "big.txt"
+        original_content = "Z" * 500
+        test_file.write_text(original_content)
+
+        async def check(session: ClientSession) -> None:
+            await session.call_tool("file_read", {"path": str(test_file)})
+
+            # Query audit log
+            result = await session.call_tool(
+                "agentguard_audit_query", {"action": "file_read"}
+            )
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            # Audit should record original size
+            assert "500" in text
+
+        await with_server(check, max_output_size=100, audit_dir=audit_dir)
+
+
+# ===========================================================================
+# Test: file_grep output truncation
+# ===========================================================================
+
+
+class TestFileGrepTruncation:
+    """Test output truncation for file_grep."""
+
+    @pytest.mark.anyio
+    async def test_small_grep_result_not_truncated(self, tmp_path: Path) -> None:
+        """Grep output under the limit should not be truncated."""
+        test_file = tmp_path / "code.py"
+        test_file.write_text("def hello():\n    return 'world'\n")
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "file_grep",
+                {"pattern": "hello", "path": str(tmp_path)},
+            )
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "hello" in text
+            assert "output truncated" not in text.lower()
+
+        await with_server(check, max_output_size=51200)
+
+    @pytest.mark.anyio
+    async def test_large_grep_result_truncated(self, tmp_path: Path) -> None:
+        """Grep output exceeding max_output_size should be truncated."""
+        # Create many files with matching content to generate large output
+        for i in range(50):
+            f = tmp_path / f"file_{i:03d}.py"
+            f.write_text(f"def function_{i}():\n    match_target = {i}\n")
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "file_grep",
+                {"pattern": "match_target", "path": str(tmp_path)},
+            )
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "truncated" in text.lower()
+
+        await with_server(check, max_output_size=200)
+
+    @pytest.mark.anyio
+    async def test_grep_truncation_preserves_complete_lines(
+        self, tmp_path: Path
+    ) -> None:
+        """Truncation should try to preserve complete match lines."""
+        for i in range(20):
+            f = tmp_path / f"mod_{i:03d}.py"
+            f.write_text(f"SEARCHABLE_LINE_{i} = True\n")
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "file_grep",
+                {"pattern": "SEARCHABLE_LINE", "path": str(tmp_path)},
+            )
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            # If truncated, the truncation should happen at a line boundary
+            if "truncated" in text.lower():
+                # Split at the truncation notice
+                parts = text.rsplit("\n", 1)
+                # The content part should not end mid-line with a partial path
+                content_part = parts[0] if len(parts) > 1 else text
+                # Each complete line should have the full match format
+                for line in content_part.strip().split("\n"):
+                    if line and "truncated" not in line.lower():
+                        assert "SEARCHABLE_LINE" in line
+
+        await with_server(check, max_output_size=300)
+
+
+# ===========================================================================
+# Test: Truncation with max_output_size=0 disables truncation
+# ===========================================================================
+
+
+class TestTruncationDisabled:
+    """Test that max_output_size=0 disables truncation."""
+
+    @pytest.mark.anyio
+    async def test_zero_max_output_disables_truncation(self, tmp_path: Path) -> None:
+        """max_output_size=0 should mean no truncation."""
+        test_file = tmp_path / "huge.txt"
+        test_file.write_text("X" * 100_000)
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool("file_read", {"path": str(test_file)})
+            assert not result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert len(text) == 100_000
+            assert "truncated" not in text
+
+        await with_server(check, max_output_size=0)
+
+
+# ===========================================================================
+# Test: Error outputs not affected by truncation
+# ===========================================================================
+
+
+class TestErrorOutputNotTruncated:
+    """Test that error messages from tools are NOT truncated."""
+
+    @pytest.mark.anyio
+    async def test_command_error_not_truncated(self) -> None:
+        """Tool error messages should not be truncated even if long."""
+
+        async def check(session: ClientSession) -> None:
+            # A failing command — the error message should be intact
+            result = await session.call_tool(
+                "shell_execute",
+                {"command": "exit 1"},
+            )
+            # Errors go through the error path, not the output path
+            assert result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "truncated" not in text.lower()
+
+        await with_server(check, max_output_size=10)
+
+    @pytest.mark.anyio
+    async def test_file_not_found_error_not_truncated(self, tmp_path: Path) -> None:
+        """File-not-found errors should not be truncated."""
+
+        async def check(session: ClientSession) -> None:
+            result = await session.call_tool(
+                "file_read",
+                {"path": str(tmp_path / "nonexistent.txt")},
+            )
+            assert result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "truncated" not in text.lower()
+
+        await with_server(check, max_output_size=10)


### PR DESCRIPTION
## Summary

- **Delta scanning**: proxy tracks which messages have already been scanned per conversation (via first-message SHA-256 fingerprint) and only scans new/unseen messages on subsequent requests. Reduces redundant policy scanning from O(n²) to O(n) over a conversation's lifetime. Controlled by `ProxyConfig.delta_scanning` flag (default: `False` for backward compatibility).
- **MCP output truncation**: `shell_execute`, `file_read`, and `file_grep` tool outputs are capped at a configurable `max_output_size` (default: 50 KB) with a truncation notice appended. Prevents unbounded tool output from flooding LLM context windows. `max_output_size=0` disables truncation. Error outputs are not affected.

## Changes

### Proxy delta scanning
- `OpenAIProvider.extract_request_params()` — new optional `seen_count` keyword parameter; when provided, skips already-scanned messages
- `Provider` protocol — updated to include `seen_count` parameter
- `ProxyConfig` — new `delta_scanning: bool = False` field
- `GuardMiddleware` — tracks `_seen_messages` dict per conversation fingerprint; computes fingerprint from first message; passes `seen_count` to provider on subsequent requests

### MCP output truncation
- `create_server()` — new `max_output_size: int = 51200` parameter
- `_truncate_output()` helper — truncates at byte boundary with notice
- Applied to `shell_execute`, `file_read`, and `file_grep` return values

### Tests
- `tests/unit/test_delta_scanning.py` — provider extraction with seen_count, config flag, middleware integration (first/second request, violations in new messages, disabled mode, independent conversations, non-JSON bodies)
- `tests/unit/test_output_truncation.py` — server param acceptance, shell/file_read/file_grep truncation, size notice, disabled mode, error outputs unaffected