### PR TITLE
fix: wire configure_compaction_logging call in _cmd_proxy

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -1627,6 +1627,12 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
         rotation = _build_rotation_config(args)
         retention = _build_retention_config(args)
         compaction = _build_compaction_config(args)
+        if compaction is not None:
+            from agentguard.proxy.compaction.config import (
+                configure_compaction_logging,
+            )
+
+            configure_compaction_logging(compaction)
         routing = _build_routing_config(args)
         config = ProxyConfig(
             upstream_base_url=args.upstream,

--- a/tests/unit/compaction/test_logging.py
+++ b/tests/unit/compaction/test_logging.py
@@ -497,3 +497,43 @@ class TestMiddlewareAuditMetadata:
             _compacted_body, metrics = await mw._compact_request_body(body)
 
         assert "summarizer_success" in metrics
+
+
+class TestCompactionLoggingWiring:
+    """Verify configure_compaction_logging is called from production code paths."""
+
+    def test_cmd_proxy_calls_configure_compaction_logging(self):
+        """_cmd_proxy must call configure_compaction_logging after building config."""
+        import ast
+        import inspect
+
+        from agentguard.cli import _cmd_proxy
+
+        source = inspect.getsource(_cmd_proxy)
+        tree = ast.parse(source)
+
+        # Walk the AST looking for a call to configure_compaction_logging
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                # Match both `configure_compaction_logging(...)` and
+                # `module.configure_compaction_logging(...)`
+                if (
+                    isinstance(func, ast.Name)
+                    and func.id == "configure_compaction_logging"
+                ):
+                    found = True
+                    break
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "configure_compaction_logging"
+                ):
+                    found = True
+                    break
+
+        assert found, (
+            "configure_compaction_logging() is not called in _cmd_proxy(). "
+            "File logging will never activate at runtime even when "
+            "--compaction-log-dir is set."
+        )


### PR DESCRIPTION
## Summary

- Wire the missing `configure_compaction_logging(compaction)` call in `_cmd_proxy()` after `_build_compaction_config()`, guarded by a `None` check
- Add AST-based wiring test that inspects `_cmd_proxy` source to prevent regression

Addresses non-blocking suggestion from PR #267 review: the function was defined and unit-tested but never called from production code, so file logging would not activate at runtime.