### PR TITLE
feat: add policy versioning and changelog support

### DIFF
--- a/src/agentguard/policies/__init__.py
+++ b/src/agentguard/policies/__init__.py
@@ -6,6 +6,7 @@ from agentguard.policies.guard import Guard
 from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
 from agentguard.policies.models import (
     Action,
+    ChangelogEntry,
     Condition,
     Context,
     Decision,
@@ -16,6 +17,7 @@ from agentguard.policies.models import (
 
 __all__ = [
     "Action",
+    "ChangelogEntry",
     "Condition",
     "Context",
     "Decision",

--- a/src/agentguard/policies/guard.py
+++ b/src/agentguard/policies/guard.py
@@ -75,6 +75,16 @@ class Guard:
         """Return the list of loaded policies."""
         return self._policies
 
+    @property
+    def policy_versions(self) -> dict[str, str | None]:
+        """Return a mapping of policy names to their versions.
+
+        Returns:
+            Dict mapping policy name to version string (or None if
+            the policy has no version).
+        """
+        return {p.name: p.version for p in self._policies}
+
     def add_policy(self, policy: Policy) -> Guard:
         """Add a policy to the guard.
 

--- a/src/agentguard/policies/loader.py
+++ b/src/agentguard/policies/loader.py
@@ -10,13 +10,20 @@ the standard library. (PyYAML is a dependency, but it's ubiquitous.)
 from __future__ import annotations
 
 import re
-from datetime import time
+from datetime import date, time
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from agentguard.policies.models import Condition, Policy, Rule, ScanTarget, Severity
+from agentguard.policies.models import (
+    ChangelogEntry,
+    Condition,
+    Policy,
+    Rule,
+    ScanTarget,
+    Severity,
+)
 
 
 def load_policy_from_string(yaml_str: str) -> Policy:
@@ -72,10 +79,14 @@ def _parse_policy(data: dict[str, Any]) -> Policy:
         raise ValueError(msg)
 
     rules = [_parse_rule(r) for r in data["rules"]]
+    version = _parse_version(data.get("version")) if "version" in data else None
+    changelog = _parse_changelog(data["changelog"]) if "changelog" in data else None
     return Policy(
         name=data["name"],
         description=data.get("description"),
         rules=rules,
+        version=version,
+        changelog=changelog,
     )
 
 
@@ -284,3 +295,116 @@ def _parse_weekdays(value: Any) -> list[int] | None:
             msg = f"Invalid weekday value {day!r}. Must be 0 (Mon) through 6 (Sun)"
             raise ValueError(msg)
     return value
+
+
+# Version format: major, major.minor, or major.minor.patch
+_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}$")
+
+
+def _parse_version(value: Any) -> str:
+    """Parse and validate a version string.
+
+    Accepts semver-like formats: major, major.minor, or
+    major.minor.patch.
+
+    Args:
+        value: Raw version value from YAML.
+
+    Returns:
+        The validated version string.
+
+    Raises:
+        ValueError: If the version string is invalid.
+    """
+    version_str = str(value)
+    if not _VERSION_RE.match(version_str):
+        msg = (
+            f"Invalid version '{version_str}'. "
+            "Expected format: major, major.minor, or major.minor.patch "
+            "(e.g., '1', '1.2', '1.2.3')"
+        )
+        raise ValueError(msg)
+    return version_str
+
+
+def _parse_changelog(data: Any) -> list[ChangelogEntry]:
+    """Parse and validate a changelog list.
+
+    Args:
+        data: Raw changelog list from YAML.
+
+    Returns:
+        A list of validated ChangelogEntry objects.
+
+    Raises:
+        ValueError: If any entry is invalid.
+    """
+    if not isinstance(data, list):
+        msg = "changelog must be a list of entries"
+        raise ValueError(msg)
+
+    entries: list[ChangelogEntry] = []
+    for i, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            msg = f"changelog entry {i} must be a mapping"
+            raise ValueError(msg)
+        entries.append(_parse_changelog_entry(entry, i))
+    return entries
+
+
+def _parse_changelog_entry(data: dict[str, Any], index: int) -> ChangelogEntry:
+    """Parse a single changelog entry.
+
+    Args:
+        data: Raw entry dict from YAML.
+        index: Entry index for error messages.
+
+    Returns:
+        A validated ChangelogEntry.
+
+    Raises:
+        ValueError: If required fields are missing or invalid.
+    """
+    if "version" not in data:
+        msg = f"changelog entry {index} must have a 'version' field"
+        raise ValueError(msg)
+    if "description" not in data:
+        msg = f"changelog entry {index} must have a 'description' field"
+        raise ValueError(msg)
+
+    entry_date: date | None = None
+    if "date" in data:
+        entry_date = _parse_date(data["date"], index)
+
+    return ChangelogEntry(
+        version=str(data["version"]),
+        description=str(data["description"]),
+        date=entry_date,
+    )
+
+
+def _parse_date(value: Any, entry_index: int) -> date:
+    """Parse a date string (YYYY-MM-DD) into a date object.
+
+    Args:
+        value: Raw value from YAML.
+        entry_index: Changelog entry index for error messages.
+
+    Returns:
+        A date object.
+
+    Raises:
+        ValueError: If the value is not a valid YYYY-MM-DD date.
+    """
+    # YAML may auto-parse dates as datetime.date objects
+    if isinstance(value, date):
+        return value
+    value_str = str(value)
+    try:
+        return date.fromisoformat(value_str)
+    except ValueError:
+        msg = (
+            f"Invalid date '{value_str}' in changelog entry {entry_index}. "
+            "Expected YYYY-MM-DD format"
+        )
+        raise ValueError(msg) from None

--- a/src/agentguard/policies/models.py
+++ b/src/agentguard/policies/models.py
@@ -1,7 +1,8 @@
-"""Policy data models: Severity, Action, Rule, Decision, Policy, Condition, Context.
+"""Policy data models for the AgentGuard policy engine.
 
-These are the core types used throughout the AgentGuard policy engine.
-All are immutable (frozen dataclasses or enums) for safety.
+Core types: Severity, Action, Rule, Decision, Policy, Condition,
+Context, ChangelogEntry. All are immutable (frozen dataclasses or
+enums) for safety.
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import re
-    from datetime import datetime, time
+    from datetime import date, datetime, time
 
 
 class Severity(enum.Enum):
@@ -190,6 +191,21 @@ class Condition:
         return True
 
 
+@dataclass(frozen=True)
+class ChangelogEntry:
+    """A single entry in a policy's changelog.
+
+    Attributes:
+        version: The version this entry describes.
+        description: Human-readable description of what changed.
+        date: Optional date of the change (ISO 8601 format in YAML).
+    """
+
+    version: str
+    description: str
+    date: date | None = None
+
+
 @dataclass
 class Rule:
     """A deny rule within a policy.
@@ -311,12 +327,15 @@ class Decision:
         denied_by: Name of the policy that denied it (if denied).
         reason: Human-readable explanation (if denied).
         severity: Severity of the violated rule (if denied).
+        policy_version: Version of the denying policy (if denied and
+            the policy has a version).
     """
 
     allowed: bool
     denied_by: str | None = None
     reason: str | None = None
     severity: Severity | None = None
+    policy_version: str | None = None
 
     @property
     def denied(self) -> bool:
@@ -330,13 +349,17 @@ class Policy:
 
     Attributes:
         name: Unique identifier for this policy.
-        description: Human-readable description.
         rules: List of deny rules. First match wins.
+        description: Human-readable description.
+        version: Optional semver-like version string.
+        changelog: Optional list of changelog entries (newest first).
     """
 
     name: str
     rules: list[Rule]
     description: str | None = None
+    version: str | None = None
+    changelog: list[ChangelogEntry] | None = None
 
     def evaluate(self, action: Action, context: Context | None = None) -> Decision:
         """Evaluate an action against all rules in this policy.
@@ -355,5 +378,6 @@ class Policy:
                     denied_by=self.name,
                     reason=f"Blocked by policy: {self.name}",
                     severity=rule.severity,
+                    policy_version=self.version,
                 )
         return Decision(allowed=True)

--- a/tests/unit/test_policy_versioning.py
+++ b/tests/unit/test_policy_versioning.py
@@ -1,0 +1,372 @@
+"""Tests for policy versioning and changelog (M11).
+
+Covers:
+- ChangelogEntry data model
+- Policy version and changelog fields
+- Guard.policy_versions property
+- YAML parsing of version and changelog
+- Version format validation
+- Changelog ordering and date parsing
+- Backward compatibility
+- Decision includes policy version
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+
+import pytest
+
+from agentguard.policies.guard import Guard
+from agentguard.policies.loader import load_policy_from_string
+from agentguard.policies.models import (
+    ChangelogEntry,
+    Policy,
+    Rule,
+    Severity,
+)
+
+
+def _make_policy(
+    name: str = "test-policy",
+    version: str | None = None,
+    changelog: list[ChangelogEntry] | None = None,
+) -> Policy:
+    """Helper to create a Policy with a single deny rule."""
+    return Policy(
+        name=name,
+        rules=[
+            Rule(
+                action_kind="shell_command",
+                deny_patterns=[re.compile("rm -rf")],
+                severity=Severity.CRITICAL,
+            ),
+        ],
+        version=version,
+        changelog=changelog,
+    )
+
+
+# --- ChangelogEntry model ---
+
+
+class TestChangelogEntry:
+    """Tests for the ChangelogEntry dataclass."""
+
+    def test_create_entry(self) -> None:
+        entry = ChangelogEntry(
+            version="1.0.0",
+            date=date(2026, 3, 21),
+            description="Initial release",
+        )
+        assert entry.version == "1.0.0"
+        assert entry.date == date(2026, 3, 21)
+        assert entry.description == "Initial release"
+
+    def test_entry_without_date(self) -> None:
+        entry = ChangelogEntry(
+            version="1.1.0",
+            description="Added new patterns",
+        )
+        assert entry.date is None
+
+    def test_entry_is_frozen(self) -> None:
+        entry = ChangelogEntry(version="1.0.0", description="Initial")
+        with pytest.raises(AttributeError):
+            entry.version = "2.0.0"  # type: ignore[misc]
+
+
+# --- Policy with version ---
+
+
+class TestPolicyVersion:
+    """Tests for Policy.version field."""
+
+    def test_policy_without_version(self) -> None:
+        """Backward compat: version is None by default."""
+        policy = Policy(
+            name="test",
+            rules=[
+                Rule(
+                    action_kind="shell_command",
+                    deny_patterns=[re.compile("rm")],
+                    severity=Severity.CRITICAL,
+                ),
+            ],
+        )
+        assert policy.version is None
+
+    def test_policy_with_version(self) -> None:
+        policy = _make_policy(version="1.2.3")
+        assert policy.version == "1.2.3"
+
+    def test_policy_with_two_part_version(self) -> None:
+        policy = _make_policy(version="2.1")
+        assert policy.version == "2.1"
+
+    def test_policy_with_single_version(self) -> None:
+        policy = _make_policy(version="3")
+        assert policy.version == "3"
+
+
+# --- Policy with changelog ---
+
+
+class TestPolicyChangelog:
+    """Tests for Policy.changelog field."""
+
+    def test_policy_without_changelog(self) -> None:
+        policy = _make_policy()
+        assert policy.changelog is None
+
+    def test_policy_with_changelog(self) -> None:
+        entries = [
+            ChangelogEntry(
+                version="1.1.0",
+                date=date(2026, 3, 21),
+                description="Added branch conditions",
+            ),
+            ChangelogEntry(
+                version="1.0.0",
+                date=date(2026, 3, 1),
+                description="Initial release",
+            ),
+        ]
+        policy = _make_policy(version="1.1.0", changelog=entries)
+        assert policy.changelog is not None
+        assert len(policy.changelog) == 2
+        assert policy.changelog[0].version == "1.1.0"
+        assert policy.changelog[1].version == "1.0.0"
+
+
+# --- Guard.policy_versions ---
+
+
+class TestGuardPolicyVersions:
+    """Tests for Guard.policy_versions property."""
+
+    def test_empty_guard(self) -> None:
+        guard = Guard()
+        assert guard.policy_versions == {}
+
+    def test_versioned_policies(self) -> None:
+        guard = Guard(
+            policies=[
+                _make_policy(name="p1", version="1.0.0"),
+                _make_policy(name="p2", version="2.3.1"),
+            ],
+        )
+        versions = guard.policy_versions
+        assert versions == {"p1": "1.0.0", "p2": "2.3.1"}
+
+    def test_mixed_versioned_unversioned(self) -> None:
+        guard = Guard(
+            policies=[
+                _make_policy(name="p1", version="1.0.0"),
+                _make_policy(name="p2"),  # no version
+            ],
+        )
+        versions = guard.policy_versions
+        assert versions == {"p1": "1.0.0", "p2": None}
+
+
+# --- Decision includes policy version ---
+
+
+class TestDecisionWithVersion:
+    """Tests for Decision.policy_version field."""
+
+    def test_denial_includes_version(self) -> None:
+        guard = Guard(
+            policies=[_make_policy(name="v-policy", version="2.0.0")],
+        )
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.denied is True
+        assert decision.policy_version == "2.0.0"
+
+    def test_denial_without_version(self) -> None:
+        guard = Guard(
+            policies=[_make_policy(name="no-ver")],
+        )
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.denied is True
+        assert decision.policy_version is None
+
+    def test_allowed_has_no_version(self) -> None:
+        guard = Guard(
+            policies=[_make_policy(name="v-policy", version="1.0.0")],
+        )
+        decision = guard.check("shell_command", command="echo hello")
+        assert decision.allowed is True
+        assert decision.policy_version is None
+
+
+# --- YAML loading with version ---
+
+
+class TestYAMLVersion:
+    """Tests for YAML parsing of version and changelog."""
+
+    def test_load_policy_with_version(self) -> None:
+        yaml_str = """
+name: versioned-policy
+version: "1.2.3"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert policy.version == "1.2.3"
+
+    def test_load_policy_without_version(self) -> None:
+        yaml_str = """
+name: unversioned
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert policy.version is None
+
+    def test_load_policy_with_changelog(self) -> None:
+        yaml_str = """
+name: with-changelog
+version: "2.0.0"
+changelog:
+  - version: "2.0.0"
+    date: "2026-03-21"
+    description: "Added environment conditions"
+  - version: "1.0.0"
+    date: "2026-01-15"
+    description: "Initial release"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert policy.version == "2.0.0"
+        assert policy.changelog is not None
+        assert len(policy.changelog) == 2
+        assert policy.changelog[0].version == "2.0.0"
+        assert policy.changelog[0].date == date(2026, 3, 21)
+        assert policy.changelog[0].description == "Added environment conditions"
+        assert policy.changelog[1].version == "1.0.0"
+
+    def test_changelog_without_date(self) -> None:
+        yaml_str = """
+name: no-date
+version: "1.0.0"
+changelog:
+  - version: "1.0.0"
+    description: "Initial release"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert policy.changelog is not None
+        assert policy.changelog[0].date is None
+
+    def test_invalid_version_format_raises(self) -> None:
+        yaml_str = """
+name: bad-version
+version: "not.a.valid.version.string"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="version"):
+            load_policy_from_string(yaml_str)
+
+    def test_invalid_changelog_date_raises(self) -> None:
+        yaml_str = """
+name: bad-date
+version: "1.0.0"
+changelog:
+  - version: "1.0.0"
+    date: "not-a-date"
+    description: "Bad"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="date"):
+            load_policy_from_string(yaml_str)
+
+    def test_changelog_entry_missing_version_raises(self) -> None:
+        yaml_str = """
+name: missing-ver
+version: "1.0.0"
+changelog:
+  - description: "No version"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="version"):
+            load_policy_from_string(yaml_str)
+
+    def test_changelog_entry_missing_description_raises(self) -> None:
+        yaml_str = """
+name: missing-desc
+version: "1.0.0"
+changelog:
+  - version: "1.0.0"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        with pytest.raises(ValueError, match="description"):
+            load_policy_from_string(yaml_str)
+
+
+# --- End-to-end ---
+
+
+class TestVersioningEndToEnd:
+    """End-to-end tests: YAML → Guard → versioned check."""
+
+    def test_versioned_policy_round_trip(self) -> None:
+        yaml_str = """
+name: production-safety
+version: "3.1.0"
+description: Production environment safety rules
+changelog:
+  - version: "3.1.0"
+    date: "2026-03-21"
+    description: "Added data deletion protection"
+  - version: "3.0.0"
+    date: "2026-02-01"
+    description: "Major overhaul of deny patterns"
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: 'rm -rf'
+"""
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+
+        assert guard.policy_versions == {"production-safety": "3.1.0"}
+
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.denied is True
+        assert decision.policy_version == "3.1.0"
+        assert decision.denied_by == "production-safety"


### PR DESCRIPTION
## Summary

- Add `ChangelogEntry` dataclass and `version`/`changelog` fields to `Policy` for tracking policy evolution
- `Decision` now includes `policy_version` when denied by a versioned policy
- `Guard.policy_versions` property for introspecting loaded policy versions
- YAML parser extended to support `version` and `changelog` blocks with validation

## Design

Policies can now declare a semver-like version and an optional changelog:

```yaml
name: production-safety
version: "3.1.0"
changelog:
  - version: "3.1.0"
    date: "2026-03-21"
    description: "Added data deletion protection"
  - version: "3.0.0"
    date: "2026-02-01"
    description: "Major overhaul of deny patterns"
rules:
  - action: shell_command
    severity: critical
    deny:
      - pattern: 'rm -rf'
```

Version format accepts: `major`, `major.minor`, or `major.minor.patch`. All version/changelog fields are optional — backward compatible with existing policies.

## Files Changed

- **Modified:** `src/agentguard/policies/models.py` — add `ChangelogEntry` dataclass, `Policy.version` and `Policy.changelog` fields, `Decision.policy_version` field
- **Modified:** `src/agentguard/policies/guard.py` — add `Guard.policy_versions` property
- **Modified:** `src/agentguard/policies/loader.py` — parse `version` and `changelog` from YAML with validation
- **Modified:** `src/agentguard/policies/__init__.py` — export `ChangelogEntry`
- **New:** `tests/unit/test_policy_versioning.py` — 24 tests covering model, guard, YAML parsing, validation, and end-to-end scenarios

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.