### PR TITLE
feat: add deny action handlers — webhook, Slack, email

### DIFF
--- a/src/agentguard/policies/guard.py
+++ b/src/agentguard/policies/guard.py
@@ -7,6 +7,8 @@ policy engine.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from agentguard.policies.loader import load_policy_from_string, load_policy_from_yaml
@@ -14,6 +16,11 @@ from agentguard.policies.models import Action, Context, Decision, Policy
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Type alias for deny handler callables.
+DenyHandler = Callable[[Decision, Action], None]
 
 
 class Guard:
@@ -38,6 +45,7 @@ class Guard:
             policies: Optional list of policies to start with.
         """
         self._policies: list[Policy] = list(policies) if policies else []
+        self._deny_handlers: list[DenyHandler] = []
 
     @classmethod
     def with_auto_discovery(cls, *, include_builtins: bool = False) -> Guard:
@@ -84,6 +92,22 @@ class Guard:
             the policy has no version).
         """
         return {p.name: p.version for p in self._policies}
+
+    def on_deny(self, handler: DenyHandler) -> Guard:
+        """Register a handler to be called when a policy denies an action.
+
+        Handlers are invoked synchronously after a deny decision, in the
+        order they were registered. Handler exceptions are logged but do
+        not affect the deny decision.
+
+        Args:
+            handler: A callable accepting ``(Decision, Action)``.
+
+        Returns:
+            Self, for method chaining.
+        """
+        self._deny_handlers.append(handler)
+        return self
 
     def add_policy(self, policy: Policy) -> Guard:
         """Add a policy to the guard.
@@ -146,5 +170,24 @@ class Guard:
         for policy in self._policies:
             decision = policy.evaluate(action, context=context)
             if decision.denied:
+                self._invoke_deny_handlers(decision, action)
                 return decision
         return Decision(allowed=True)
+
+    def _invoke_deny_handlers(
+        self,
+        decision: Decision,
+        action: Action,
+    ) -> None:
+        """Invoke all registered deny handlers.
+
+        Exceptions from handlers are logged but do not propagate.
+        """
+        for handler in self._deny_handlers:
+            try:
+                handler(decision, action)
+            except Exception:
+                logger.exception(
+                    "Deny handler %r raised an exception",
+                    handler,
+                )

--- a/src/agentguard/policies/handlers.py
+++ b/src/agentguard/policies/handlers.py
@@ -1,0 +1,214 @@
+"""Built-in deny action handlers for policy violations.
+
+Provides handlers that can be registered with :meth:`Guard.on_deny` to
+receive notifications when a policy denies an action. All handlers use
+only Python standard library modules (zero external dependencies).
+
+Usage::
+
+    from agentguard.policies.guard import Guard
+    from agentguard.policies.handlers import WebhookHandler
+
+    guard = Guard(policies=[...])
+    guard.on_deny(WebhookHandler(url="https://example.com/webhook"))
+
+Handlers follow the ``DenyHandler`` protocol: any callable accepting
+``(Decision, Action)`` can be used. The built-in classes implement
+``__call__`` for this purpose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from email.mime.text import MIMEText
+from smtplib import SMTP
+from typing import TYPE_CHECKING
+from urllib.request import Request, urlopen
+
+if TYPE_CHECKING:
+    from agentguard.policies.models import Action, Decision
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookHandler:
+    """Send a JSON POST request to a webhook URL on policy deny.
+
+    The payload includes event type, policy name, severity, action
+    kind, reason, action parameters, and policy version.
+
+    Args:
+        url: The webhook URL to POST to.
+        headers: Optional additional HTTP headers.
+        timeout: Request timeout in seconds (default 10).
+
+    Raises:
+        ValueError: If url is empty.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        timeout: int = 10,
+    ) -> None:
+        if not url:
+            msg = "url must not be empty"
+            raise ValueError(msg)
+        self.url = url
+        self.headers = headers or {}
+        self.timeout = timeout
+
+    def __call__(self, decision: Decision, action: Action) -> None:
+        """Send webhook notification."""
+        payload = {
+            "event": "policy_deny",
+            "policy": decision.denied_by,
+            "severity": decision.severity.value if decision.severity else None,
+            "reason": decision.reason,
+            "action_kind": action.kind,
+            "action_params": dict(action.params),
+            "policy_version": decision.policy_version,
+        }
+        data = json.dumps(payload).encode("utf-8")
+        request = Request(
+            self.url,
+            data=data,
+            method="POST",
+        )
+        request.add_header("Content-Type", "application/json")
+        for key, value in self.headers.items():
+            request.add_header(key, value)
+
+        with urlopen(request, timeout=self.timeout):
+            pass
+
+
+class SlackHandler:
+    """Send a formatted message to a Slack webhook on policy deny.
+
+    Uses Slack's incoming webhook format with a text field containing
+    the deny details.
+
+    Args:
+        webhook_url: The Slack incoming webhook URL.
+        channel: Optional channel override (e.g., "#security").
+        timeout: Request timeout in seconds (default 10).
+
+    Raises:
+        ValueError: If webhook_url is empty.
+    """
+
+    def __init__(
+        self,
+        webhook_url: str,
+        channel: str | None = None,
+        timeout: int = 10,
+    ) -> None:
+        if not webhook_url:
+            msg = "webhook_url must not be empty"
+            raise ValueError(msg)
+        self.webhook_url = webhook_url
+        self.channel = channel
+        self.timeout = timeout
+
+    def __call__(self, decision: Decision, action: Action) -> None:
+        """Send Slack notification."""
+        severity = decision.severity.value.upper() if decision.severity else "UNKNOWN"
+        text = (
+            f":rotating_light: *Policy Deny* [{severity}]\n"
+            f"*Policy:* {decision.denied_by}"
+        )
+        if decision.policy_version:
+            text += f" (v{decision.policy_version})"
+        text += f"\n*Action:* {action.kind}\n*Reason:* {decision.reason}"
+
+        payload: dict[str, str] = {"text": text}
+        if self.channel:
+            payload["channel"] = self.channel
+
+        data = json.dumps(payload).encode("utf-8")
+        request = Request(
+            self.webhook_url,
+            data=data,
+            method="POST",
+        )
+        request.add_header("Content-Type", "application/json")
+
+        with urlopen(request, timeout=self.timeout):
+            pass
+
+
+class EmailHandler:
+    """Send an email notification on policy deny via SMTP.
+
+    Uses Python's built-in ``smtplib`` module. Supports optional
+    TLS and authentication.
+
+    Args:
+        smtp_host: SMTP server hostname.
+        smtp_port: SMTP server port (typically 587 for TLS, 25 for
+            plain).
+        from_addr: Sender email address.
+        to_addrs: List of recipient email addresses.
+        username: Optional SMTP username for authentication.
+        password: Optional SMTP password for authentication.
+        use_tls: Whether to use STARTTLS (default False).
+        timeout: SMTP connection timeout in seconds (default 30).
+
+    Raises:
+        ValueError: If smtp_host is empty or to_addrs is empty.
+    """
+
+    def __init__(
+        self,
+        smtp_host: str,
+        smtp_port: int,
+        from_addr: str,
+        to_addrs: list[str],
+        username: str | None = None,
+        password: str | None = None,
+        use_tls: bool = False,
+        timeout: int = 30,
+    ) -> None:
+        if not smtp_host:
+            msg = "smtp_host must not be empty"
+            raise ValueError(msg)
+        if not to_addrs:
+            msg = "to_addrs must not be empty"
+            raise ValueError(msg)
+        self.smtp_host = smtp_host
+        self.smtp_port = smtp_port
+        self.from_addr = from_addr
+        self.to_addrs = to_addrs
+        self.username = username
+        self.password = password
+        self.use_tls = use_tls
+        self.timeout = timeout
+
+    def __call__(self, decision: Decision, action: Action) -> None:
+        """Send email notification."""
+        severity = decision.severity.value.upper() if decision.severity else "UNKNOWN"
+        subject = f"[AgentGuard] Policy Deny [{severity}]: {decision.denied_by}"
+        body = (
+            f"Policy: {decision.denied_by}\n"
+            f"Severity: {severity}\n"
+            f"Action: {action.kind}\n"
+            f"Reason: {decision.reason}\n"
+            f"Parameters: {dict(action.params)}\n"
+        )
+        if decision.policy_version:
+            body += f"Policy version: {decision.policy_version}\n"
+
+        msg = MIMEText(body, "plain", "utf-8")
+        msg["Subject"] = subject
+        msg["From"] = self.from_addr
+        msg["To"] = ", ".join(self.to_addrs)
+
+        with SMTP(self.smtp_host, self.smtp_port, timeout=self.timeout) as smtp:
+            if self.use_tls:
+                smtp.starttls()
+            if self.username and self.password:
+                smtp.login(self.username, self.password)
+            smtp.sendmail(self.from_addr, self.to_addrs, msg.as_string())

--- a/tests/unit/test_deny_handlers.py
+++ b/tests/unit/test_deny_handlers.py
@@ -1,0 +1,413 @@
+"""Tests for custom deny action handlers (M11).
+
+Covers:
+- Guard.on_deny() registration
+- Handler invocation on deny
+- Handler not invoked on allow
+- Multiple handlers
+- Handler errors are caught (don't affect deny decision)
+- WebhookHandler: sends POST with JSON payload
+- SlackHandler: sends Slack-formatted message
+- EmailHandler: sends SMTP email
+- Built-in handler configuration and validation
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentguard.policies.guard import Guard
+from agentguard.policies.handlers import EmailHandler, SlackHandler, WebhookHandler
+from agentguard.policies.models import (
+    Action,
+    Decision,
+    Policy,
+    Rule,
+    Severity,
+)
+
+
+def _deny_policy(name: str = "test") -> Policy:
+    """Helper: a policy that denies 'rm -rf'."""
+    return Policy(
+        name=name,
+        version="1.0.0",
+        rules=[
+            Rule(
+                action_kind="shell_command",
+                deny_patterns=[re.compile("rm -rf")],
+                severity=Severity.CRITICAL,
+            ),
+        ],
+    )
+
+
+# --- Guard.on_deny registration and invocation ---
+
+
+class TestGuardOnDeny:
+    """Tests for Guard.on_deny() and handler invocation."""
+
+    def test_register_handler(self) -> None:
+        guard = Guard()
+        handler = MagicMock()
+        result = guard.on_deny(handler)
+        assert result is guard  # method chaining
+
+    def test_handler_called_on_deny(self) -> None:
+        handler = MagicMock()
+        guard = Guard(policies=[_deny_policy()])
+        guard.on_deny(handler)
+
+        decision = guard.check("shell_command", command="rm -rf /")
+
+        assert decision.denied is True
+        handler.assert_called_once()
+        call_args = handler.call_args
+        assert isinstance(call_args[0][0], Decision)
+        assert isinstance(call_args[0][1], Action)
+        assert call_args[0][0].denied is True
+
+    def test_handler_not_called_on_allow(self) -> None:
+        handler = MagicMock()
+        guard = Guard(policies=[_deny_policy()])
+        guard.on_deny(handler)
+
+        decision = guard.check("shell_command", command="echo hello")
+
+        assert decision.allowed is True
+        handler.assert_not_called()
+
+    def test_multiple_handlers_all_called(self) -> None:
+        handler1 = MagicMock()
+        handler2 = MagicMock()
+        guard = Guard(policies=[_deny_policy()])
+        guard.on_deny(handler1)
+        guard.on_deny(handler2)
+
+        guard.check("shell_command", command="rm -rf /")
+
+        handler1.assert_called_once()
+        handler2.assert_called_once()
+
+    def test_handler_error_does_not_affect_decision(self) -> None:
+        """Handler exceptions are caught; deny decision is still returned."""
+        bad_handler = MagicMock(side_effect=RuntimeError("boom"))
+        good_handler = MagicMock()
+        guard = Guard(policies=[_deny_policy()])
+        guard.on_deny(bad_handler)
+        guard.on_deny(good_handler)
+
+        decision = guard.check("shell_command", command="rm -rf /")
+
+        assert decision.denied is True
+        bad_handler.assert_called_once()
+        good_handler.assert_called_once()  # Still called despite first error
+
+    def test_handler_receives_correct_action(self) -> None:
+        handler = MagicMock()
+        guard = Guard(policies=[_deny_policy()])
+        guard.on_deny(handler)
+
+        guard.check("shell_command", command="rm -rf /home")
+
+        _, action = handler.call_args[0]
+        assert action.kind == "shell_command"
+        assert action.params["command"] == "rm -rf /home"
+
+    def test_handler_receives_policy_version(self) -> None:
+        handler = MagicMock()
+        guard = Guard(policies=[_deny_policy()])
+        guard.on_deny(handler)
+
+        guard.check("shell_command", command="rm -rf /")
+
+        decision, _ = handler.call_args[0]
+        assert decision.policy_version == "1.0.0"
+
+
+# --- WebhookHandler ---
+
+
+class TestWebhookHandler:
+    """Tests for WebhookHandler."""
+
+    def test_create_webhook_handler(self) -> None:
+        handler = WebhookHandler(url="https://example.com/webhook")
+        assert handler.url == "https://example.com/webhook"
+
+    def test_webhook_sends_post_request(self) -> None:
+        handler = WebhookHandler(url="https://example.com/hook")
+        decision = Decision(
+            allowed=False,
+            denied_by="test-policy",
+            reason="Blocked by policy: test-policy",
+            severity=Severity.CRITICAL,
+            policy_version="1.0.0",
+        )
+        action = Action(kind="shell_command", params={"command": "rm -rf /"})
+
+        with patch("agentguard.policies.handlers.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = MagicMock()
+            mock_urlopen.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            handler(decision, action)
+
+        mock_urlopen.assert_called_once()
+        request = mock_urlopen.call_args[0][0]
+        assert request.full_url == "https://example.com/hook"
+        assert request.method == "POST"
+        assert request.get_header("Content-type") == "application/json"
+
+        body = json.loads(request.data.decode())
+        assert body["event"] == "policy_deny"
+        assert body["policy"] == "test-policy"
+        assert body["severity"] == "critical"
+        assert body["action_kind"] == "shell_command"
+        assert body["policy_version"] == "1.0.0"
+
+    def test_webhook_custom_headers(self) -> None:
+        handler = WebhookHandler(
+            url="https://example.com/hook",
+            headers={"Authorization": "Bearer token123"},
+        )
+        decision = Decision(
+            allowed=False,
+            denied_by="p",
+            reason="r",
+            severity=Severity.HIGH,
+        )
+        action = Action(kind="test", params={})
+
+        with patch("agentguard.policies.handlers.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = MagicMock()
+            mock_urlopen.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            handler(decision, action)
+
+        request = mock_urlopen.call_args[0][0]
+        assert request.get_header("Authorization") == "Bearer token123"
+
+    def test_webhook_url_required(self) -> None:
+        with pytest.raises(ValueError, match="url"):
+            WebhookHandler(url="")
+
+
+# --- SlackHandler ---
+
+
+class TestSlackHandler:
+    """Tests for SlackHandler."""
+
+    def test_create_slack_handler(self) -> None:
+        handler = SlackHandler(webhook_url="https://hooks.slack.com/xxx")
+        assert handler.webhook_url == "https://hooks.slack.com/xxx"
+
+    def test_slack_sends_formatted_message(self) -> None:
+        handler = SlackHandler(webhook_url="https://hooks.slack.com/xxx")
+        decision = Decision(
+            allowed=False,
+            denied_by="safety-policy",
+            reason="Blocked by policy: safety-policy",
+            severity=Severity.CRITICAL,
+            policy_version="2.0.0",
+        )
+        action = Action(
+            kind="shell_command",
+            params={"command": "rm -rf /"},
+        )
+
+        with patch("agentguard.policies.handlers.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = MagicMock()
+            mock_urlopen.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            handler(decision, action)
+
+        mock_urlopen.assert_called_once()
+        request = mock_urlopen.call_args[0][0]
+        body = json.loads(request.data.decode())
+        assert "text" in body
+        assert "safety-policy" in body["text"]
+        assert "CRITICAL" in body["text"]
+
+    def test_slack_custom_channel(self) -> None:
+        handler = SlackHandler(
+            webhook_url="https://hooks.slack.com/xxx",
+            channel="#security",
+        )
+        decision = Decision(
+            allowed=False,
+            denied_by="p",
+            reason="r",
+            severity=Severity.HIGH,
+        )
+        action = Action(kind="test", params={})
+
+        with patch("agentguard.policies.handlers.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = MagicMock()
+            mock_urlopen.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            handler(decision, action)
+
+        request = mock_urlopen.call_args[0][0]
+        body = json.loads(request.data.decode())
+        assert body["channel"] == "#security"
+
+    def test_slack_url_required(self) -> None:
+        with pytest.raises(ValueError, match="webhook_url"):
+            SlackHandler(webhook_url="")
+
+
+# --- EmailHandler ---
+
+
+class TestEmailHandler:
+    """Tests for EmailHandler."""
+
+    def test_create_email_handler(self) -> None:
+        handler = EmailHandler(
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            from_addr="alerts@example.com",
+            to_addrs=["admin@example.com"],
+        )
+        assert handler.smtp_host == "smtp.example.com"
+        assert handler.to_addrs == ["admin@example.com"]
+
+    def test_email_sends_message(self) -> None:
+        handler = EmailHandler(
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            from_addr="alerts@example.com",
+            to_addrs=["admin@example.com"],
+        )
+        decision = Decision(
+            allowed=False,
+            denied_by="prod-policy",
+            reason="Blocked by policy: prod-policy",
+            severity=Severity.CRITICAL,
+            policy_version="1.0.0",
+        )
+        action = Action(
+            kind="shell_command",
+            params={"command": "rm -rf /"},
+        )
+
+        with patch("agentguard.policies.handlers.SMTP") as mock_smtp_cls:
+            mock_smtp = MagicMock()
+            mock_smtp_cls.return_value.__enter__ = MagicMock(
+                return_value=mock_smtp,
+            )
+            mock_smtp_cls.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            handler(decision, action)
+
+        mock_smtp_cls.assert_called_once_with(
+            "smtp.example.com",
+            587,
+            timeout=30,
+        )
+        mock_smtp.sendmail.assert_called_once()
+        call_args = mock_smtp.sendmail.call_args
+        assert call_args[0][0] == "alerts@example.com"
+        assert call_args[0][1] == ["admin@example.com"]
+        body: str = call_args[0][2]
+        assert "prod-policy" in body
+        assert "CRITICAL" in body
+
+    def test_email_with_auth(self) -> None:
+        handler = EmailHandler(
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            from_addr="alerts@example.com",
+            to_addrs=["admin@example.com"],
+            username="user",
+            password="pass",
+            use_tls=True,
+        )
+
+        decision = Decision(
+            allowed=False,
+            denied_by="p",
+            reason="r",
+            severity=Severity.LOW,
+        )
+        action = Action(kind="test", params={})
+
+        with patch("agentguard.policies.handlers.SMTP") as mock_smtp_cls:
+            mock_smtp = MagicMock()
+            mock_smtp_cls.return_value.__enter__ = MagicMock(
+                return_value=mock_smtp,
+            )
+            mock_smtp_cls.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            handler(decision, action)
+
+        mock_smtp.starttls.assert_called_once()
+        mock_smtp.login.assert_called_once_with("user", "pass")
+
+    def test_email_host_required(self) -> None:
+        with pytest.raises(ValueError, match="smtp_host"):
+            EmailHandler(
+                smtp_host="",
+                smtp_port=587,
+                from_addr="a@b.com",
+                to_addrs=["c@d.com"],
+            )
+
+    def test_email_to_addrs_required(self) -> None:
+        with pytest.raises(ValueError, match="to_addrs"):
+            EmailHandler(
+                smtp_host="smtp.example.com",
+                smtp_port=587,
+                from_addr="a@b.com",
+                to_addrs=[],
+            )
+
+
+# --- Integration: Guard + handlers end-to-end ---
+
+
+class TestGuardHandlerIntegration:
+    """End-to-end tests: Guard with registered handlers."""
+
+    def test_guard_with_webhook_handler(self) -> None:
+        guard = Guard(policies=[_deny_policy()])
+        with patch("agentguard.policies.handlers.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = MagicMock()
+            mock_urlopen.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            guard.on_deny(WebhookHandler(url="https://example.com/hook"))
+            decision = guard.check("shell_command", command="rm -rf /")
+
+        assert decision.denied is True
+        mock_urlopen.assert_called_once()
+
+    def test_guard_mixed_handlers(self) -> None:
+        """Multiple handler types registered together."""
+        guard = Guard(policies=[_deny_policy()])
+        mock_handler = MagicMock()
+        guard.on_deny(mock_handler)
+
+        with patch("agentguard.policies.handlers.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = MagicMock()
+            mock_urlopen.return_value.__exit__ = MagicMock(
+                return_value=False,
+            )
+            guard.on_deny(WebhookHandler(url="https://example.com/hook"))
+            decision = guard.check("shell_command", command="rm -rf /")
+
+        assert decision.denied is True
+        mock_handler.assert_called_once()
+        mock_urlopen.assert_called_once()


### PR DESCRIPTION
## Summary

- Add pluggable deny handler callback system to `Guard` via `on_deny(handler)` method
- Handlers are invoked synchronously after a deny decision; exceptions are logged but don't affect policy evaluation
- Three built-in handlers using only Python stdlib (zero external dependencies)
- Completes M11 (Policy Enhancements) milestone

## Design

`DenyHandler` protocol: any `Callable[[Decision, Action], None]` can be registered as a handler.

### Built-in Handlers

| Handler | Transport | Description |
|---------|-----------|-------------|
| `WebhookHandler` | `urllib.request` | JSON POST to any webhook URL with custom headers |
| `SlackHandler` | `urllib.request` | Slack incoming webhook with formatted message |
| `EmailHandler` | `smtplib` | SMTP email with optional TLS and authentication |

### Usage

```python
from agentguard.policies.guard import Guard
from agentguard.policies.handlers import WebhookHandler, SlackHandler

guard = Guard(policies=[...])
guard.on_deny(WebhookHandler(url="https://example.com/hook"))
guard.on_deny(SlackHandler(webhook_url="https://hooks.slack.com/xxx"))
guard.on_deny(lambda decision, action: print(f"Denied: {decision.reason}"))
```

## Files Changed

- **Modified:** `src/agentguard/policies/guard.py` — add `on_deny()` method, `_invoke_deny_handlers()`, `DenyHandler` type alias
- **New:** `src/agentguard/policies/handlers.py` — `WebhookHandler`, `SlackHandler`, `EmailHandler`
- **New:** `tests/unit/test_deny_handlers.py` — 22 tests covering registration, invocation, error handling, and all three handler types

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.