### PR TITLE
feat: add conditional policies — time, environment, branch rules

### DIFF
--- a/src/agentguard/policies/__init__.py
+++ b/src/agentguard/policies/__init__.py
@@ -4,10 +4,20 @@ from agentguard.policies.builtins import list_builtins, load_all_builtins, load_
 from agentguard.policies.discovery import auto_discover, discover_policies
 from agentguard.policies.guard import Guard
 from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
-from agentguard.policies.models import Action, Decision, Policy, Rule, Severity
+from agentguard.policies.models import (
+    Action,
+    Condition,
+    Context,
+    Decision,
+    Policy,
+    Rule,
+    Severity,
+)
 
 __all__ = [
     "Action",
+    "Condition",
+    "Context",
     "Decision",
     "Guard",
     "Policy",

--- a/src/agentguard/policies/guard.py
+++ b/src/agentguard/policies/guard.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
-from agentguard.policies.models import Action, Decision, Policy
+from agentguard.policies.models import Action, Context, Decision, Policy
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -113,11 +113,20 @@ class Guard:
         self._policies.append(policy)
         return self
 
-    def check(self, action_kind: str, **params: str) -> Decision:
+    def check(
+        self,
+        action_kind: str,
+        context: Context | None = None,
+        /,
+        **params: str,
+    ) -> Decision:
         """Check an action against all loaded policies.
 
         Args:
             action_kind: The type of action (e.g. "shell_command").
+            context: Optional runtime context for conditional rules.
+                Pass a :class:`Context` with environment, branch,
+                time, etc. to enable conditional policy evaluation.
             **params: Key-value parameters for the action.
 
         Returns:
@@ -125,7 +134,7 @@ class Guard:
         """
         action = Action(kind=action_kind, params=params)
         for policy in self._policies:
-            decision = policy.evaluate(action)
+            decision = policy.evaluate(action, context=context)
             if decision.denied:
                 return decision
         return Decision(allowed=True)

--- a/src/agentguard/policies/loader.py
+++ b/src/agentguard/policies/loader.py
@@ -10,12 +10,13 @@ the standard library. (PyYAML is a dependency, but it's ubiquitous.)
 from __future__ import annotations
 
 import re
+from datetime import time
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from agentguard.policies.models import Policy, Rule, ScanTarget, Severity
+from agentguard.policies.models import Condition, Policy, Rule, ScanTarget, Severity
 
 
 def load_policy_from_string(yaml_str: str) -> Policy:
@@ -100,6 +101,7 @@ def _parse_rule(data: Any) -> Rule:
     patterns = [_parse_pattern(p) for p in data["deny"]]
     scan = _parse_scan_target(data["scan"]) if "scan" in data else None
     min_unique_chars = _parse_min_unique_chars(data.get("min_unique_chars"))
+    conditions = _parse_conditions(data["conditions"]) if "conditions" in data else None
 
     return Rule(
         action_kind=data["action"],
@@ -108,6 +110,7 @@ def _parse_rule(data: Any) -> Rule:
         description=data.get("description"),
         scan=scan,
         min_unique_chars=min_unique_chars,
+        conditions=conditions,
     )
 
 
@@ -178,4 +181,106 @@ def _parse_min_unique_chars(value: Any) -> int | None:
     if value < 1:
         msg = f"min_unique_chars must be a positive integer (>= 1), got: {value}"
         raise ValueError(msg)
+    return value
+
+
+_VALID_CONDITION_FIELDS = frozenset(
+    {
+        "time_after",
+        "time_before",
+        "environment",
+        "branch",
+        "weekdays",
+    }
+)
+
+
+def _parse_conditions(data: Any) -> Condition:
+    """Parse and validate a conditions block into a Condition.
+
+    Args:
+        data: Raw conditions dict from YAML.
+
+    Returns:
+        A validated Condition object.
+
+    Raises:
+        ValueError: If the conditions block has invalid fields or values.
+    """
+    if not isinstance(data, dict):
+        msg = "conditions must be a mapping"
+        raise ValueError(msg)
+
+    unknown = set(data.keys()) - _VALID_CONDITION_FIELDS
+    if unknown:
+        msg = f"Unknown condition field(s): {', '.join(sorted(unknown))}"
+        raise ValueError(msg)
+
+    time_after = _parse_time_field(data.get("time_after"), "time_after")
+    time_before = _parse_time_field(data.get("time_before"), "time_before")
+    environment: str | None = data.get("environment")
+    if environment is not None:
+        environment = str(environment)
+    branch: str | None = data.get("branch")
+    if branch is not None:
+        branch = str(branch)
+    weekdays = _parse_weekdays(data.get("weekdays"))
+
+    return Condition(
+        time_after=time_after,
+        time_before=time_before,
+        environment=environment,
+        branch=branch,
+        weekdays=weekdays,
+    )
+
+
+def _parse_time_field(value: Any, field_name: str) -> time | None:
+    """Parse a time string (HH:MM) into a time object.
+
+    Args:
+        value: Raw value from YAML (None if absent, str if present).
+        field_name: Field name for error messages.
+
+    Returns:
+        A time object, or None if value is None.
+
+    Raises:
+        ValueError: If the value is not a valid HH:MM time string.
+    """
+    if value is None:
+        return None
+    value_str = str(value)
+    try:
+        parts = value_str.split(":")
+        if len(parts) != 2:
+            raise ValueError
+        hour, minute = int(parts[0]), int(parts[1])
+        return time(hour, minute)
+    except (ValueError, IndexError):
+        msg = f"Invalid {field_name} value '{value_str}'. Expected HH:MM format"
+        raise ValueError(msg) from None
+
+
+def _parse_weekdays(value: Any) -> list[int] | None:
+    """Parse and validate a weekdays list.
+
+    Args:
+        value: Raw value from YAML (None if absent, list if present).
+
+    Returns:
+        A validated list of integers (0-6), or None if value is None.
+
+    Raises:
+        ValueError: If any weekday value is not in 0-6 range.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        msg = f"weekdays must be a list of integers (0-6), got: {type(value).__name__}"
+        raise ValueError(msg)
+    for day in value:
+        if not isinstance(day, int) or isinstance(day, bool) or day < 0 or day > 6:
+            msg = f"Invalid weekday value {day!r}. Must be 0 (Mon) through 6 (Sun)"
+            raise ValueError(msg)
     return value

--- a/src/agentguard/policies/models.py
+++ b/src/agentguard/policies/models.py
@@ -1,4 +1,4 @@
-"""Policy data models: Severity, Action, Rule, Decision, Policy.
+"""Policy data models: Severity, Action, Rule, Decision, Policy, Condition, Context.
 
 These are the core types used throughout the AgentGuard policy engine.
 All are immutable (frozen dataclasses or enums) for safety.
@@ -7,11 +7,13 @@ All are immutable (frozen dataclasses or enums) for safety.
 from __future__ import annotations
 
 import enum
+import fnmatch
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import re
+    from datetime import datetime, time
 
 
 class Severity(enum.Enum):
@@ -85,6 +87,109 @@ class Action:
     params: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class Context:
+    """Runtime context for conditional policy evaluation.
+
+    Provides environmental information used by :class:`Condition` to
+    determine whether a rule is active. All fields are optional; when
+    a condition references a context field that is ``None``, the
+    condition is considered *not met* (fail-closed for the condition,
+    meaning the rule is skipped).
+
+    Attributes:
+        time: Current UTC timestamp. Used by time-of-day and weekday
+            conditions.
+        environment: Deployment environment name (e.g., "production",
+            "staging", "development").
+        branch: Current git branch name. Supports fnmatch-style
+            patterns in conditions (e.g., ``"feature/*"``).
+        variables: Additional custom key-value context for future
+            extensibility.
+    """
+
+    time: datetime | None = None
+    environment: str | None = None
+    branch: str | None = None
+    variables: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Condition:
+    """Conditions that must be met for a rule to be active.
+
+    All specified conditions are AND-combined: every non-None field
+    must match the provided :class:`Context` for the condition to be
+    met. If a condition field is ``None``, it imposes no constraint.
+
+    YAML example::
+
+        conditions:
+          time_after: "09:00"
+          time_before: "17:00"
+          environment: production
+          branch: main
+          weekdays: [0, 1, 2, 3, 4]
+
+    Attributes:
+        time_after: Rule is active only after this time of day (UTC).
+        time_before: Rule is active only before this time of day (UTC).
+        environment: Rule is active only in this environment
+            (case-insensitive match).
+        branch: Rule is active only on this branch. Supports
+            fnmatch-style patterns (e.g., ``"feature/*"``).
+        weekdays: Rule is active only on these days of the week.
+            Monday=0 through Sunday=6 (ISO weekday numbering).
+    """
+
+    time_after: time | None = None
+    time_before: time | None = None
+    environment: str | None = None
+    branch: str | None = None
+    weekdays: list[int] | None = None
+
+    def is_met(self, ctx: Context) -> bool:
+        """Evaluate whether all conditions are satisfied by the context.
+
+        Args:
+            ctx: The runtime context to check against.
+
+        Returns:
+            True if all specified conditions are met.
+        """
+        if self.time_after is not None:
+            if ctx.time is None:
+                return False
+            if ctx.time.time() < self.time_after:
+                return False
+
+        if self.time_before is not None:
+            if ctx.time is None:
+                return False
+            if ctx.time.time() >= self.time_before:
+                return False
+
+        if self.weekdays is not None:
+            if ctx.time is None:
+                return False
+            if ctx.time.weekday() not in self.weekdays:
+                return False
+
+        if self.environment is not None:
+            if ctx.environment is None:
+                return False
+            if self.environment.lower() != ctx.environment.lower():
+                return False
+
+        if self.branch is not None:
+            if ctx.branch is None:
+                return False
+            if not fnmatch.fnmatch(ctx.branch, self.branch):
+                return False
+
+        return True
+
+
 @dataclass
 class Rule:
     """A deny rule within a policy.
@@ -122,6 +227,7 @@ class Rule:
     description: str | None = None
     scan: ScanTarget | None = None
     min_unique_chars: int | None = None
+    conditions: Condition | None = None
 
     def _has_sufficient_entropy(self, match: re.Match[str]) -> bool:
         """Check if a regex match has enough unique characters.
@@ -141,10 +247,27 @@ class Rule:
         unique_count = len(set(matched_text))
         return unique_count >= self.min_unique_chars
 
-    def matches(self, action: Action) -> bool:
-        """Check if this rule matches the given action."""
+    def matches(self, action: Action, context: Context | None = None) -> bool:
+        """Check if this rule matches the given action.
+
+        When the rule has conditions, they are checked against the
+        provided context first. If conditions are not met (or context
+        is missing when conditions require it), the rule is skipped.
+
+        Args:
+            action: The action to check.
+            context: Optional runtime context for conditional evaluation.
+
+        Returns:
+            True if the rule matches (action should be denied).
+        """
         if action.kind != self.action_kind:
             return False
+        if self.conditions is not None:
+            if context is None:
+                return False
+            if not self.conditions.is_met(context):
+                return False
         if self.scan is not None:
             return self._matches_scan_target(action)
         for pattern in self.deny_patterns:
@@ -215,13 +338,18 @@ class Policy:
     rules: list[Rule]
     description: str | None = None
 
-    def evaluate(self, action: Action) -> Decision:
+    def evaluate(self, action: Action, context: Context | None = None) -> Decision:
         """Evaluate an action against all rules in this policy.
 
-        Returns the first matching rule's decision, or allows if none match.
+        Args:
+            action: The action to check.
+            context: Optional runtime context for conditional rules.
+
+        Returns:
+            The first matching rule's decision, or allows if none match.
         """
         for rule in self.rules:
-            if rule.matches(action):
+            if rule.matches(action, context=context):
                 return Decision(
                     allowed=False,
                     denied_by=self.name,

--- a/tests/unit/test_conditional_policies.py
+++ b/tests/unit/test_conditional_policies.py
@@ -1,0 +1,687 @@
+"""Tests for conditional policies (M11).
+
+Covers:
+- Condition and Context data models
+- Time-based conditions (time_after, time_before, weekdays)
+- Environment-based conditions
+- Branch-based conditions
+- Combined conditions (AND semantics)
+- Rule evaluation with conditions
+- Policy evaluation with context
+- Guard.check() with context
+- YAML parsing of conditions
+- Edge cases and backward compatibility
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, time, timezone
+
+import pytest
+
+from agentguard.policies.guard import Guard
+from agentguard.policies.loader import load_policy_from_string
+from agentguard.policies.models import (
+    Action,
+    Condition,
+    Context,
+    Policy,
+    Rule,
+    Severity,
+)
+
+
+def _make_rule(
+    action_kind: str = "shell_command",
+    pattern: str = "rm -rf",
+    severity: Severity = Severity.CRITICAL,
+    conditions: Condition | None = None,
+) -> Rule:
+    """Helper to create a Rule with a single deny pattern."""
+    return Rule(
+        action_kind=action_kind,
+        deny_patterns=[re.compile(pattern)],
+        severity=severity,
+        conditions=conditions,
+    )
+
+
+# --- Condition model ---
+
+
+class TestCondition:
+    """Tests for the Condition dataclass."""
+
+    def test_empty_condition_is_valid(self) -> None:
+        cond = Condition()
+        assert cond.time_after is None
+        assert cond.time_before is None
+        assert cond.environment is None
+        assert cond.branch is None
+        assert cond.weekdays is None
+
+    def test_time_after_only(self) -> None:
+        cond = Condition(time_after=time(9, 0))
+        assert cond.time_after == time(9, 0)
+
+    def test_time_before_only(self) -> None:
+        cond = Condition(time_before=time(17, 0))
+        assert cond.time_before == time(17, 0)
+
+    def test_environment_set(self) -> None:
+        cond = Condition(environment="production")
+        assert cond.environment == "production"
+
+    def test_branch_set(self) -> None:
+        cond = Condition(branch="main")
+        assert cond.branch == "main"
+
+    def test_weekdays_set(self) -> None:
+        cond = Condition(weekdays=[0, 1, 2, 3, 4])  # Mon-Fri
+        assert cond.weekdays == [0, 1, 2, 3, 4]
+
+    def test_all_fields(self) -> None:
+        cond = Condition(
+            time_after=time(9, 0),
+            time_before=time(17, 0),
+            environment="production",
+            branch="main",
+            weekdays=[0, 1, 2, 3, 4],
+        )
+        assert cond.time_after == time(9, 0)
+        assert cond.time_before == time(17, 0)
+        assert cond.environment == "production"
+        assert cond.branch == "main"
+        assert cond.weekdays == [0, 1, 2, 3, 4]
+
+
+# --- Context model ---
+
+
+class TestContext:
+    """Tests for the Context dataclass."""
+
+    def test_default_context(self) -> None:
+        ctx = Context()
+        assert ctx.time is None
+        assert ctx.environment is None
+        assert ctx.branch is None
+        assert ctx.variables == {}
+
+    def test_with_time(self) -> None:
+        t = datetime(2026, 3, 21, 14, 30, tzinfo=timezone.utc)
+        ctx = Context(time=t)
+        assert ctx.time == t
+
+    def test_with_environment(self) -> None:
+        ctx = Context(environment="staging")
+        assert ctx.environment == "staging"
+
+    def test_with_branch(self) -> None:
+        ctx = Context(branch="feature/new")
+        assert ctx.branch == "feature/new"
+
+    def test_with_variables(self) -> None:
+        ctx = Context(variables={"team": "engineering"})
+        assert ctx.variables == {"team": "engineering"}
+
+
+# --- Condition evaluation ---
+
+
+class TestConditionEvaluation:
+    """Tests for Condition.is_met(context) evaluation."""
+
+    def test_empty_condition_always_met(self) -> None:
+        """Condition with no fields set is always met."""
+        cond = Condition()
+        ctx = Context()
+        assert cond.is_met(ctx) is True
+
+    def test_empty_condition_met_with_any_context(self) -> None:
+        cond = Condition()
+        ctx = Context(environment="production", branch="main")
+        assert cond.is_met(ctx) is True
+
+    # --- Time-based ---
+
+    def test_time_after_met(self) -> None:
+        """Current time is after the threshold."""
+        cond = Condition(time_after=time(9, 0))
+        ctx = Context(
+            time=datetime(2026, 3, 21, 10, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is True
+
+    def test_time_after_not_met(self) -> None:
+        """Current time is before the threshold."""
+        cond = Condition(time_after=time(9, 0))
+        ctx = Context(
+            time=datetime(2026, 3, 21, 8, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is False
+
+    def test_time_before_met(self) -> None:
+        """Current time is before the threshold."""
+        cond = Condition(time_before=time(17, 0))
+        ctx = Context(
+            time=datetime(2026, 3, 21, 16, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is True
+
+    def test_time_before_not_met(self) -> None:
+        """Current time is after the threshold."""
+        cond = Condition(time_before=time(17, 0))
+        ctx = Context(
+            time=datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is False
+
+    def test_time_window(self) -> None:
+        """time_after + time_before define a window; inside = met."""
+        cond = Condition(time_after=time(9, 0), time_before=time(17, 0))
+        ctx = Context(
+            time=datetime(2026, 3, 21, 12, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is True
+
+    def test_time_window_outside(self) -> None:
+        """Outside the time window = not met."""
+        cond = Condition(time_after=time(9, 0), time_before=time(17, 0))
+        ctx = Context(
+            time=datetime(2026, 3, 21, 20, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is False
+
+    def test_time_condition_without_context_time_not_met(self) -> None:
+        """Time condition without context time = not met (fail-closed)."""
+        cond = Condition(time_after=time(9, 0))
+        ctx = Context()
+        assert cond.is_met(ctx) is False
+
+    def test_weekdays_met(self) -> None:
+        """Friday is in the weekday list."""
+        cond = Condition(weekdays=[0, 1, 2, 3, 4])  # Mon-Fri
+        # 2026-03-20 is a Friday (weekday=4)
+        ctx = Context(
+            time=datetime(2026, 3, 20, 12, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is True
+
+    def test_weekdays_not_met(self) -> None:
+        """Saturday is not in the weekday list."""
+        cond = Condition(weekdays=[0, 1, 2, 3, 4])  # Mon-Fri
+        # 2026-03-21 is a Saturday (weekday=5)
+        ctx = Context(
+            time=datetime(2026, 3, 21, 12, 0, tzinfo=timezone.utc),
+        )
+        assert cond.is_met(ctx) is False
+
+    def test_weekdays_without_context_time_not_met(self) -> None:
+        """Weekday condition without context time = not met."""
+        cond = Condition(weekdays=[0, 1, 2, 3, 4])
+        ctx = Context()
+        assert cond.is_met(ctx) is False
+
+    # --- Environment-based ---
+
+    def test_environment_met(self) -> None:
+        cond = Condition(environment="production")
+        ctx = Context(environment="production")
+        assert cond.is_met(ctx) is True
+
+    def test_environment_not_met(self) -> None:
+        cond = Condition(environment="production")
+        ctx = Context(environment="staging")
+        assert cond.is_met(ctx) is False
+
+    def test_environment_case_insensitive(self) -> None:
+        cond = Condition(environment="Production")
+        ctx = Context(environment="production")
+        assert cond.is_met(ctx) is True
+
+    def test_environment_without_context_env_not_met(self) -> None:
+        """Environment condition without context environment = not met."""
+        cond = Condition(environment="production")
+        ctx = Context()
+        assert cond.is_met(ctx) is False
+
+    # --- Branch-based ---
+
+    def test_branch_exact_match(self) -> None:
+        cond = Condition(branch="main")
+        ctx = Context(branch="main")
+        assert cond.is_met(ctx) is True
+
+    def test_branch_not_met(self) -> None:
+        cond = Condition(branch="main")
+        ctx = Context(branch="feature/new")
+        assert cond.is_met(ctx) is False
+
+    def test_branch_glob_pattern(self) -> None:
+        """Branch supports fnmatch-style glob patterns."""
+        cond = Condition(branch="feature/*")
+        ctx = Context(branch="feature/new-thing")
+        assert cond.is_met(ctx) is True
+
+    def test_branch_glob_not_met(self) -> None:
+        cond = Condition(branch="feature/*")
+        ctx = Context(branch="main")
+        assert cond.is_met(ctx) is False
+
+    def test_branch_without_context_branch_not_met(self) -> None:
+        """Branch condition without context branch = not met."""
+        cond = Condition(branch="main")
+        ctx = Context()
+        assert cond.is_met(ctx) is False
+
+    # --- Combined conditions (AND semantics) ---
+
+    def test_all_conditions_met(self) -> None:
+        cond = Condition(
+            time_after=time(9, 0),
+            time_before=time(17, 0),
+            environment="production",
+            branch="main",
+        )
+        ctx = Context(
+            time=datetime(2026, 3, 20, 12, 0, tzinfo=timezone.utc),
+            environment="production",
+            branch="main",
+        )
+        assert cond.is_met(ctx) is True
+
+    def test_one_condition_not_met(self) -> None:
+        """If any one condition fails, the whole is not met."""
+        cond = Condition(
+            environment="production",
+            branch="main",
+        )
+        ctx = Context(
+            environment="staging",
+            branch="main",
+        )
+        assert cond.is_met(ctx) is False
+
+
+# --- Rule with conditions ---
+
+
+class TestRuleWithConditions:
+    """Tests for Rule.matches() with conditions."""
+
+    def test_rule_without_conditions_always_evaluated(self) -> None:
+        """Backward compat: no conditions = always match if pattern matches."""
+        rule = _make_rule()
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        assert rule.matches(action) is True
+
+    def test_rule_with_met_condition_matches(self) -> None:
+        """Rule matches when conditions are met and pattern matches."""
+        rule = _make_rule(
+            conditions=Condition(environment="production"),
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        ctx = Context(environment="production")
+        assert rule.matches(action, context=ctx) is True
+
+    def test_rule_with_unmet_condition_skipped(self) -> None:
+        """Rule is skipped when conditions are not met."""
+        rule = _make_rule(
+            conditions=Condition(environment="production"),
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        ctx = Context(environment="staging")
+        assert rule.matches(action, context=ctx) is False
+
+    def test_rule_with_conditions_no_context_skipped(self) -> None:
+        """Rule with conditions but no context passed = skipped (fail-open)."""
+        rule = _make_rule(
+            conditions=Condition(environment="production"),
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        assert rule.matches(action) is False
+
+    def test_rule_pattern_not_matched_even_with_conditions_met(self) -> None:
+        """Even if conditions are met, pattern must also match."""
+        rule = _make_rule(
+            conditions=Condition(environment="production"),
+        )
+        action = Action(kind="shell_command", params={"command": "echo hello"})
+        ctx = Context(environment="production")
+        assert rule.matches(action, context=ctx) is False
+
+
+# --- Policy evaluation with context ---
+
+
+class TestPolicyWithContext:
+    """Tests for Policy.evaluate() with context."""
+
+    def test_evaluate_with_context_denies(self) -> None:
+        policy = Policy(
+            name="conditional-deny",
+            rules=[
+                _make_rule(conditions=Condition(environment="production")),
+            ],
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        ctx = Context(environment="production")
+        decision = policy.evaluate(action, context=ctx)
+        assert decision.denied is True
+
+    def test_evaluate_with_context_allows(self) -> None:
+        policy = Policy(
+            name="conditional-deny",
+            rules=[
+                _make_rule(conditions=Condition(environment="production")),
+            ],
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        ctx = Context(environment="staging")
+        decision = policy.evaluate(action, context=ctx)
+        assert decision.allowed is True
+
+    def test_evaluate_without_context_backward_compat(self) -> None:
+        """Policy with unconditional rules still works without context."""
+        policy = Policy(
+            name="always-deny",
+            rules=[_make_rule()],
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+        decision = policy.evaluate(action)
+        assert decision.denied is True
+
+
+# --- Guard.check() with context ---
+
+
+class TestGuardWithContext:
+    """Tests for Guard.check() with context."""
+
+    def test_check_with_context_denies(self) -> None:
+        guard = Guard(
+            policies=[
+                Policy(
+                    name="prod-only",
+                    rules=[
+                        _make_rule(
+                            conditions=Condition(environment="production"),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        decision = guard.check(
+            "shell_command",
+            Context(environment="production"),
+            command="rm -rf /",
+        )
+        assert decision.denied is True
+
+    def test_check_with_context_allows(self) -> None:
+        guard = Guard(
+            policies=[
+                Policy(
+                    name="prod-only",
+                    rules=[
+                        _make_rule(
+                            conditions=Condition(environment="production"),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        decision = guard.check(
+            "shell_command",
+            Context(environment="staging"),
+            command="rm -rf /",
+        )
+        assert decision.allowed is True
+
+    def test_check_without_context_backward_compat(self) -> None:
+        """Guard.check() without context works for unconditional rules."""
+        guard = Guard(
+            policies=[
+                Policy(name="always-deny", rules=[_make_rule()]),
+            ],
+        )
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.denied is True
+
+
+# --- YAML loading with conditions ---
+
+
+class TestYAMLConditions:
+    """Tests for YAML parsing of conditions."""
+
+    def test_load_policy_with_time_conditions(self) -> None:
+        yaml_str = """
+name: time-based
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      time_after: "09:00"
+      time_before: "17:00"
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert policy.name == "time-based"
+        rule = policy.rules[0]
+        assert rule.conditions is not None
+        assert rule.conditions.time_after == time(9, 0)
+        assert rule.conditions.time_before == time(17, 0)
+
+    def test_load_policy_with_environment_condition(self) -> None:
+        yaml_str = """
+name: env-based
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      environment: production
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        rule = policy.rules[0]
+        assert rule.conditions is not None
+        assert rule.conditions.environment == "production"
+
+    def test_load_policy_with_branch_condition(self) -> None:
+        yaml_str = """
+name: branch-based
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      branch: main
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        rule = policy.rules[0]
+        assert rule.conditions is not None
+        assert rule.conditions.branch == "main"
+
+    def test_load_policy_with_weekdays_condition(self) -> None:
+        yaml_str = """
+name: weekday-based
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      weekdays: [0, 1, 2, 3, 4]
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        rule = policy.rules[0]
+        assert rule.conditions is not None
+        assert rule.conditions.weekdays == [0, 1, 2, 3, 4]
+
+    def test_load_policy_with_all_conditions(self) -> None:
+        yaml_str = """
+name: full-conditional
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      time_after: "08:30"
+      time_before: "18:30"
+      environment: production
+      branch: "release/*"
+      weekdays: [0, 1, 2, 3, 4]
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        rule = policy.rules[0]
+        assert rule.conditions is not None
+        assert rule.conditions.time_after == time(8, 30)
+        assert rule.conditions.time_before == time(18, 30)
+        assert rule.conditions.environment == "production"
+        assert rule.conditions.branch == "release/*"
+        assert rule.conditions.weekdays == [0, 1, 2, 3, 4]
+
+    def test_load_policy_without_conditions_backward_compat(self) -> None:
+        yaml_str = """
+name: no-conditions
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        rule = policy.rules[0]
+        assert rule.conditions is None
+
+    def test_invalid_time_format_raises(self) -> None:
+        yaml_str = """
+name: bad-time
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      time_after: "not-a-time"
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="time_after"):
+            load_policy_from_string(yaml_str)
+
+    def test_invalid_weekday_raises(self) -> None:
+        yaml_str = """
+name: bad-weekday
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      weekdays: [0, 7]
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="weekday"):
+            load_policy_from_string(yaml_str)
+
+    def test_unknown_condition_field_raises(self) -> None:
+        yaml_str = """
+name: bad-field
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      unknown_field: value
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="Unknown condition"):
+            load_policy_from_string(yaml_str)
+
+
+# --- End-to-end: YAML → Guard → conditional check ---
+
+
+class TestEndToEnd:
+    """End-to-end tests: load YAML, create guard, check with context."""
+
+    def test_conditional_policy_enforced_in_production(self) -> None:
+        yaml_str = """
+name: prod-protection
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      environment: production
+    deny:
+      - pattern: 'rm -rf'
+"""
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+        decision = guard.check(
+            "shell_command",
+            Context(environment="production"),
+            command="rm -rf /",
+        )
+        assert decision.denied is True
+        assert decision.denied_by == "prod-protection"
+
+    def test_conditional_policy_not_enforced_in_staging(self) -> None:
+        yaml_str = """
+name: prod-protection
+rules:
+  - action: shell_command
+    severity: critical
+    conditions:
+      environment: production
+    deny:
+      - pattern: 'rm -rf'
+"""
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+        decision = guard.check(
+            "shell_command",
+            Context(environment="staging"),
+            command="rm -rf /",
+        )
+        assert decision.allowed is True
+
+    def test_time_based_enforcement(self) -> None:
+        yaml_str = """
+name: business-hours-only
+rules:
+  - action: shell_command
+    severity: high
+    conditions:
+      time_after: "09:00"
+      time_before: "17:00"
+    deny:
+      - pattern: 'deploy'
+"""
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+
+        # During business hours: denied
+        during = guard.check(
+            "shell_command",
+            Context(
+                time=datetime(2026, 3, 20, 12, 0, tzinfo=timezone.utc),
+            ),
+            command="deploy production",
+        )
+        assert during.denied is True
+
+        # Outside business hours: allowed
+        outside = guard.check(
+            "shell_command",
+            Context(
+                time=datetime(2026, 3, 20, 20, 0, tzinfo=timezone.utc),
+            ),
+            command="deploy production",
+        )
+        assert outside.allowed is True


### PR DESCRIPTION
## Summary

- Add `Condition` and `Context` dataclasses to the policy engine for conditional rule activation
- Rules with conditions are only evaluated when all conditions match the runtime context
- Backward compatible: rules without conditions behave unchanged, `Guard.check()` without context works as before
- First task of M11 (Policy Enhancements) milestone

## Condition Types

| Field | Type | Description |
|-------|------|-------------|
| `time_after` | HH:MM | Rule active only after this UTC time |
| `time_before` | HH:MM | Rule active only before this UTC time |
| `weekdays` | [0-6] | Rule active only on these days (Mon=0, Sun=6) |
| `environment` | string | Rule active only in this environment (case-insensitive) |
| `branch` | string/glob | Rule active only on matching branch (fnmatch patterns) |

All conditions are AND-combined. Missing context fields cause the condition to fail (fail-closed for the condition, meaning the rule is skipped).

## YAML Syntax

```yaml
name: prod-protection
rules:
  - action: shell_command
    severity: critical
    conditions:
      time_after: "09:00"
      time_before: "17:00"
      environment: production
      branch: main
      weekdays: [0, 1, 2, 3, 4]
    deny:
      - pattern: 'rm -rf'
```

## Files Changed

- **Modified:** `src/agentguard/policies/models.py` — add `Condition`, `Context` dataclasses; `Rule.conditions` field; context propagation through `matches()` and `evaluate()`
- **Modified:** `src/agentguard/policies/guard.py` — `Guard.check()` accepts positional `Context` parameter
- **Modified:** `src/agentguard/policies/loader.py` — parse `conditions` block from YAML with validation
- **Modified:** `src/agentguard/policies/__init__.py` — export `Condition` and `Context`
- **New:** `tests/unit/test_conditional_policies.py` — 58 tests covering all condition types, combinations, YAML parsing, and end-to-end scenarios

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.