### PR TITLE
fix: difficulty=0 fail-closed + classifier windowing

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -716,6 +716,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "Medium/Complex before routing. Empty string disables."
         ),
     )
+    proxy_parser.add_argument(
+        "--classifier-window",
+        type=int,
+        default=None,
+        help=(
+            "Number of recent messages to send to the difficulty "
+            "classifier. Only the last N messages are classified, "
+            "keeping input small and focused. Default: 5."
+        ),
+    )
 
     return parser
 
@@ -1280,6 +1290,9 @@ def _build_routing_config(
     config = load_routing_config(routing_path)
     config.log_dir = getattr(args, "routing_log_dir", "")
     config.classifier_url = getattr(args, "classifier_url", "")
+    classifier_window = getattr(args, "classifier_window", None)
+    if classifier_window is not None:
+        config.classifier_window = classifier_window
     return config
 
 

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -186,10 +186,27 @@ class GuardMiddleware:
         all_content = " ".join(content_parts)
         token_est = estimate_tokens(all_content)
 
-        # Classify difficulty if classifier is configured
+        # Classify difficulty if classifier is configured.
+        # Use only the last N messages (classifier_window) to focus
+        # on the current task rather than the full conversation history.
         difficulty = 0
         if self._classifier is not None:
-            difficulty = await self._classifier.classify(all_content)
+            window = self.config.routing.classifier_window  # type: ignore[union-attr]
+            windowed_messages = messages[-window:] if window > 0 else messages
+            window_parts: list[str] = []
+            for msg in windowed_messages:
+                if isinstance(msg, dict):
+                    content = msg.get("content", "")
+                    if isinstance(content, str):
+                        window_parts.append(content)
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict):
+                                text = block.get("text")
+                                if isinstance(text, str):
+                                    window_parts.append(text)
+            windowed_content = " ".join(window_parts)
+            difficulty = await self._classifier.classify(windowed_content)
 
         # Route the request
         decision = self.router.route(

--- a/src/agentguard/proxy/routing/config.py
+++ b/src/agentguard/proxy/routing/config.py
@@ -58,6 +58,12 @@ class RoutingConfig:
             Should match a tier name in the tiers list.
         log_dir: Directory for routing log files.  Set via
             ``--routing-log-dir``.  Empty string disables file logging.
+        classifier_url: URL of the difficulty classification service.
+            Empty string disables classification (difficulty=0).
+        classifier_window: Number of recent messages to send to the
+            classifier.  Only the last N messages are classified,
+            keeping classifier input small and focused on the current
+            task.  Defaults to 5.
     """
 
     enabled: bool = False
@@ -65,6 +71,7 @@ class RoutingConfig:
     default_tier: str = "default"
     log_dir: str = ""
     classifier_url: str = ""
+    classifier_window: int = 5
 
 
 def load_routing_config(path: Path | str) -> RoutingConfig:
@@ -137,6 +144,7 @@ def _parse_routing_config(data: dict[str, Any]) -> RoutingConfig:
         tiers=tiers,
         default_tier=str(default_tier),
         classifier_url=str(data.get("classifier_url", "")),
+        classifier_window=int(data.get("classifier_window", 5)),
     )
 
 

--- a/src/agentguard/proxy/routing/router.py
+++ b/src/agentguard/proxy/routing/router.py
@@ -171,8 +171,15 @@ class Router:
                 return False, ""
             reasons.append(f"messages({message_count}) <= {tier.max_messages}")
 
-        # Check difficulty constraint (skip when difficulty=0 / unknown)
-        if tier.max_difficulty is not None and difficulty > 0:
+        # Check difficulty constraint
+        # When difficulty=0 (unknown / classifier failure) and the
+        # tier has a max_difficulty constraint, the tier is REJECTED.
+        # This is fail-closed on the difficulty dimension: we route
+        # to the more capable (and expensive) model rather than risk
+        # sending a complex request to a cheap model.
+        if tier.max_difficulty is not None:
+            if difficulty == 0:
+                return False, ""
             if difficulty > tier.max_difficulty:
                 return False, ""
             reasons.append(f"difficulty({difficulty}) <= {tier.max_difficulty}")

--- a/tests/proxy/routing/test_config.py
+++ b/tests/proxy/routing/test_config.py
@@ -284,3 +284,54 @@ tiers:
 
         config = load_routing_config(config_file)
         assert config.classifier_url == "http://localhost:11435"
+
+
+class TestRoutingConfigClassifierWindow:
+    """Tests for classifier_window field on RoutingConfig."""
+
+    def test_classifier_window_default_is_five(self) -> None:
+        """classifier_window defaults to 5."""
+        from agentguard.proxy.routing.config import RoutingConfig
+
+        config = RoutingConfig()
+        assert config.classifier_window == 5
+
+    def test_classifier_window_can_be_set(self) -> None:
+        """classifier_window can be set to a custom value."""
+        from agentguard.proxy.routing.config import RoutingConfig
+
+        config = RoutingConfig(classifier_window=10)
+        assert config.classifier_window == 10
+
+    def test_classifier_window_loaded_from_yaml(self, tmp_path) -> None:
+        """classifier_window is loaded from YAML config."""
+        from agentguard.proxy.routing.config import load_routing_config
+
+        yaml_content = """\
+enabled: true
+classifier_window: 3
+tiers:
+  - name: default
+    model: claude-sonnet-4
+"""
+        config_file = tmp_path / "routing.yaml"
+        config_file.write_text(yaml_content)
+
+        config = load_routing_config(config_file)
+        assert config.classifier_window == 3
+
+    def test_classifier_window_default_when_not_in_yaml(self, tmp_path) -> None:
+        """classifier_window defaults to 5 when not in YAML."""
+        from agentguard.proxy.routing.config import load_routing_config
+
+        yaml_content = """\
+enabled: true
+tiers:
+  - name: default
+    model: claude-sonnet-4
+"""
+        config_file = tmp_path / "routing.yaml"
+        config_file.write_text(yaml_content)
+
+        config = load_routing_config(config_file)
+        assert config.classifier_window == 5

--- a/tests/proxy/routing/test_middleware_integration.py
+++ b/tests/proxy/routing/test_middleware_integration.py
@@ -239,7 +239,7 @@ class TestMiddlewareNullModelPassthrough:
                 ModelTier(
                     name="passthrough",
                     max_tokens=10000,
-                    max_difficulty=1,
+                    # No max_difficulty — not dependent on classifier
                 ),
                 ModelTier(name="premium", model="claude-opus-4"),
             ],
@@ -281,12 +281,12 @@ class TestMiddlewareNullModelPassthrough:
                 ModelTier(
                     name="fast",
                     max_tokens=10000,
-                    max_difficulty=1,
+                    # No max_difficulty — not dependent on classifier
                 ),
                 ModelTier(
                     name="standard",
                     max_tokens=40000,
-                    max_difficulty=2,
+                    # No max_difficulty — not dependent on classifier
                 ),
                 ModelTier(name="premium"),
             ],
@@ -366,7 +366,12 @@ class TestMiddlewareClassifierWiring:
 
     @pytest.mark.asyncio
     async def test_apply_routing_without_classifier(self) -> None:
-        """Without classifier_url, difficulty defaults to 0 (skip)."""
+        """Without classifier_url, difficulty defaults to 0 (fail-closed).
+
+        When no classifier is configured, difficulty=0 causes tiers
+        with max_difficulty to be rejected.  The request falls through
+        to the next tier without a difficulty constraint.
+        """
         from agentguard.proxy.config import ProxyConfig
         from agentguard.proxy.middleware import GuardMiddleware
         from agentguard.proxy.routing.config import ModelTier, RoutingConfig
@@ -399,14 +404,20 @@ class TestMiddlewareClassifierWiring:
             }
         ).encode()
 
-        # Without classifier, difficulty=0, so max_difficulty check
-        # is skipped — fast tier should match
+        # Without classifier, difficulty=0, so max_difficulty
+        # constraint rejects fast tier → falls through to premium
         _new_body, decision = await mw._apply_routing(body)
-        assert decision.tier_name == "fast"
+        assert decision.tier_name == "premium"
 
     @pytest.mark.asyncio
-    async def test_classifier_error_falls_open(self) -> None:
-        """Classifier error returns difficulty=0, routing proceeds."""
+    async def test_classifier_error_falls_to_premium(self) -> None:
+        """Classifier error returns difficulty=0, tier with max_difficulty rejected.
+
+        When the classifier fails (returns 0), tiers with max_difficulty
+        constraints are rejected.  The request falls through to the
+        premium tier — the safe direction for cost (overspend on quality
+        rather than underspend on capability).
+        """
         from unittest.mock import AsyncMock, patch
 
         from agentguard.proxy.config import ProxyConfig
@@ -446,8 +457,8 @@ class TestMiddlewareClassifierWiring:
             mock_classifier.classify = AsyncMock(return_value=0)
             _new_body, decision = await mw._apply_routing(body)
 
-        # difficulty=0 skips the check → fast tier matches
-        assert decision.tier_name == "fast"
+        # difficulty=0 rejects fast tier → premium
+        assert decision.tier_name == "premium"
 
     @pytest.mark.asyncio
     async def test_complex_request_routes_to_premium(self) -> None:
@@ -543,3 +554,200 @@ class TestMiddlewareClassifierWiring:
         mw = GuardMiddleware(config)
 
         assert mw._classifier is None
+
+
+class TestClassifierWindowing:
+    """Tests for last-N-messages windowing sent to the classifier."""
+
+    @pytest.mark.asyncio
+    async def test_classifier_receives_only_last_n_messages(self) -> None:
+        """Classifier receives content from only the last N messages.
+
+        With classifier_window=2, a 5-message conversation should
+        only pass the last 2 messages' content to the classifier.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            classifier_window=2,
+            tiers=[
+                ModelTier(name="fast", model="claude-haiku-4.5", max_difficulty=2),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "old message 1"},
+                    {"role": "assistant", "content": "old reply 1"},
+                    {"role": "user", "content": "old message 2"},
+                    {"role": "assistant", "content": "old reply 2"},
+                    {"role": "user", "content": "latest question"},
+                ],
+            }
+        ).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            await mw._apply_routing(body)
+
+        # Classifier should have been called with only the last 2
+        # messages' content, not all 5
+        call_args = mock_classifier.classify.call_args
+        classified_text = call_args[0][0]
+        assert "old message 1" not in classified_text
+        assert "old reply 1" not in classified_text
+        assert "old message 2" not in classified_text
+        assert "old reply 2" in classified_text
+        assert "latest question" in classified_text
+
+    @pytest.mark.asyncio
+    async def test_classifier_window_with_fewer_messages(self) -> None:
+        """When conversation has fewer messages than window, use all."""
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            classifier_window=10,  # Window larger than message count
+            tiers=[
+                ModelTier(name="fast", model="claude-haiku-4.5", max_difficulty=2),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi there"},
+                ],
+            }
+        ).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            await mw._apply_routing(body)
+
+        classified_text = mock_classifier.classify.call_args[0][0]
+        # Both messages should be included (fewer than window)
+        assert "hello" in classified_text
+        assert "hi there" in classified_text
+
+    @pytest.mark.asyncio
+    async def test_router_still_gets_full_content(self) -> None:
+        """Router receives ALL content for token estimation and patterns.
+
+        The classifier window only limits what the classifier sees.
+        The router still gets the full content for token estimation,
+        pattern matching, and message count.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            classifier_window=1,  # Only classify last message
+            tiers=[
+                ModelTier(
+                    name="pattern-match",
+                    model="claude-opus-4.6",
+                    patterns=["architect"],
+                ),
+                ModelTier(name="default", model="claude-haiku-4.5"),
+            ],
+            default_tier="default",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "Help me architect a system"},
+                    {"role": "assistant", "content": "Sure, here is the plan"},
+                    {"role": "user", "content": "Looks good"},
+                ],
+            }
+        ).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            _, decision = await mw._apply_routing(body)
+
+        # Pattern "architect" is in message 1 (outside classifier window)
+        # but the router sees ALL content, so pattern match should work
+        assert decision.tier_name == "pattern-match"
+
+    @pytest.mark.asyncio
+    async def test_default_classifier_window_is_five(self) -> None:
+        """Default classifier_window is 5 — classifier sees last 5 messages."""
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            # Default classifier_window=5
+            tiers=[
+                ModelTier(name="fast", model="claude-haiku-4.5", max_difficulty=2),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        messages = [{"role": "user", "content": f"message {i}"} for i in range(10)]
+        body = json.dumps({"model": "claude-opus-4.6", "messages": messages}).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            await mw._apply_routing(body)
+
+        classified_text = mock_classifier.classify.call_args[0][0]
+        # Messages 0-4 should NOT be in classifier input
+        assert "message 0" not in classified_text
+        assert "message 4" not in classified_text
+        # Messages 5-9 should be in classifier input (last 5)
+        assert "message 5" in classified_text
+        assert "message 9" in classified_text

--- a/tests/proxy/routing/test_router.py
+++ b/tests/proxy/routing/test_router.py
@@ -516,8 +516,49 @@ class TestRouterDifficultyMatching:
         assert decision.tier_name == "premium"
         assert decision.model == "claude-opus-4"
 
-    def test_difficulty_zero_skips_constraint(self) -> None:
-        """difficulty=0 (unknown) skips the difficulty constraint."""
+    def test_difficulty_zero_rejects_tier_with_max_difficulty(self) -> None:
+        """difficulty=0 (unknown) does NOT match a tier with max_difficulty.
+
+        When the classifier fails or is unavailable (difficulty=0),
+        tiers that rely on difficulty constraints must be skipped.
+        This ensures complex requests fall through to the premium
+        tier rather than being routed to a cheap model by accident.
+        """
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+        from agentguard.proxy.routing.router import Router
+
+        config = RoutingConfig(
+            enabled=True,
+            tiers=[
+                ModelTier(
+                    name="fast",
+                    model="claude-haiku-4.5",
+                    max_difficulty=2,
+                ),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        router = Router(config)
+
+        # difficulty=0 (unknown/classifier failure) — fast tier has
+        # max_difficulty so it must NOT match; falls through to premium
+        decision = router.route(
+            token_estimate=1000,
+            message_count=5,
+            content="",
+            difficulty=0,
+        )
+        assert decision.tier_name == "premium"
+        assert decision.model == "claude-opus-4.6"
+
+    def test_difficulty_zero_matches_tier_without_max_difficulty(self) -> None:
+        """difficulty=0 still matches tiers that have no max_difficulty.
+
+        Tiers without a difficulty constraint are unaffected by
+        unknown difficulty — they match based on their other
+        constraints (tokens, messages, patterns).
+        """
         from agentguard.proxy.routing.config import ModelTier, RoutingConfig
         from agentguard.proxy.routing.router import Router
 
@@ -527,22 +568,25 @@ class TestRouterDifficultyMatching:
                 ModelTier(
                     name="fast",
                     model="claude-sonnet-4",
-                    max_difficulty=1,
+                    max_tokens=10000,
+                    # No max_difficulty — not dependent on classifier
                 ),
-                ModelTier(name="premium", model="claude-opus-4"),
+                ModelTier(name="premium", model="claude-opus-4.6"),
             ],
             default_tier="premium",
         )
         router = Router(config)
 
-        # difficulty=0 (unknown) — max_difficulty constraint is skipped
+        # difficulty=0 — fast tier has no max_difficulty constraint,
+        # so it matches based on tokens alone
         decision = router.route(
-            token_estimate=1000,
+            token_estimate=5000,
             message_count=5,
             content="",
             difficulty=0,
         )
         assert decision.tier_name == "fast"
+        assert decision.model == "claude-sonnet-4"
 
     def test_difficulty_combined_with_tokens(self) -> None:
         """Difficulty constraint works alongside token constraint (AND logic)."""
@@ -592,7 +636,12 @@ class TestRouterDifficultyMatching:
         assert decision.tier_name == "premium"
 
     def test_difficulty_default_is_zero(self) -> None:
-        """Calling route() without difficulty defaults to 0 (skip)."""
+        """Calling route() without difficulty defaults to 0.
+
+        When difficulty defaults to 0, tiers with max_difficulty are
+        rejected (fail-closed on difficulty), so the request falls
+        through to the next tier without a difficulty constraint.
+        """
         from agentguard.proxy.routing.config import ModelTier, RoutingConfig
         from agentguard.proxy.routing.router import Router
 
@@ -610,13 +659,14 @@ class TestRouterDifficultyMatching:
         )
         router = Router(config)
 
-        # No difficulty argument — defaults to 0, difficulty check skipped
+        # No difficulty argument — defaults to 0, tier with
+        # max_difficulty is rejected, falls through to premium
         decision = router.route(
             token_estimate=1000,
             message_count=5,
             content="",
         )
-        assert decision.tier_name == "fast"
+        assert decision.tier_name == "premium"
 
     def test_three_tier_difficulty_routing(self) -> None:
         """Three-tier setup: simple→fast, medium→standard, complex→premium."""


### PR DESCRIPTION
Two routing improvements:

**1. Fix fail-open bug on classifier failure**

When the classifier fails or is unavailable (difficulty=0), tiers with `max_difficulty` constraints are now **rejected** instead of matched. This prevents complex requests from being accidentally routed to cheap models when the classifier is down.

- Before: difficulty=0 skipped the max_difficulty check → first tier matched unconditionally (fail-open to cheap model)
- After: difficulty=0 rejects tiers with max_difficulty → falls through to premium tier (fail-open to expensive model — the safe direction)

**2. Classifier windowing**

Adds `classifier_window` config field (default: 5). Only the last N messages are sent to the difficulty classifier, keeping input small and focused on the current task. The router still sees all content for token estimation and pattern matching.

- New field: `RoutingConfig.classifier_window: int = 5`
- YAML: `classifier_window: 3`
- CLI: `--classifier-window 3`

**Files changed:**
- `src/agentguard/proxy/routing/router.py` — difficulty=0 now rejects tiers with max_difficulty
- `src/agentguard/proxy/routing/config.py` — classifier_window field + YAML parsing
- `src/agentguard/proxy/middleware.py` — windowed content extraction for classifier
- `src/agentguard/cli.py` — `--classifier-window` flag
- `tests/proxy/routing/test_router.py` — updated difficulty=0 tests
- `tests/proxy/routing/test_config.py` — classifier_window config tests
- `tests/proxy/routing/test_middleware_integration.py` — windowing + fail-closed integration tests