### PR TITLE
docs: update README and architecture diagram with model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ AgentGuard guards AI agents at **two layers**:
    outbound prompts for secrets/PII before they reach the LLM. Scans
    inbound responses for prompt injection and exfiltration patterns in
    real time, including streaming (SSE). Terminates dangerous streams
-   mid-flight. Compresses bloated conversations via context compaction
+   mid-flight. Routes requests to cheaper models when the task is simple
+   (model routing). Compresses bloated conversations via context compaction
    before forwarding, saving tokens and money on every request.
 
 <p align="center">
@@ -325,6 +326,41 @@ agentguard proxy https://api.openai.com \
 Compaction metrics (phase used, tokens before/after) are recorded in
 every audit log entry, so you can measure savings over time.
 
+### Model Routing
+
+Route requests to different LLM models based on task complexity. Simple
+queries go to fast, cheap models (Haiku at 0.33× cost); complex reasoning
+goes to premium models (Opus at 3× cost). A DistilBERT classifier scores
+query difficulty in real time:
+
+```bash
+agentguard proxy https://api.openai.com \
+  --routing-config routing.yaml \
+  --classifier-url http://localhost:11435 \
+  --routing-log-dir /var/log/agentguard \
+  --audit-dir audit/
+```
+
+```yaml
+# routing.yaml
+routing:
+  enabled: true
+  tiers:
+    - name: fast
+      model: claude-haiku-4.5
+      max_difficulty: 2    # Simple + medium queries
+    - name: premium
+      model: claude-opus-4.5
+      # No max_difficulty = fallback for complex
+```
+
+The classifier extracts the last user message (skipping tool results) and
+returns a difficulty score (1=simple, 2=medium, 3=complex). Fail-open: if
+the classifier is unavailable, requests pass through to the original model.
+
+Routing decisions are logged with structured metrics (tier, model, reason,
+difficulty) for cost analysis.
+
 ### Delta Scanning
 
 By default, the proxy scans the entire conversation on every request.
@@ -568,9 +604,11 @@ src/agentguard/
   mcp/              MCP server: transparent tool proxy with policy enforcement
   proxy/            LLM API proxy: middleware, outbound/inbound scanners
     compaction/     Context compaction: truncation, summarization, metrics
+    routing/        Model routing: difficulty classifier, tier-based routing
     providers/      Format adapters: Provider protocol, OpenAI adapter
   scanner/          Package scanner: regex-based source code analysis, 6 risk categories
   trust/            Trust registry: trust levels, hash verification, YAML persistence
+  sandbox/          Policy sandbox: scenario runner, TPR/FPR gating
   cli.py            Command-line interface
 ```
 
@@ -583,7 +621,7 @@ src/agentguard/
 5. **Streaming-aware** — scans SSE responses in real time, terminates on violation
 6. **Extensible** — YAML policies, pluggable providers, pluggable interceptors
 7. **Type-safe** — full mypy strict compliance, py.typed marker
-8. **Tested** — 1700+ tests, TDD, CI on Python 3.10–3.13
+8. **Tested** — 1850+ tests, TDD, CI on Python 3.10–3.13
 
 ## Roadmap
 
@@ -604,6 +642,7 @@ src/agentguard/
 - [ ] Anthropic provider adapter
 - [x] Audit log rotation and retention (size/age thresholds, file count limits)
 - [x] Context compaction (rule-based truncation + local model summarization)
+- [x] Model routing (difficulty classifier + tier-based model selection)
 - [x] Delta scanning (incremental message scanning)
 - [x] Policy sandbox (scenario-driven validation, deployment gating)
 - [x] Web fetch tool (JS-rendering headless browser)

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 520" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 580" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="13">
   <defs>
     <marker id="arrow-right" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
       <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
@@ -25,31 +25,40 @@
   </style>
 
   <!-- Outer AgentGuard box -->
-  <rect x="220" y="20" width="480" height="480" class="outer-box"/>
-  <text x="460" y="52" text-anchor="middle" class="title">AgentGuard</text>
+  <rect x="220" y="20" width="580" height="540" class="outer-box"/>
+  <text x="510" y="52" text-anchor="middle" class="title">AgentGuard</text>
 
   <!-- AI Agent box (external, left) -->
   <rect x="20" y="100" width="130" height="80" rx="6" fill="#e0f2fe" stroke="#0284c7" stroke-width="1.5"/>
   <text x="85" y="138" text-anchor="middle" class="label-lg" fill="#0369a1">AI Agent</text>
   <text x="85" y="156" text-anchor="middle" class="label-sm" fill="#0369a1">(MCP client)</text>
 
-  <!-- LLM API box (external, right) -->
-  <rect x="770" y="100" width="130" height="80" rx="6" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
-  <text x="835" y="134" text-anchor="middle" class="label-lg" fill="#92400e">LLM API</text>
-  <text x="835" y="152" text-anchor="middle" class="label-sm" fill="#92400e">(OpenAI, Anthropic,</text>
-  <text x="835" y="166" text-anchor="middle" class="label-sm" fill="#92400e">Azure, etc.)</text>
+  <!-- LLM API boxes (external, right) - two tiers -->
+  <rect x="870" y="70" width="130" height="60" rx="6" fill="#dcfce7" stroke="#16a34a" stroke-width="1.5"/>
+  <text x="935" y="98" text-anchor="middle" class="label-lg" fill="#166534">Fast Model</text>
+  <text x="935" y="114" text-anchor="middle" class="label-sm" fill="#166534">(Haiku 0.33×)</text>
+
+  <rect x="870" y="140" width="130" height="60" rx="6" fill="#fef3c7" stroke="#d97706" stroke-width="1.5"/>
+  <text x="935" y="168" text-anchor="middle" class="label-lg" fill="#92400e">Premium Model</text>
+  <text x="935" y="184" text-anchor="middle" class="label-sm" fill="#92400e">(Opus 3×)</text>
 
   <!-- Outbound Scanner box -->
-  <rect x="250" y="90" width="170" height="100" rx="6" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
-  <text x="335" y="130" text-anchor="middle" class="label-lg" fill="#991b1b">Outbound</text>
-  <text x="335" y="148" text-anchor="middle" class="label-lg" fill="#991b1b">Scanner</text>
-  <text x="335" y="170" text-anchor="middle" class="label-sm" fill="#991b1b">secrets · PII · paths</text>
+  <rect x="250" y="90" width="150" height="90" rx="6" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+  <text x="325" y="125" text-anchor="middle" class="label-lg" fill="#991b1b">Outbound</text>
+  <text x="325" y="143" text-anchor="middle" class="label-lg" fill="#991b1b">Scanner</text>
+  <text x="325" y="165" text-anchor="middle" class="label-sm" fill="#991b1b">secrets · PII · paths</text>
 
-  <!-- LLM API Proxy box -->
-  <rect x="480" y="90" width="170" height="100" rx="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.5"/>
-  <text x="565" y="130" text-anchor="middle" class="label-lg" fill="#065f46">LLM API</text>
-  <text x="565" y="148" text-anchor="middle" class="label-lg" fill="#065f46">Proxy</text>
-  <text x="565" y="170" text-anchor="middle" class="label-sm" fill="#065f46">policy enforcement</text>
+  <!-- Context Compaction box -->
+  <rect x="420" y="90" width="150" height="90" rx="6" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="495" y="120" text-anchor="middle" class="label-lg" fill="#166534">Context</text>
+  <text x="495" y="138" text-anchor="middle" class="label-lg" fill="#166534">Compaction</text>
+  <text x="495" y="160" text-anchor="middle" class="label-sm" fill="#166534">3-phase · 60k budget</text>
+
+  <!-- Model Router box -->
+  <rect x="590" y="90" width="150" height="90" rx="6" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="665" y="120" text-anchor="middle" class="label-lg" fill="#1e40af">Model</text>
+  <text x="665" y="138" text-anchor="middle" class="label-lg" fill="#1e40af">Router</text>
+  <text x="665" y="160" text-anchor="middle" class="label-sm" fill="#1e40af">difficulty classifier</text>
 
   <!-- Arrows: AI Agent → Outbound Scanner (prompts) -->
   <line x1="150" y1="125" x2="248" y2="125" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
@@ -59,51 +68,86 @@
   <line x1="248" y1="155" x2="150" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
   <text x="199" y="172" text-anchor="middle" class="arrow-label">responses</text>
 
-  <!-- Arrows: Outbound Scanner → LLM API Proxy -->
-  <line x1="420" y1="130" x2="478" y2="130" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
-  <!-- Arrows: Outbound Scanner ← LLM API Proxy -->
-  <line x1="478" y1="150" x2="420" y2="150" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
+  <!-- Arrows: Outbound Scanner → Context Compaction -->
+  <line x1="400" y1="130" x2="418" y2="130" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
 
-  <!-- Arrows: LLM API Proxy → LLM API (forwarded) -->
-  <line x1="650" y1="125" x2="768" y2="125" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
-  <text x="709" y="118" text-anchor="middle" class="arrow-label">forwarded</text>
+  <!-- Arrows: Context Compaction → Model Router -->
+  <line x1="570" y1="130" x2="588" y2="130" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
 
-  <!-- Arrows: LLM API → LLM API Proxy (responses) -->
-  <line x1="768" y1="155" x2="650" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
-  <text x="709" y="172" text-anchor="middle" class="arrow-label">responses</text>
+  <!-- Arrows: Model Router → Fast Model -->
+  <line x1="740" y1="115" x2="868" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <text x="804" y="100" text-anchor="middle" class="arrow-label">simple</text>
 
-  <!-- Policy Engine label (between scanner columns and lower boxes) -->
-  <line x1="335" y1="190" x2="335" y2="260" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)" marker-start="url(#arrow-up)"/>
-  <line x1="565" y1="190" x2="565" y2="260" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)" marker-start="url(#arrow-up)"/>
-  <text x="450" y="232" text-anchor="middle" class="label-sm">policy engine</text>
+  <!-- Arrows: Model Router → Premium Model -->
+  <line x1="740" y1="145" x2="868" y2="165" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <text x="804" y="165" text-anchor="middle" class="arrow-label">complex</text>
+
+  <!-- Arrows: LLM APIs → back through chain (responses) -->
+  <line x1="868" y1="185" x2="740" y2="165" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-left)"/>
+
+  <!-- Policy Engine label -->
+  <line x1="325" y1="180" x2="325" y2="240" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)" marker-start="url(#arrow-up)"/>
+  <line x1="665" y1="180" x2="665" y2="240" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)" marker-start="url(#arrow-up)"/>
+  <text x="495" y="218" text-anchor="middle" class="label-sm">policy engine</text>
 
   <!-- MCP Server box -->
-  <rect x="250" y="262" width="170" height="80" rx="6" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="335" y="298" text-anchor="middle" class="label-lg" fill="#5b21b6">MCP Server</text>
-  <text x="335" y="318" text-anchor="middle" class="label-sm" fill="#5b21b6">7 guarded tools</text>
+  <rect x="250" y="250" width="170" height="80" rx="6" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="335" y="286" text-anchor="middle" class="label-lg" fill="#5b21b6">MCP Server</text>
+  <text x="335" y="306" text-anchor="middle" class="label-sm" fill="#5b21b6">8 guarded tools</text>
 
   <!-- Inbound Scanner box -->
-  <rect x="480" y="262" width="170" height="80" rx="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
-  <text x="565" y="298" text-anchor="middle" class="label-lg" fill="#9a3412">Inbound Scanner</text>
-  <text x="565" y="318" text-anchor="middle" class="label-sm" fill="#9a3412">SSE sliding window</text>
+  <rect x="570" y="250" width="170" height="80" rx="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5"/>
+  <text x="655" y="286" text-anchor="middle" class="label-lg" fill="#9a3412">Inbound Scanner</text>
+  <text x="655" y="306" text-anchor="middle" class="label-sm" fill="#9a3412">SSE sliding window</text>
 
   <!-- Arrow: AI Agent → MCP Server (tool calls) -->
-  <line x1="85" y1="180" x2="85" y2="300" stroke="#64748b" stroke-width="1.5" stroke-dasharray="0"/>
-  <line x1="85" y1="300" x2="248" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
+  <line x1="85" y1="180" x2="85" y2="288" stroke="#64748b" stroke-width="1.5" stroke-dasharray="0"/>
+  <line x1="85" y1="288" x2="248" y2="288" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow-right)"/>
   <text x="60" y="228" text-anchor="end" class="label-sm">MCP tools</text>
-  <text x="167" y="290" text-anchor="middle" class="arrow-label">shell_execute</text>
-  <text x="167" y="304" text-anchor="middle" class="arrow-label">file_read / file_write</text>
-  <text x="167" y="318" text-anchor="middle" class="arrow-label">file_edit / file_glob</text>
-  <text x="167" y="332" text-anchor="middle" class="arrow-label">file_grep / file_list</text>
+  <text x="167" y="278" text-anchor="middle" class="arrow-label">shell_execute</text>
+  <text x="167" y="292" text-anchor="middle" class="arrow-label">file_read / file_write</text>
+  <text x="167" y="306" text-anchor="middle" class="arrow-label">file_edit / file_glob</text>
+  <text x="167" y="320" text-anchor="middle" class="arrow-label">file_grep / file_list</text>
+
+  <!-- Difficulty Classifier box (external, bottom right) -->
+  <rect x="870" y="250" width="130" height="60" rx="6" fill="#fdf4ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="935" y="278" text-anchor="middle" class="label-lg" fill="#7e22ce">Classifier</text>
+  <text x="935" y="296" text-anchor="middle" class="label-sm" fill="#7e22ce">(DistilBERT)</text>
+
+  <!-- Arrow: Model Router → Classifier -->
+  <line x1="740" y1="155" x2="775" y2="280" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3"/>
+  <line x1="775" y1="280" x2="868" y2="280" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-right)"/>
+  <text x="810" y="272" text-anchor="middle" class="arrow-label">classify</text>
 
   <!-- Audit Log box -->
-  <rect x="280" y="400" width="340" height="70" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1.5"/>
-  <text x="450" y="432" text-anchor="middle" class="label-lg" fill="#1e293b">Hash-Chained Audit Log</text>
-  <text x="450" y="452" text-anchor="middle" class="label-sm">JSONL · SHA-256 linked · tamper-evident</text>
+  <rect x="320" y="380" width="360" height="70" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1.5"/>
+  <text x="500" y="412" text-anchor="middle" class="label-lg" fill="#1e293b">Hash-Chained Audit Log</text>
+  <text x="500" y="432" text-anchor="middle" class="label-sm">JSONL · SHA-256 linked · rotation · retention</text>
 
   <!-- Arrow: MCP Server → Audit Log -->
-  <line x1="335" y1="342" x2="335" y2="398" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
+  <line x1="335" y1="330" x2="335" y2="378" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
 
   <!-- Arrow: Inbound Scanner → Audit Log -->
-  <line x1="565" y1="342" x2="565" y2="398" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
+  <line x1="655" y1="330" x2="655" y2="378" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
+
+  <!-- Policy Sandbox box -->
+  <rect x="250" y="480" width="150" height="60" rx="6" fill="#fef9c3" stroke="#ca8a04" stroke-width="1.5"/>
+  <text x="325" y="508" text-anchor="middle" class="label-lg" fill="#854d0e">Policy Sandbox</text>
+  <text x="325" y="524" text-anchor="middle" class="label-sm" fill="#854d0e">59 scenarios · gate</text>
+
+  <!-- Trust Registry box -->
+  <rect x="420" y="480" width="150" height="60" rx="6" fill="#e0e7ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="495" y="508" text-anchor="middle" class="label-lg" fill="#4338ca">Trust Registry</text>
+  <text x="495" y="524" text-anchor="middle" class="label-sm" fill="#4338ca">SHA-256 verified</text>
+
+  <!-- Package Scanner box -->
+  <rect x="590" y="480" width="150" height="60" rx="6" fill="#fee2e2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="665" y="508" text-anchor="middle" class="label-lg" fill="#b91c1c">Package Scanner</text>
+  <text x="665" y="524" text-anchor="middle" class="label-sm" fill="#b91c1c">22 rules · 6 categories</text>
+
+  <!-- Arrow: Audit Log → Policy Sandbox -->
+  <line x1="400" y1="450" x2="325" y2="478" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-down)"/>
+
+  <!-- Compaction details label -->
+  <text x="495" y="78" text-anchor="middle" class="label-sm">truncate → summarize → hard cap</text>
 </svg>


### PR DESCRIPTION
Updates the README and architecture.svg to reflect current features.

## Changes

### Architecture diagram (docs/architecture.svg)
- Added **Context Compaction** box (3-phase: truncate → summarize → hard cap)
- Added **Model Router** box with 2-tier routing (fast/premium models)
- Added **Difficulty Classifier** box (external DistilBERT service)
- Added **Policy Sandbox**, **Trust Registry**, **Package Scanner** boxes
- Updated MCP Server to show 8 guarded tools (was 7)
- Updated Audit Log to mention rotation/retention
- Expanded viewBox to accommodate new components

### README.md
- Added **Model Routing** section with configuration example
- Updated solution description to mention model routing
- Updated test count from 1700+ to 1850+
- Added `routing/` and `sandbox/` to architecture tree
- Marked model routing as complete in roadmap

## Screenshots

The new architecture diagram shows the full proxy pipeline:
```
AI Agent → Outbound Scanner → Context Compaction → Model Router → LLM APIs
                                                         ↓
                                                   Difficulty Classifier
```