### PR TITLE
feat: add SOC 2 Trust Services Criteria report generator

### DIFF
--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -569,7 +569,7 @@ def _build_parser() -> argparse.ArgumentParser:
     report_parser = subparsers.add_parser("report", help="Generate compliance reports.")
     report_parser.add_argument(
         "framework",
-        help="Compliance framework (e.g. eu-ai-act, iso-42001, nist-ai-rmf).",
+        help="Compliance framework (e.g. eu-ai-act, iso-42001, nist-ai-rmf, soc-2).",
     )
     report_parser.add_argument("file", help="Path to the audit JSONL file.")
     report_parser.add_argument(
@@ -1655,7 +1655,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
     """Generate a compliance report."""
     framework = args.framework.lower()
 
-    supported_frameworks = ("eu-ai-act", "iso-42001", "nist-ai-rmf")
+    supported_frameworks = ("eu-ai-act", "iso-42001", "nist-ai-rmf", "soc-2")
     if framework not in supported_frameworks:
         print(
             f"Error: Unknown framework '{args.framework}'. "
@@ -1678,10 +1678,14 @@ def _cmd_report(args: argparse.Namespace) -> int:
         from agentguard.compliance.iso_42001 import ISO42001ReportGenerator
 
         report = ISO42001ReportGenerator().generate(log)
-    else:  # nist-ai-rmf
+    elif framework == "nist-ai-rmf":
         from agentguard.compliance.nist_ai_rmf import NISTAIRMFReportGenerator
 
         report = NISTAIRMFReportGenerator().generate(log)
+    else:  # soc-2
+        from agentguard.compliance.soc2 import SOC2ReportGenerator
+
+        report = SOC2ReportGenerator().generate(log)
 
     if args.format == "json":
         output = render_json(report, output=args.output)

--- a/src/agentguard/compliance/__init__.py
+++ b/src/agentguard/compliance/__init__.py
@@ -1,4 +1,4 @@
-"""Compliance reporting for EU AI Act, ISO 42001, NIST AI RMF, and other frameworks.
+"""Compliance reporting for EU AI Act, ISO 42001, NIST AI RMF, SOC 2, and more.
 
 Provides data models, report generators, and renderers for producing
 compliance reports from AgentGuard audit logs.
@@ -15,6 +15,7 @@ from agentguard.compliance.models import (
 )
 from agentguard.compliance.nist_ai_rmf import NISTAIRMFReportGenerator
 from agentguard.compliance.renderers import render_json, render_text
+from agentguard.compliance.soc2 import SOC2ReportGenerator
 
 __all__ = [
     "ComplianceReport",
@@ -24,6 +25,7 @@ __all__ = [
     "ISO42001ReportGenerator",
     "NISTAIRMFReportGenerator",
     "ReportSection",
+    "SOC2ReportGenerator",
     "SectionStatus",
     "render_json",
     "render_text",

--- a/src/agentguard/compliance/soc2.py
+++ b/src/agentguard/compliance/soc2.py
@@ -1,0 +1,449 @@
+"""SOC 2 Trust Services Criteria compliance report generator.
+
+Analyzes an AuditLog and produces a ComplianceReport assessing
+compliance with key SOC 2 Trust Services Criteria:
+
+- CC6.1: Logical Access — access controls and policy enforcement
+- CC7.2: System Monitoring — audit log completeness and integrity
+- CC8.1: Change Management — action diversity and scope coverage
+- A1.2:  Availability — error patterns and system resilience
+- CC4.1: Monitoring Activities — oversight and governance evidence
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from agentguard.compliance.models import (
+    ComplianceReport,
+    Finding,
+    FindingSeverity,
+    ReportSection,
+    SectionStatus,
+)
+
+if TYPE_CHECKING:
+    from agentguard.audit.log import AuditLog
+
+# Threshold: error rate above this fraction triggers FAIL in A1.2.
+_ERROR_RATE_FAIL_THRESHOLD = 0.5
+
+
+class SOC2ReportGenerator:
+    """Generate SOC 2 compliance reports from audit logs.
+
+    Analyzes an AuditLog against five SOC 2 Trust Services Criteria
+    that are most relevant to autonomous AI agent governance:
+
+    - CC6.1: Logical Access (actor diversity, policy enforcement)
+    - CC7.2: System Monitoring (log integrity, completeness)
+    - CC8.1: Change Management (action type diversity)
+    - A1.2: Availability (error rates, resilience)
+    - CC4.1: Monitoring Activities (oversight evidence)
+
+    Usage::
+
+        from agentguard.audit.log import AuditLog
+        from agentguard.compliance.soc2 import SOC2ReportGenerator
+
+        log = AuditLog.load("audit.jsonl", session_id="s1")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        print(report.overall_status())
+    """
+
+    def generate(self, audit_log: AuditLog) -> ComplianceReport:
+        """Generate a compliance report from an audit log.
+
+        Args:
+            audit_log: The audit log to analyze.
+
+        Returns:
+            A ComplianceReport with sections for each assessed criterion.
+        """
+        sections = [
+            self._assess_cc61(audit_log),
+            self._assess_cc72(audit_log),
+            self._assess_cc81(audit_log),
+            self._assess_a12(audit_log),
+            self._assess_cc41(audit_log),
+        ]
+
+        return ComplianceReport(
+            framework="SOC 2",
+            generated_at=datetime.now(tz=timezone.utc),
+            session_id=audit_log.session_id,
+            sections=sections,
+        )
+
+    # -- CC6.1: Logical Access -----------------------------------------
+
+    def _assess_cc61(self, audit_log: AuditLog) -> ReportSection:
+        """Assess CC6.1: Logical Access.
+
+        Checks for access control evidence:
+        - Multiple distinct actors suggest role-based access
+        - Policy denials indicate active access controls
+        - Single actor with no denials suggests weak access controls
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="CC6.1",
+                title="Logical Access",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="CC6.1",
+                        description=(
+                            "No actions recorded; "
+                            "access control assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        unique_actors = {e.actor for e in entries if e.actor.strip()}
+        denied_count = sum(1 for e in entries if e.result == "denied")
+        total = len(entries)
+
+        if unique_actors:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="CC6.1",
+                    description="Actors with logical access to the AI system",
+                    evidence=(
+                        f"{len(unique_actors)} unique actor(s): "
+                        f"{', '.join(sorted(unique_actors))}"
+                    ),
+                )
+            )
+
+        if denied_count > 0:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="CC6.1",
+                    description="Access controls actively restricting actions",
+                    evidence=(f"{denied_count} of {total} actions denied by policy"),
+                )
+            )
+
+        has_controls = len(unique_actors) > 1 or denied_count > 0
+
+        if not has_controls:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="CC6.1",
+                    description=(
+                        "Limited access control evidence; "
+                        "consider role-based access and policy enforcement"
+                    ),
+                    evidence=(
+                        f"{len(unique_actors)} actor(s), "
+                        f"{denied_count} denial(s) across {total} action(s)"
+                    ),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="CC6.1",
+            title="Logical Access",
+            status=status,
+            findings=findings,
+        )
+
+    # -- CC7.2: System Monitoring --------------------------------------
+
+    def _assess_cc72(self, audit_log: AuditLog) -> ReportSection:
+        """Assess CC7.2: System Monitoring.
+
+        Checks audit log completeness and integrity:
+        - Log must have entries (monitoring is active)
+        - Hash chain integrity must be intact
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="CC7.2",
+                title="System Monitoring",
+                status=SectionStatus.FAIL,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.VIOLATION,
+                        article="CC7.2",
+                        description=(
+                            "No monitoring data recorded; "
+                            "CC7.2 requires system component monitoring"
+                        ),
+                        evidence="0 entries in audit log",
+                    ),
+                ],
+            )
+
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="CC7.2",
+                description="System monitoring data is being collected",
+                evidence=f"{len(entries)} entries recorded in session",
+            )
+        )
+
+        if audit_log.verify():
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="CC7.2",
+                    description="Monitoring data integrity verified",
+                )
+            )
+            status = SectionStatus.PASS
+        else:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.VIOLATION,
+                    article="CC7.2",
+                    description=(
+                        "Monitoring data integrity check failed; "
+                        "hash chain has been tampered with"
+                    ),
+                    evidence="AuditLog.verify() returned False",
+                )
+            )
+            status = SectionStatus.FAIL
+
+        return ReportSection(
+            article="CC7.2",
+            title="System Monitoring",
+            status=status,
+            findings=findings,
+        )
+
+    # -- CC8.1: Change Management --------------------------------------
+
+    def _assess_cc81(self, audit_log: AuditLog) -> ReportSection:
+        """Assess CC8.1: Change Management.
+
+        Checks action diversity as a proxy for change management
+        scope coverage.
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="CC8.1",
+                title="Change Management",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="CC8.1",
+                        description=(
+                            "No actions recorded; "
+                            "change management assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        unique_actions = {e.action for e in entries}
+
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="CC8.1",
+                description="Change types tracked by the AI system",
+                evidence=(
+                    f"{len(unique_actions)} distinct action type(s): "
+                    f"{', '.join(sorted(unique_actions))}"
+                ),
+            )
+        )
+
+        if len(unique_actions) <= 1:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="CC8.1",
+                    description=(
+                        "Only one action type recorded; "
+                        "change management scope may be limited"
+                    ),
+                    evidence=(
+                        f"{len(unique_actions)} action type across "
+                        f"{len(entries)} entries"
+                    ),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="CC8.1",
+            title="Change Management",
+            status=status,
+            findings=findings,
+        )
+
+    # -- A1.2: Availability --------------------------------------------
+
+    def _assess_a12(self, audit_log: AuditLog) -> ReportSection:
+        """Assess A1.2: Availability.
+
+        Checks error patterns and system resilience:
+        - High error rate indicates availability issues (FAIL)
+        - Some errors indicate potential availability risks (WARN)
+        - Denied actions are NOT availability issues (policy enforcement)
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="A1.2",
+                title="Availability",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="A1.2",
+                        description=(
+                            "No actions recorded; availability assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        error_count = sum(1 for e in entries if e.result == "error")
+        total = len(entries)
+        error_rate = error_count / total
+
+        if error_rate >= _ERROR_RATE_FAIL_THRESHOLD:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.VIOLATION,
+                    article="A1.2",
+                    description=(
+                        "High error rate indicates system availability issues"
+                    ),
+                    evidence=(
+                        f"{error_count} of {total} actions resulted in errors "
+                        f"({error_rate:.0%} error rate)"
+                    ),
+                )
+            )
+            status = SectionStatus.FAIL
+        elif error_count > 0:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="A1.2",
+                    description=("Errors detected; review for availability impact"),
+                    evidence=(f"{error_count} of {total} actions resulted in errors"),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="A1.2",
+                    description="No errors detected; system availability nominal",
+                    evidence=f"{total} actions completed without errors",
+                )
+            )
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="A1.2",
+            title="Availability",
+            status=status,
+            findings=findings,
+        )
+
+    # -- CC4.1: Monitoring Activities ----------------------------------
+
+    def _assess_cc41(self, audit_log: AuditLog) -> ReportSection:
+        """Assess CC4.1: Monitoring Activities.
+
+        Checks for oversight and governance evidence:
+        - Multiple actors suggest multi-party oversight
+        - Policy denials indicate active monitoring
+        - Single actor with no denials suggests limited oversight
+        """
+        entries = audit_log.entries
+        findings: list[Finding] = []
+
+        if not entries:
+            return ReportSection(
+                article="CC4.1",
+                title="Monitoring Activities",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="CC4.1",
+                        description=(
+                            "No actions recorded; "
+                            "monitoring activities assessment not possible"
+                        ),
+                    ),
+                ],
+            )
+
+        unique_actors = {e.actor for e in entries if e.actor.strip()}
+        denied_count = sum(1 for e in entries if e.result == "denied")
+        total = len(entries)
+
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="CC4.1",
+                description="Monitoring participants and policy enforcement",
+                evidence=(
+                    f"{len(unique_actors)} actor(s), "
+                    f"{denied_count} denial(s) across {total} action(s)"
+                ),
+            )
+        )
+
+        has_oversight = len(unique_actors) > 1 or denied_count > 0
+
+        if not has_oversight:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="CC4.1",
+                    description=(
+                        "Limited oversight evidence; "
+                        "consider multi-party monitoring and policy enforcement"
+                    ),
+                    evidence=(
+                        f"{len(unique_actors)} actor(s), {denied_count} denial(s)"
+                    ),
+                )
+            )
+            status = SectionStatus.WARN
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="CC4.1",
+            title="Monitoring Activities",
+            status=status,
+            findings=findings,
+        )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -518,6 +518,55 @@ class TestReportCommand:
         content = output_file.read_text()
         assert "NIST AI RMF" in content
 
+    def test_report_soc2_text(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        _create_audit_log(log_file, num_entries=5)
+        exit_code, stdout, _ = _run_cli(
+            "report",
+            "soc-2",
+            str(log_file),
+            "--session",
+            "test-session-001",
+        )
+        assert exit_code == 0
+        assert "SOC 2" in stdout
+        assert "CC" in stdout or "A1" in stdout
+
+    def test_report_soc2_json(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        _create_audit_log(log_file, num_entries=5)
+        exit_code, stdout, _ = _run_cli(
+            "report",
+            "soc-2",
+            str(log_file),
+            "--session",
+            "test-session-001",
+            "--format",
+            "json",
+        )
+        assert exit_code == 0
+        data = json.loads(stdout)
+        assert data["framework"] == "SOC 2"
+        assert "sections" in data
+
+    def test_report_soc2_output_to_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "audit.jsonl"
+        _create_audit_log(log_file, num_entries=5)
+        output_file = tmp_path / "report.txt"
+        exit_code, _, _ = _run_cli(
+            "report",
+            "soc-2",
+            str(log_file),
+            "--session",
+            "test-session-001",
+            "--output",
+            str(output_file),
+        )
+        assert exit_code == 0
+        assert output_file.exists()
+        content = output_file.read_text()
+        assert "SOC 2" in content
+
 
 # --- Help / no args ---
 

--- a/tests/unit/test_soc2.py
+++ b/tests/unit/test_soc2.py
@@ -1,0 +1,419 @@
+"""Tests for SOC 2 Trust Services Criteria report generator (M9).
+
+Covers:
+- Generating a compliance report from an AuditLog
+- CC6.1 (Logical Access) assessment
+- CC7.2 (System Monitoring) assessment
+- CC8.1 (Change Management) assessment
+- A1.2 (Availability) assessment
+- CC4.1 (Monitoring Activities) assessment
+- Edge cases: empty log, all denied, mixed results
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agentguard.audit.log import AuditLog
+from agentguard.audit.models import AuditEntry
+from agentguard.compliance.models import (
+    FindingSeverity,
+    SectionStatus,
+)
+from agentguard.compliance.soc2 import SOC2ReportGenerator
+
+
+def _make_log(
+    entries: list[dict[str, str]],
+    session_id: str = "test-session",
+) -> AuditLog:
+    """Helper to create an AuditLog with preset entries."""
+    log = AuditLog(session_id=session_id)
+    for entry_data in entries:
+        log.record(
+            action=entry_data.get("action", "test"),
+            actor=entry_data.get("actor", "agent"),
+            target=entry_data.get("target", "target"),
+            result=entry_data.get("result", "allowed"),
+            metadata=None,
+        )
+    return log
+
+
+class TestSOC2ReportGenerator:
+    """SOC 2 report generator basics."""
+
+    def test_generates_report_from_audit_log(self) -> None:
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        assert report.framework == "SOC 2"
+        assert report.session_id == "test-session"
+
+    def test_report_has_five_sections(self) -> None:
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        assert len(report.sections) == 5
+        articles = [s.article for s in report.sections]
+        assert "CC6.1" in articles
+        assert "CC7.2" in articles
+        assert "CC8.1" in articles
+        assert "A1.2" in articles
+        assert "CC4.1" in articles
+
+    def test_report_generated_at_is_set(self) -> None:
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = SOC2ReportGenerator()
+        before = datetime.now(tz=timezone.utc)
+        report = generator.generate(log)
+        after = datetime.now(tz=timezone.utc)
+        assert before <= report.generated_at <= after
+
+    def test_section_titles(self) -> None:
+        """Each section should have a descriptive title."""
+        log = _make_log([{"action": "file_read", "result": "allowed"}])
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        titles = {s.article: s.title for s in report.sections}
+        assert titles["CC6.1"] == "Logical Access"
+        assert titles["CC7.2"] == "System Monitoring"
+        assert titles["CC8.1"] == "Change Management"
+        assert titles["A1.2"] == "Availability"
+        assert titles["CC4.1"] == "Monitoring Activities"
+
+
+class TestCC61LogicalAccess:
+    """CC6.1: Logical Access — access controls and policy enforcement."""
+
+    def test_denials_with_multiple_actors_is_pass(self) -> None:
+        """Policy enforcement + multiple actors = strong access controls."""
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "agent-1", "result": "allowed"},
+                {"action": "shell_cmd", "actor": "agent-2", "result": "denied"},
+                {"action": "review", "actor": "human", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc61 = next(s for s in report.sections if s.article == "CC6.1")
+        assert cc61.status == SectionStatus.PASS
+
+    def test_single_actor_no_denials_is_warning(self) -> None:
+        """No access restrictions suggests weak access controls."""
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "solo-agent", "result": "allowed"},
+                {"action": "file_write", "actor": "solo-agent", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc61 = next(s for s in report.sections if s.article == "CC6.1")
+        assert cc61.status == SectionStatus.WARN
+        warnings = [f for f in cc61.findings if f.severity == FindingSeverity.WARNING]
+        assert len(warnings) >= 1
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc61 = next(s for s in report.sections if s.article == "CC6.1")
+        assert cc61.status == SectionStatus.NOT_ASSESSED
+
+    def test_reports_actor_count(self) -> None:
+        log = _make_log(
+            [
+                {"action": "a1", "actor": "agent-a", "result": "allowed"},
+                {"action": "a2", "actor": "agent-b", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc61 = next(s for s in report.sections if s.article == "CC6.1")
+        info_findings = [f for f in cc61.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+
+
+class TestCC72SystemMonitoring:
+    """CC7.2: System Monitoring — log integrity and completeness."""
+
+    def test_nonempty_verified_log_passes(self) -> None:
+        log = _make_log([{"action": "test", "result": "allowed"}])
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc72 = next(s for s in report.sections if s.article == "CC7.2")
+        assert cc72.status == SectionStatus.PASS
+
+    def test_empty_log_is_violation(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc72 = next(s for s in report.sections if s.article == "CC7.2")
+        assert cc72.status == SectionStatus.FAIL
+        violations = [
+            f for f in cc72.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert len(violations) >= 1
+
+    def test_log_reports_entry_count(self) -> None:
+        log = _make_log(
+            [
+                {"action": "a1", "result": "allowed"},
+                {"action": "a2", "result": "allowed"},
+                {"action": "a3", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc72 = next(s for s in report.sections if s.article == "CC7.2")
+        info_findings = [f for f in cc72.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+        assert any("3" in f.evidence for f in info_findings if f.evidence)
+
+    def test_tampered_log_is_violation(self) -> None:
+        log = AuditLog(session_id="tampered")
+        log.record(action="a1", actor="a", target="t", result="ok")
+        log.record(action="a2", actor="a", target="t", result="ok")
+        log._entries[0] = AuditEntry(
+            action="TAMPERED",
+            actor=log._entries[0].actor,
+            target=log._entries[0].target,
+            result=log._entries[0].result,
+            timestamp=log._entries[0].timestamp,
+            previous_hash=log._entries[0].previous_hash,
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc72 = next(s for s in report.sections if s.article == "CC7.2")
+        assert cc72.status == SectionStatus.FAIL
+        violations = [
+            f for f in cc72.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert any("integrity" in v.description.lower() for v in violations)
+
+
+class TestCC81ChangeManagement:
+    """CC8.1: Change Management — action diversity and scope."""
+
+    def test_diverse_actions_is_pass(self) -> None:
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "allowed"},
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_write", "result": "denied"},
+                {"action": "api_call", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc81 = next(s for s in report.sections if s.article == "CC8.1")
+        assert cc81.status == SectionStatus.PASS
+
+    def test_single_action_type_is_warning(self) -> None:
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc81 = next(s for s in report.sections if s.article == "CC8.1")
+        assert cc81.status == SectionStatus.WARN
+
+    def test_reports_action_type_count(self) -> None:
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_write", "result": "allowed"},
+                {"action": "shell_command", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc81 = next(s for s in report.sections if s.article == "CC8.1")
+        info_findings = [f for f in cc81.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+        assert any("3" in f.evidence for f in info_findings if f.evidence)
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc81 = next(s for s in report.sections if s.article == "CC8.1")
+        assert cc81.status == SectionStatus.NOT_ASSESSED
+
+
+class TestA12Availability:
+    """A1.2: Availability — error patterns and resilience."""
+
+    def test_no_errors_is_pass(self) -> None:
+        log = _make_log(
+            [
+                {"action": "file_read", "result": "allowed"},
+                {"action": "shell_command", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        a12 = next(s for s in report.sections if s.article == "A1.2")
+        assert a12.status == SectionStatus.PASS
+
+    def test_some_errors_is_warning(self) -> None:
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "error"},
+                {"action": "file_read", "result": "allowed"},
+                {"action": "file_write", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        a12 = next(s for s in report.sections if s.article == "A1.2")
+        assert a12.status == SectionStatus.WARN
+        warnings = [f for f in a12.findings if f.severity == FindingSeverity.WARNING]
+        assert len(warnings) >= 1
+
+    def test_high_error_rate_is_fail(self) -> None:
+        log = _make_log(
+            [
+                {"action": "a1", "result": "error"},
+                {"action": "a2", "result": "error"},
+                {"action": "a3", "result": "error"},
+                {"action": "a4", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        a12 = next(s for s in report.sections if s.article == "A1.2")
+        assert a12.status == SectionStatus.FAIL
+        violations = [
+            f for f in a12.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert len(violations) >= 1
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        a12 = next(s for s in report.sections if s.article == "A1.2")
+        assert a12.status == SectionStatus.NOT_ASSESSED
+
+    def test_denied_actions_are_not_errors(self) -> None:
+        """Denied actions are policy enforcement, not availability issues."""
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "denied"},
+                {"action": "file_read", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        a12 = next(s for s in report.sections if s.article == "A1.2")
+        assert a12.status == SectionStatus.PASS
+
+
+class TestCC41MonitoringActivities:
+    """CC4.1: Monitoring Activities — oversight evidence."""
+
+    def test_multiple_actors_with_denials_is_pass(self) -> None:
+        """Multiple actors + denials = strong oversight."""
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "agent-1", "result": "allowed"},
+                {"action": "shell_cmd", "actor": "agent-2", "result": "denied"},
+                {"action": "review", "actor": "human", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc41 = next(s for s in report.sections if s.article == "CC4.1")
+        assert cc41.status == SectionStatus.PASS
+
+    def test_single_actor_no_oversight_is_warning(self) -> None:
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "solo", "result": "allowed"},
+                {"action": "file_write", "actor": "solo", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc41 = next(s for s in report.sections if s.article == "CC4.1")
+        assert cc41.status == SectionStatus.WARN
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc41 = next(s for s in report.sections if s.article == "CC4.1")
+        assert cc41.status == SectionStatus.NOT_ASSESSED
+
+    def test_reports_oversight_metrics(self) -> None:
+        """Should report actor and denial counts."""
+        log = _make_log(
+            [
+                {"action": "file_read", "actor": "agent-a", "result": "allowed"},
+                {"action": "shell_cmd", "actor": "agent-b", "result": "denied"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc41 = next(s for s in report.sections if s.article == "CC4.1")
+        info_findings = [f for f in cc41.findings if f.severity == FindingSeverity.INFO]
+        assert len(info_findings) >= 1
+
+
+class TestEdgeCases:
+    """Edge cases for the SOC 2 report generator."""
+
+    def test_empty_audit_log(self) -> None:
+        log = AuditLog(session_id="empty")
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        cc72 = next(s for s in report.sections if s.article == "CC7.2")
+        assert cc72.status == SectionStatus.FAIL
+        assert report.overall_status() == SectionStatus.FAIL
+
+    def test_large_log(self) -> None:
+        log = _make_log(
+            [{"action": f"action_{i}", "result": "allowed"} for i in range(100)]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        assert report.overall_status() in {SectionStatus.PASS, SectionStatus.WARN}
+
+    def test_mixed_results(self) -> None:
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "allowed"},
+                {"action": "shell_command", "result": "denied"},
+                {"action": "file_write", "result": "error"},
+                {"action": "api_call", "result": "allowed"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        assert len(report.sections) == 5
+        all_findings = [f for s in report.sections for f in s.findings]
+        severities = {f.severity for f in all_findings}
+        assert FindingSeverity.INFO in severities
+
+    def test_report_to_dict_is_serializable(self) -> None:
+        import json
+
+        log = _make_log(
+            [
+                {"action": "shell_command", "result": "allowed"},
+                {"action": "shell_command", "result": "denied"},
+            ]
+        )
+        generator = SOC2ReportGenerator()
+        report = generator.generate(log)
+        d = report.to_dict()
+        json_str = json.dumps(d)
+        assert isinstance(json_str, str)
+        parsed = json.loads(json_str)
+        assert parsed["framework"] == "SOC 2"


### PR DESCRIPTION
## Summary

- Add `SOC2ReportGenerator` that assesses audit logs against 5 SOC 2 Trust Services Criteria
- CLI support via `agentguard report soc-2 <file>` with text/json output formats
- Re-export from `agentguard.compliance` module
- Completes M9 (Compliance Expansion) milestone

## SOC 2 Criteria Assessed

| Criterion | Title | What it checks |
|-----------|-------|----------------|
| CC6.1 | Logical Access | Actor diversity and policy enforcement evidence |
| CC7.2 | System Monitoring | Log completeness and hash chain integrity |
| CC8.1 | Change Management | Action type diversity and scope coverage |
| A1.2 | Availability | Error patterns and system resilience |
| CC4.1 | Monitoring Activities | Oversight and governance evidence |

## Files Changed

- **New:** `src/agentguard/compliance/soc2.py` — generator class with `generate()` and 5 private `_assess_*()` methods
- **New:** `tests/unit/test_soc2.py` — 29 tests covering all criteria and edge cases
- **Modified:** `src/agentguard/compliance/__init__.py` — add export
- **Modified:** `src/agentguard/cli.py` — dispatch `soc-2` framework, update help text
- **Modified:** `tests/unit/test_cli.py` — 3 new CLI tests (text, json, file output)

## Testing

All tests pass locally across the full suite. mypy strict passes.