### PR TITLE
feat: add NIST AI RMF report generator

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -569,7 +569,7 @@ def _build_parser() -> argparse.ArgumentParser:
     report_parser = subparsers.add_parser("report", help="Generate compliance reports.")
     report_parser.add_argument(
         "framework",
-        help="Compliance framework (e.g. eu-ai-act, iso-42001).",
+        help="Compliance framework (e.g. eu-ai-act, iso-42001, nist-ai-rmf).",
     )
     report_parser.add_argument("file", help="Path to the audit JSONL file.")
     report_parser.add_argument(
@@ -1655,7 +1655,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
     """Generate a compliance report."""
     framework = args.framework.lower()
 
-    supported_frameworks = ("eu-ai-act", "iso-42001")
+    supported_frameworks = ("eu-ai-act", "iso-42001", "nist-ai-rmf")
     if framework not in supported_frameworks:
         print(
             f"Error: Unknown framework '{args.framework}'. "
@@ -1674,10 +1674,14 @@ def _cmd_report(args: argparse.Namespace) -> int:
         from agentguard.compliance.eu_ai_act import EUAIActReportGenerator
 
         report = EUAIActReportGenerator().generate(log)
-    else:  # iso-42001
+    elif framework == "iso-42001":
         from agentguard.compliance.iso_42001 import ISO42001ReportGenerator
 
         report = ISO42001ReportGenerator().generate(log)
+    else:  # nist-ai-rmf
+        from agentguard.compliance.nist_ai_rmf import NISTAIRMFReportGenerator
+
+        report = NISTAIRMFReportGenerator().generate(log)
 
     if args.format == "json":
         output = render_json(report, output=args.output)

--- a/src/agentguard/compliance/__init__.py
+++ b/src/agentguard/compliance/__init__.py
@@ -1,4 +1,4 @@
-"""Compliance reporting for EU AI Act, ISO 42001, and other regulatory frameworks.
+"""Compliance reporting for EU AI Act, ISO 42001, NIST AI RMF, and other frameworks.
 
 Provides data models, report generators, and renderers for producing
 compliance reports from AgentGuard audit logs.
@@ -13,6 +13,7 @@ from agentguard.compliance.models import (
     ReportSection,
     SectionStatus,
 )
+from agentguard.compliance.nist_ai_rmf import NISTAIRMFReportGenerator
 from agentguard.compliance.renderers import render_json, render_text
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "Finding",
     "FindingSeverity",
     "ISO42001ReportGenerator",
+    "NISTAIRMFReportGenerator",
     "ReportSection",
     "SectionStatus",
     "render_json",

--- a/src/agentguard/compliance/nist_ai_rmf.py
+++ b/src/agentguard/compliance/nist_ai_rmf.py
@@ -1,0 +1,460 @@
+"""NIST AI Risk Management Framework (AI RMF 1.0) compliance report generator.
+
+Analyzes an AuditLog and produces a ComplianceReport assessing
+compliance with key NIST AI RMF functions and subcategories:
+
+- GOVERN 1:  Governance — policies and oversight
+- MAP 1:     Context — AI system context and scope mapping
+- MEASURE 2: Assessment — risk measurement metrics
+- MANAGE 1:  Risk Response — active risk mitigation
+- MANAGE 2:  Monitoring — ongoing monitoring and integrity
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from agentguard.compliance.models import (
+    ComplianceReport,
+    Finding,
+    FindingSeverity,
+    ReportSection,
+    SectionStatus,
+)
+
+if TYPE_CHECKING:
+    from agentguard.audit.log import AuditLog
+
+# Threshold: error rate above this fraction triggers FAIL in MEASURE 2.
+_ERROR_RATE_FAIL_THRESHOLD = 0.5
+
+
+class NISTAIRMFReportGenerator:
+    """Generate NIST AI RMF compliance reports from audit logs.
+
+    Analyzes an AuditLog against five subcategories of the NIST AI
+    Risk Management Framework (AI RMF 1.0) that are most relevant
+    to autonomous AI agent governance:
+
+    - GOVERN 1: Policies and oversight (actor diversity, policy enforcement)
+    - MAP 1: Context mapping (action type diversity, scope coverage)
+    - MEASURE 2: Risk measurement (error rates, denial rates)
+    - MANAGE 1: Risk response (denied actions as risk management)
+    - MANAGE 2: Monitoring (log integrity, completeness)
+
+    Usage::
+
+        from agentguard.audit.log import AuditLog
+        from agentguard.compliance.nist_ai_rmf import NISTAIRMFReportGenerator
+
+        log = AuditLog.load("audit.jsonl", session_id="s1")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        print(report.overall_status())
+    """
+
+    def generate(self, audit_log: AuditLog) -> ComplianceReport:
+        """Generate a compliance report from an audit log.
+
+        Args:
+            audit_log: The audit log to analyze.
+
+        Returns:
+            A ComplianceReport with sections for each assessed function.
+        """
+        sections = [
+            self._assess_govern1(audit_log),
+            self._assess_map1(audit_log),
+            self._assess_measure2(audit_log),
+            self._assess_manage1(audit_log),
+            self._assess_manage2(audit_log),
+        ]
+
+        return ComplianceReport(
+            framework="NIST AI RMF",
+            generated_at=datetime.now(tz=timezone.utc),
+            session_id=audit_log.session_id,
+            sections=sections,
+        )
+
+    # -- GOVERN 1: Governance ------------------------------------------
+
+    def _assess_govern1(self, audit_log: AuditLog) -> ReportSection:
+        """Assess GOVERN 1: Policies and oversight.
+
+        Checks for governance evidence:
+        - Multiple distinct actors suggest oversight structure
+        - Policy denials indicate active governance
+        - Single actor with no denials suggests weak governance
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="GOVERN 1",
+                title="Governance",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="GOVERN 1",
+                        description=(
+                            "No actions recorded; governance assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        unique_actors = {e.actor for e in entries if e.actor.strip()}
+        denied_count = sum(1 for e in entries if e.result == "denied")
+        total = len(entries)
+
+        if denied_count > 0:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="GOVERN 1",
+                    description="Policy enforcement active",
+                    evidence=(f"{denied_count} of {total} actions denied by policy"),
+                )
+            )
+
+        if unique_actors:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="GOVERN 1",
+                    description="Actors participating in AI system governance",
+                    evidence=(
+                        f"{len(unique_actors)} unique actor(s): "
+                        f"{', '.join(sorted(unique_actors))}"
+                    ),
+                )
+            )
+
+        has_governance = len(unique_actors) > 1 or denied_count > 0
+
+        if not has_governance:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="GOVERN 1",
+                    description=(
+                        "Limited governance evidence; "
+                        "consider multi-party oversight and policy enforcement"
+                    ),
+                    evidence=(
+                        f"{len(unique_actors)} actor(s), "
+                        f"{denied_count} denial(s) across {total} action(s)"
+                    ),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="GOVERN 1",
+            title="Governance",
+            status=status,
+            findings=findings,
+        )
+
+    # -- MAP 1: Context ------------------------------------------------
+
+    def _assess_map1(self, audit_log: AuditLog) -> ReportSection:
+        """Assess MAP 1: AI system context and scope mapping.
+
+        Checks action diversity as a proxy for how well the AI
+        system's operational context has been mapped and monitored.
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="MAP 1",
+                title="Context",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="MAP 1",
+                        description=(
+                            "No actions recorded; context assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        unique_actions = {e.action for e in entries}
+
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="MAP 1",
+                description="Action types observed in AI system context",
+                evidence=(
+                    f"{len(unique_actions)} distinct action type(s): "
+                    f"{', '.join(sorted(unique_actions))}"
+                ),
+            )
+        )
+
+        if len(unique_actions) <= 1:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="MAP 1",
+                    description=(
+                        "Only one action type recorded; "
+                        "context mapping scope may be limited"
+                    ),
+                    evidence=(
+                        f"{len(unique_actions)} action type across "
+                        f"{len(entries)} entries"
+                    ),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="MAP 1",
+            title="Context",
+            status=status,
+            findings=findings,
+        )
+
+    # -- MEASURE 2: Assessment -----------------------------------------
+
+    def _assess_measure2(self, audit_log: AuditLog) -> ReportSection:
+        """Assess MEASURE 2: Risk measurement metrics.
+
+        Examines error rates and denial rates as quantitative
+        risk measurement data.
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="MEASURE 2",
+                title="Assessment",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="MEASURE 2",
+                        description=(
+                            "No actions recorded; measurement assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        error_count = sum(1 for e in entries if e.result == "error")
+        denied_count = sum(1 for e in entries if e.result == "denied")
+        allowed_count = sum(1 for e in entries if e.result == "allowed")
+        total = len(entries)
+        error_rate = error_count / total
+
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="MEASURE 2",
+                description="Risk measurement metrics",
+                evidence=(
+                    f"{total} actions: "
+                    f"{allowed_count} allowed, "
+                    f"{denied_count} denied, "
+                    f"{error_count} errors"
+                ),
+            )
+        )
+
+        if error_rate >= _ERROR_RATE_FAIL_THRESHOLD:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.VIOLATION,
+                    article="MEASURE 2",
+                    description=(
+                        "High error rate indicates systemic risk measurement failure"
+                    ),
+                    evidence=(
+                        f"{error_count} of {total} actions resulted in errors "
+                        f"({error_rate:.0%} error rate)"
+                    ),
+                )
+            )
+            status = SectionStatus.FAIL
+        elif error_count > 0:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="MEASURE 2",
+                    description=("Errors detected; review risk measurement coverage"),
+                    evidence=(f"{error_count} of {total} actions resulted in errors"),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="MEASURE 2",
+            title="Assessment",
+            status=status,
+            findings=findings,
+        )
+
+    # -- MANAGE 1: Risk Response ---------------------------------------
+
+    def _assess_manage1(self, audit_log: AuditLog) -> ReportSection:
+        """Assess MANAGE 1: Risk response.
+
+        Checks for evidence of active risk mitigation:
+        - Denied actions indicate policy-based risk response
+        - Errors suggest gaps in risk response
+        - No denials may indicate absent risk response mechanisms
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="MANAGE 1",
+                title="Risk Response",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="MANAGE 1",
+                        description=(
+                            "No actions recorded; risk response assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        denied_count = sum(1 for e in entries if e.result == "denied")
+        error_count = sum(1 for e in entries if e.result == "error")
+        total = len(entries)
+
+        if denied_count > 0:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="MANAGE 1",
+                    description=("Policy enforcement actively mitigating risks"),
+                    evidence=(f"{denied_count} of {total} actions denied by policy"),
+                )
+            )
+
+        if error_count > 0:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="MANAGE 1",
+                    description=("Errors detected; risk response may have gaps"),
+                    evidence=(f"{error_count} of {total} actions resulted in errors"),
+                )
+            )
+
+        if denied_count > 0:
+            status = SectionStatus.PASS
+        elif error_count > 0:
+            status = SectionStatus.WARN
+        else:
+            # No denials and no errors — may indicate no risk controls
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="MANAGE 1",
+                    description=(
+                        "No policy denials observed; "
+                        "risk response mechanisms may be absent"
+                    ),
+                    evidence=(f"{total} actions, all allowed, no denials"),
+                )
+            )
+            status = SectionStatus.WARN
+
+        return ReportSection(
+            article="MANAGE 1",
+            title="Risk Response",
+            status=status,
+            findings=findings,
+        )
+
+    # -- MANAGE 2: Monitoring ------------------------------------------
+
+    def _assess_manage2(self, audit_log: AuditLog) -> ReportSection:
+        """Assess MANAGE 2: Ongoing monitoring.
+
+        Checks audit log completeness and integrity:
+        - Log must have entries (monitoring is active)
+        - Hash chain integrity must be intact
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="MANAGE 2",
+                title="Monitoring",
+                status=SectionStatus.FAIL,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.VIOLATION,
+                        article="MANAGE 2",
+                        description=(
+                            "No monitoring data recorded; "
+                            "MANAGE 2 requires ongoing monitoring"
+                        ),
+                        evidence="0 entries in audit log",
+                    ),
+                ],
+            )
+
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="MANAGE 2",
+                description="Monitoring data is being collected",
+                evidence=f"{len(entries)} entries recorded in session",
+            )
+        )
+
+        if audit_log.verify():
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="MANAGE 2",
+                    description="Monitoring data integrity verified",
+                )
+            )
+            status = SectionStatus.PASS
+        else:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.VIOLATION,
+                    article="MANAGE 2",
+                    description=(
+                        "Monitoring data integrity check failed; "
+                        "hash chain has been tampered with"
+                    ),
+                    evidence="AuditLog.verify() returned False",
+                )
+            )
+            status = SectionStatus.FAIL
+
+        return ReportSection(
+            article="MANAGE 2",
+            title="Monitoring",
+            status=status,
+            findings=findings,
+        )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -469,6 +469,55 @@ class TestReportCommand:
         content = output_file.read_text()
         assert "ISO 42001" in content
 
+    def test_report_nist_ai_rmf_text(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        _create_audit_log(log_file, num_entries=5)
+        exit_code, stdout, _ = _run_cli(
+            "report",
+            "nist-ai-rmf",
+            str(log_file),
+            "--session",
+            "test-session-001",
+        )
+        assert exit_code == 0
+        assert "NIST AI RMF" in stdout
+        assert "GOVERN" in stdout or "MANAGE" in stdout
+
+    def test_report_nist_ai_rmf_json(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        _create_audit_log(log_file, num_entries=5)
+        exit_code, stdout, _ = _run_cli(
+            "report",
+            "nist-ai-rmf",
+            str(log_file),
+            "--session",
+            "test-session-001",
+            "--format",
+            "json",
+        )
+        assert exit_code == 0
+        data = json.loads(stdout)
+        assert data["framework"] == "NIST AI RMF"
+        assert "sections" in data
+
+    def test_report_nist_ai_rmf_output_to_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        _create_audit_log(log_file, num_entries=5)
+        output_file = tmp_path / "report.txt"
+        exit_code, _, _ = _run_cli(
+            "report",
+            "nist-ai-rmf",
+            str(log_file),
+            "--session",
+            "test-session-001",
+            "--output",
+            str(output_file),
+        )
+        assert exit_code == 0
+        assert output_file.exists()
+        content = output_file.read_text()
+        assert "NIST AI RMF" in content
+
 
 # --- Help / no args ---
 

--- a/tests/unit/test_nist_ai_rmf.py
+++ b/tests/unit/test_nist_ai_rmf.py
@@ -1,0 +1,442 @@
+"""Tests for NIST AI RMF report generator (M9).
+
+Covers:
+- Generating a compliance report from an AuditLog
+- GOVERN 1 (Governance) assessment
+- MAP 1 (Context) assessment
+- MEASURE 2 (Assessment) assessment
+- MANAGE 1 (Risk Response) assessment
+- MANAGE 2 (Monitoring) assessment
+- Edge cases: empty log, all denied, mixed results
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agentguard.audit.log import AuditLog
+from agentguard.audit.models import AuditEntry
+from agentguard.compliance.models import (
+    FindingSeverity,
+    SectionStatus,
+)
+from agentguard.compliance.nist_ai_rmf import NISTAIRMFReportGenerator
+
+
+def _make_log(
+    entries: list[dict[str, str]],
+    session_id: str = "test-session",
+) -> AuditLog:
+    """Helper to create an AuditLog with preset entries."""
+    log = AuditLog(session_id=session_id)
+    for entry_data in entries:
+        log.record(
+            action=entry_data.get("action", "test"),
+            actor=entry_data.get("actor", "agent"),
+            target=entry_data.get("target", "target"),
+            result=entry_data.get("result", "allowed"),
+            metadata=None,
+        )
+    return log
+
+
+class TestNISTAIRMFReportGenerator:
+    """NIST AI RMF report generator basics."""
+
+    def test_generates_report_from_audit_log(self) -> None:
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        assert report.framework == "NIST AI RMF"
+        assert report.session_id == "test-session"
+
+    def test_report_has_five_sections(self) -> None:
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        assert len(report.sections) == 5
+        articles = [s.article for s in report.sections]
+        assert "GOVERN 1" in articles
+        assert "MAP 1" in articles
+        assert "MEASURE 2" in articles
+        assert "MANAGE 1" in articles
+        assert "MANAGE 2" in articles
+
+    def test_report_generated_at_is_set(self) -> None:
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = NISTAIRMFReportGenerator()
+        before = datetime.now(tz=timezone.utc)
+        report = generator.generate(log)
+        after = datetime.now(tz=timezone.utc)
+        assert before <= report.generated_at <= after
+
+
+class TestGovern1Governance:
+    """GOVERN 1: Policies and oversight."""
+
+    def test_multiple_actors_with_denials_is_pass(self) -> None:
+        """Multiple actors and policy enforcement suggest governance."""
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "agent-1", "result": "allowed"},
+                {"action": "shell_cmd", "actor": "agent-2", "result": "denied"},
+                {"action": "review", "actor": "human", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        gov1 = next(s for s in report.sections if s.article == "GOVERN 1")
+        assert gov1.status == SectionStatus.PASS
+
+    def test_single_actor_no_denials_is_warning(self) -> None:
+        """Single actor with no policy enforcement suggests weak governance."""
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "solo-agent", "result": "allowed"},
+                {"action": "file_write", "actor": "solo-agent", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        gov1 = next(s for s in report.sections if s.article == "GOVERN 1")
+        assert gov1.status == SectionStatus.WARN
+        warnings = [f for f in gov1.findings if f.severity == FindingSeverity.WARNING]
+        assert len(warnings) >= 1
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        gov1 = next(s for s in report.sections if s.article == "GOVERN 1")
+        assert gov1.status == SectionStatus.NOT_ASSESSED
+
+    def test_denial_evidence_produces_info(self) -> None:
+        """Policy denials should produce an info finding about governance."""
+        log = _make_log(
+            [
+                {"action": "shell_cmd", "result": "denied"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        gov1 = next(s for s in report.sections if s.article == "GOVERN 1")
+        info_findings = [f for f in gov1.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+
+
+class TestMap1Context:
+    """MAP 1: AI system context mapping."""
+
+    def test_diverse_actions_is_pass(self) -> None:
+        """Multiple action types suggest broad context mapping."""
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "allowed"},
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_write", "result": "denied"},
+                {"action": "api_call", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        map1 = next(s for s in report.sections if s.article == "MAP 1")
+        assert map1.status == SectionStatus.PASS
+
+    def test_single_action_type_is_warning(self) -> None:
+        """Only one action type suggests limited context mapping."""
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        map1 = next(s for s in report.sections if s.article == "MAP 1")
+        assert map1.status == SectionStatus.WARN
+
+    def test_reports_action_type_count(self) -> None:
+        """Findings should mention action type diversity."""
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_write", "result": "allowed"},
+                {"action": "shell_command", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        map1 = next(s for s in report.sections if s.article == "MAP 1")
+        info_findings = [f for f in map1.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+        assert any("3" in f.evidence for f in info_findings if f.evidence)
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        map1 = next(s for s in report.sections if s.article == "MAP 1")
+        assert map1.status == SectionStatus.NOT_ASSESSED
+
+
+class TestMeasure2Assessment:
+    """MEASURE 2: Risk measurement metrics."""
+
+    def test_low_error_rate_is_pass(self) -> None:
+        """Low error rate suggests good measurement."""
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "shell_cmd", "result": "allowed"},
+                {"action": "api_call", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        meas2 = next(s for s in report.sections if s.article == "MEASURE 2")
+        assert meas2.status == SectionStatus.PASS
+
+    def test_some_errors_is_warning(self) -> None:
+        """Some errors indicate measurement gaps."""
+        log = _make_log(
+            [
+                {"action": "shell_cmd", "result": "error"},
+                {"action": "file_read", "result": "allowed"},
+                {"action": "api_call", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        meas2 = next(s for s in report.sections if s.article == "MEASURE 2")
+        assert meas2.status == SectionStatus.WARN
+        warnings = [f for f in meas2.findings if f.severity == FindingSeverity.WARNING]
+        assert len(warnings) >= 1
+
+    def test_high_error_rate_is_fail(self) -> None:
+        """High error rate indicates systemic measurement failure."""
+        log = _make_log(
+            [
+                {"action": "a1", "result": "error"},
+                {"action": "a2", "result": "error"},
+                {"action": "a3", "result": "error"},
+                {"action": "a4", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        meas2 = next(s for s in report.sections if s.article == "MEASURE 2")
+        assert meas2.status == SectionStatus.FAIL
+        violations = [
+            f for f in meas2.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert len(violations) >= 1
+
+    def test_reports_denial_rate(self) -> None:
+        """Findings should include denial rate as measurement data."""
+        log = _make_log(
+            [
+                {"action": "shell_cmd", "result": "denied"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        meas2 = next(s for s in report.sections if s.article == "MEASURE 2")
+        info_findings = [
+            f for f in meas2.findings if f.severity == FindingSeverity.INFO
+        ]
+        assert len(info_findings) >= 1
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        meas2 = next(s for s in report.sections if s.article == "MEASURE 2")
+        assert meas2.status == SectionStatus.NOT_ASSESSED
+
+
+class TestManage1RiskResponse:
+    """MANAGE 1: Risk response via policy enforcement."""
+
+    def test_denied_actions_show_active_response(self) -> None:
+        """Denied actions are evidence of active risk response."""
+        log = _make_log(
+            [
+                {"action": "shell_cmd", "result": "denied"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr1 = next(s for s in report.sections if s.article == "MANAGE 1")
+        assert mgr1.status == SectionStatus.PASS
+        info_findings = [f for f in mgr1.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+
+    def test_no_denials_is_warning(self) -> None:
+        """No denied actions may indicate no risk response mechanisms."""
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "shell_cmd", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr1 = next(s for s in report.sections if s.article == "MANAGE 1")
+        assert mgr1.status == SectionStatus.WARN
+
+    def test_errors_produce_warning(self) -> None:
+        """Errors suggest risk response gaps."""
+        log = _make_log(
+            [
+                {"action": "shell_cmd", "result": "error"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr1 = next(s for s in report.sections if s.article == "MANAGE 1")
+        warnings = [f for f in mgr1.findings if f.severity == FindingSeverity.WARNING]
+        assert len(warnings) >= 1
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr1 = next(s for s in report.sections if s.article == "MANAGE 1")
+        assert mgr1.status == SectionStatus.NOT_ASSESSED
+
+
+class TestManage2Monitoring:
+    """MANAGE 2: Ongoing monitoring — log integrity and completeness."""
+
+    def test_nonempty_verified_log_passes(self) -> None:
+        """A non-empty, verified log passes monitoring requirements."""
+        log = _make_log([{"action": "test", "result": "allowed"}])
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr2 = next(s for s in report.sections if s.article == "MANAGE 2")
+        assert mgr2.status == SectionStatus.PASS
+
+    def test_empty_log_is_violation(self) -> None:
+        """No monitoring data is a violation."""
+        log = AuditLog(session_id="empty")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr2 = next(s for s in report.sections if s.article == "MANAGE 2")
+        assert mgr2.status == SectionStatus.FAIL
+        violations = [
+            f for f in mgr2.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert len(violations) >= 1
+
+    def test_log_reports_entry_count(self) -> None:
+        """Findings should report the number of monitored entries."""
+        log = _make_log(
+            [
+                {"action": "a1", "result": "allowed"},
+                {"action": "a2", "result": "allowed"},
+                {"action": "a3", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr2 = next(s for s in report.sections if s.article == "MANAGE 2")
+        info_findings = [f for f in mgr2.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+        assert any("3" in f.evidence for f in info_findings if f.evidence)
+
+    def test_tampered_log_is_violation(self) -> None:
+        """A tampered log fails monitoring integrity."""
+        log = AuditLog(session_id="tampered")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        # Tamper with the chain
+        log._entries[0] = AuditEntry(
+            action="TAMPERED",
+            actor=log._entries[0].actor,
+            target=log._entries[0].target,
+            result=log._entries[0].result,
+            timestamp=log._entries[0].timestamp,
+            previous_hash=log._entries[0].previous_hash,
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr2 = next(s for s in report.sections if s.article == "MANAGE 2")
+        assert mgr2.status == SectionStatus.FAIL
+        violations = [
+            f for f in mgr2.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert any("integrity" in v.description.lower() for v in violations)
+
+
+class TestEdgeCases:
+    """Edge cases for the NIST AI RMF report generator."""
+
+    def test_empty_audit_log(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        # MANAGE 2 should fail (no monitoring)
+        mgr2 = next(s for s in report.sections if s.article == "MANAGE 2")
+        assert mgr2.status == SectionStatus.FAIL
+        assert report.overall_status() == SectionStatus.FAIL
+
+    def test_large_log(self) -> None:
+        log = _make_log(
+            [{"action": f"action_{i}", "result": "allowed"} for i in range(100)]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        assert report.overall_status() in {SectionStatus.PASS, SectionStatus.WARN}
+
+    def test_mixed_results(self) -> None:
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "allowed"},
+                {"action": "shell_command", "result": "denied"},
+                {"action": "file_write", "result": "error"},
+                {"action": "api_call", "result": "allowed"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        # Should produce a valid report with all 5 sections
+        assert len(report.sections) == 5
+        # Should have both info and warning findings
+        all_findings = [f for s in report.sections for f in s.findings]
+        severities = {f.severity for f in all_findings}
+        assert FindingSeverity.INFO in severities
+
+    def test_report_to_dict_is_serializable(self) -> None:
+        """The report should be JSON-serializable via to_dict."""
+        import json
+
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "allowed"},
+                {"action": "shell_command", "result": "denied"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        d = report.to_dict()
+        json_str = json.dumps(d)
+        assert isinstance(json_str, str)
+        parsed = json.loads(json_str)
+        assert parsed["framework"] == "NIST AI RMF"
+
+    def test_all_denied_shows_strong_risk_response(self) -> None:
+        """All denied actions should show strong risk response in MANAGE 1."""
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "denied"},
+                {"action": "file_write", "result": "denied"},
+            ]
+        )
+        generator = NISTAIRMFReportGenerator()
+        report = generator.generate(log)
+        mgr1 = next(s for s in report.sections if s.article == "MANAGE 1")
+        assert mgr1.status == SectionStatus.PASS


### PR DESCRIPTION
## Summary

- Add `NISTAIRMFReportGenerator` that assesses audit logs against 5 NIST AI RMF 1.0 functions/subcategories
- CLI support via `agentguard report nist-ai-rmf <file>` with text/json output formats
- Re-export from `agentguard.compliance` module

## NIST AI RMF Functions Assessed

| Function | Title | What it checks |
|----------|-------|----------------|
| GOVERN 1 | Governance | Actor diversity and policy enforcement evidence |
| MAP 1 | Context | Action type diversity as context mapping scope |
| MEASURE 2 | Assessment | Error/denial rates as quantitative risk metrics |
| MANAGE 1 | Risk Response | Denied actions as active risk mitigation |
| MANAGE 2 | Monitoring | Log completeness and hash chain integrity |

## Files Changed

- **New:** `src/agentguard/compliance/nist_ai_rmf.py` — generator class with `generate()` and 5 private `_assess_*()` methods
- **New:** `tests/unit/test_nist_ai_rmf.py` — 29 tests covering all functions and edge cases
- **Modified:** `src/agentguard/compliance/__init__.py` — add export
- **Modified:** `src/agentguard/cli.py` — dispatch `nist-ai-rmf` framework, update help text
- **Modified:** `tests/unit/test_cli.py` — 3 new CLI tests (text, json, file output)

## Testing

All tests pass locally across the full suite. mypy strict passes.