### PR TITLE
feat: log classified_text in audit entries for training dataset

### DIFF
--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -194,6 +194,7 @@ class GuardMiddleware:
         # Complex.  The actual user intent is in the last real human
         # message.
         difficulty = 0
+        classifier_input = ""
         if self._classifier is not None:
             classifier_input = self._extract_last_user_message(messages)
             difficulty = await self._classifier.classify(classifier_input)
@@ -205,6 +206,15 @@ class GuardMiddleware:
             content=all_content,
             difficulty=difficulty,
         )
+
+        # Attach classified text to the decision for audit logging.
+        # The router doesn't know about classifier input — only the
+        # middleware extracts it.  We use dataclasses.replace since
+        # RoutingDecision is frozen.
+        if classifier_input:
+            from dataclasses import replace
+
+            decision = replace(decision, classified_text=classifier_input)
 
         # Rewrite model if the decision specifies one
         if decision.model is not None:
@@ -232,6 +242,8 @@ class GuardMiddleware:
             metadata["routing_upstream"] = str(decision.upstream_url)
         if decision.reason:
             metadata["routing_reason"] = str(decision.reason)
+        if decision.classified_text:
+            metadata["classified_text"] = decision.classified_text
         return metadata
 
     async def _compact_request_body(

--- a/src/agentguard/proxy/routing/router.py
+++ b/src/agentguard/proxy/routing/router.py
@@ -30,12 +30,16 @@ class RoutingDecision:
         upstream_url: Override upstream URL, or None to use the
             default upstream.
         reason: Human-readable explanation of why this tier was chosen.
+        classified_text: The user message text sent to the difficulty
+            classifier, or empty string if classification was skipped.
+            Stored for audit logging and training dataset extraction.
     """
 
     tier_name: str
     model: str | None
     upstream_url: str | None
     reason: str
+    classified_text: str = ""
 
 
 class Router:

--- a/tests/proxy/routing/test_middleware_integration.py
+++ b/tests/proxy/routing/test_middleware_integration.py
@@ -936,3 +936,229 @@ class TestClassifierWindowing:
         # Pattern "architect" is in message 1 (not the last user msg)
         # but the router sees ALL content, so pattern match should work
         assert decision.tier_name == "pattern-match"
+
+
+class TestClassifiedTextInAudit:
+    """Tests for logging classified_text in audit and routing decisions."""
+
+    @pytest.mark.asyncio
+    async def test_routing_decision_includes_classified_text(self) -> None:
+        """RoutingDecision carries the classified text for audit logging."""
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            tiers=[
+                ModelTier(
+                    name="fast",
+                    model="claude-haiku-4.5",
+                    max_difficulty=2,
+                ),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "What is 2+2?"},
+                ],
+            }
+        ).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            _, decision = await mw._apply_routing(body)
+
+        assert decision.classified_text == "What is 2+2?"
+
+    @pytest.mark.asyncio
+    async def test_classified_text_empty_without_classifier(self) -> None:
+        """Without a classifier, classified_text is empty string."""
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="",
+            tiers=[
+                ModelTier(name="default", model="claude-sonnet-4"),
+            ],
+            default_tier="default",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                ],
+            }
+        ).encode()
+
+        _, decision = await mw._apply_routing(body)
+        assert decision.classified_text == ""
+
+    @pytest.mark.asyncio
+    async def test_classified_text_in_audit_metadata(self) -> None:
+        """classified_text appears in routing audit metadata."""
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            tiers=[
+                ModelTier(
+                    name="fast",
+                    model="claude-haiku-4.5",
+                    max_difficulty=2,
+                ),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "Explain quicksort"},
+                ],
+            }
+        ).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            _, decision = await mw._apply_routing(body)
+
+        metadata = mw._routing_audit_metadata(decision)
+        assert metadata["classified_text"] == "Explain quicksort"
+
+    @pytest.mark.asyncio
+    async def test_classified_text_omitted_when_empty(self) -> None:
+        """classified_text is not in audit metadata when empty."""
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            tiers=[
+                ModelTier(name="default", model="claude-sonnet-4"),
+            ],
+            default_tier="default",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                ],
+            }
+        ).encode()
+
+        _, decision = await mw._apply_routing(body)
+        metadata = mw._routing_audit_metadata(decision)
+        assert "classified_text" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_classified_text_from_agentic_conversation(
+        self,
+    ) -> None:
+        """classified_text is the last user message, not tool output."""
+        from unittest.mock import AsyncMock, patch
+
+        from agentguard.proxy.config import ProxyConfig
+        from agentguard.proxy.middleware import GuardMiddleware
+        from agentguard.proxy.routing.config import ModelTier, RoutingConfig
+
+        routing = RoutingConfig(
+            enabled=True,
+            classifier_url="http://localhost:11435",
+            tiers=[
+                ModelTier(
+                    name="fast",
+                    model="claude-haiku-4.5",
+                    max_difficulty=2,
+                ),
+                ModelTier(name="premium", model="claude-opus-4.6"),
+            ],
+            default_tier="premium",
+        )
+        config = ProxyConfig(
+            upstream_base_url="https://api.example.com",
+            routing=routing,
+        )
+        mw = GuardMiddleware(config)
+
+        body = json.dumps(
+            {
+                "model": "claude-opus-4.6",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Help me architect a system",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "bash",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "PASSED 1874 tests in 45.2s",
+                    },
+                    {"role": "user", "content": "looks good"},
+                ],
+            }
+        ).encode()
+
+        with patch.object(mw, "_classifier", create=True) as mock_classifier:
+            mock_classifier.classify = AsyncMock(return_value=1)
+            _, decision = await mw._apply_routing(body)
+
+        # classified_text is the LAST user message, not tool output
+        assert decision.classified_text == "looks good"


### PR DESCRIPTION
Enables extraction of (text, difficulty) training pairs from audit logs.

Every routed request now records the user message that was sent to the difficulty classifier in the audit JSONL. This allows building benchmark datasets and fine-tuning the classifier from production traffic.

**Changes:**
- `RoutingDecision` — new `classified_text: str` field (default `""`)
- `_apply_routing()` — captures `classifier_input` and attaches it to the decision via `dataclasses.replace()`
- `_routing_audit_metadata()` — includes `classified_text` when non-empty
- 5 new tests covering: text in decision, empty without classifier, text in audit metadata, omitted when empty, agentic conversation extraction

**Audit JSONL after this change:**
```json
{"classified_text": "What is 2+2?", "difficulty": 1, "routing_tier": "fast", ...}
```

**Dataset extraction (future):**
```bash
jq -c 'select(.classified_text != null) | {text: .classified_text, difficulty, tier: .routing_tier}' audit.jsonl
```