### PR TITLE
feat: add hot-reload policy file watcher

### DIFF
--- a/src/agentguard/policies/watcher.py
+++ b/src/agentguard/policies/watcher.py
@@ -1,0 +1,222 @@
+"""Hot-reload policy file watcher.
+
+Monitors YAML policy files for changes and automatically reloads
+them into a Guard instance. Uses file stat polling (no external
+dependencies).
+
+Usage::
+
+    from agentguard.policies.guard import Guard
+    from agentguard.policies.watcher import PolicyWatcher
+
+    guard = Guard()
+    watcher = PolicyWatcher(guard=guard, paths=["policies/"])
+
+    with watcher:
+        # Watcher polls for changes in background thread.
+        # Guard policies are automatically updated on file changes.
+        decision = guard.check("shell_command", command="rm -rf /")
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+from agentguard.policies.loader import load_policy_from_yaml
+from agentguard.policies.models import Policy
+
+logger = logging.getLogger(__name__)
+
+#: File extensions treated as policy files when scanning directories.
+_POLICY_EXTENSIONS = {".yaml", ".yml"}
+
+#: Type alias for reload callback.
+ReloadCallback = Callable[[list[Policy]], None]
+
+
+class PolicyWatcher:
+    """Watch policy files for changes and hot-reload into a Guard.
+
+    Monitors file modification times at a configurable polling
+    interval. When changes are detected, reloads all policy files
+    and replaces the Guard's policy list atomically.
+
+    Supports watching individual files and/or directories (scans
+    for ``*.yaml`` and ``*.yml`` files).
+
+    Args:
+        guard: The Guard instance whose policies will be updated.
+        paths: List of file or directory paths to watch.
+        poll_interval: Seconds between polls (default 2.0).
+        on_reload: Optional callback invoked after a successful
+            reload with the new list of policies.
+    """
+
+    def __init__(
+        self,
+        guard: object,
+        paths: list[str | Path],
+        poll_interval: float = 2.0,
+        on_reload: ReloadCallback | None = None,
+    ) -> None:
+        # Import here to avoid circular imports at module level
+        from agentguard.policies.guard import Guard
+
+        if not isinstance(guard, Guard):
+            msg = "guard must be a Guard instance"
+            raise TypeError(msg)
+
+        self._guard: Guard = guard
+        self._paths = [Path(p) for p in paths]
+        self._poll_interval = poll_interval
+        self._on_reload = on_reload
+        self._mtimes: dict[Path, float] = {}
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def guard(self) -> object:
+        """The Guard instance being managed."""
+        return self._guard
+
+    @property
+    def paths(self) -> list[Path]:
+        """The watched paths."""
+        return list(self._paths)
+
+    @property
+    def poll_interval(self) -> float:
+        """Polling interval in seconds."""
+        return self._poll_interval
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the watcher thread is running."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def _resolve_files(self) -> list[Path]:
+        """Resolve all watched paths to individual YAML files.
+
+        Directories are scanned for ``*.yaml`` and ``*.yml`` files.
+        Missing paths are silently skipped.
+
+        Returns:
+            Sorted list of existing YAML file paths.
+        """
+        files: list[Path] = []
+        for path in self._paths:
+            if path.is_dir():
+                for child in sorted(path.iterdir()):
+                    if child.is_file() and child.suffix in _POLICY_EXTENSIONS:
+                        files.append(child)
+            elif path.is_file():
+                files.append(path)
+            # Missing paths are silently skipped
+        return files
+
+    def _get_current_mtimes(self) -> dict[Path, float]:
+        """Get modification times for all watched files."""
+        mtimes: dict[Path, float] = {}
+        for f in self._resolve_files():
+            with contextlib.suppress(OSError):
+                mtimes[f] = f.stat().st_mtime
+        return mtimes
+
+    def has_changes(self) -> bool:
+        """Check if any watched files have changed since last reload.
+
+        Returns:
+            True if files have been added, removed, or modified.
+        """
+        current = self._get_current_mtimes()
+        return current != self._mtimes
+
+    def reload(self) -> None:
+        """Reload all policy files into the Guard.
+
+        Replaces all policies in the Guard with freshly loaded ones.
+        On error (e.g. invalid YAML), the previous policies are
+        retained and the error is logged.
+
+        Deny handlers on the Guard are preserved across reloads.
+        """
+        files = self._resolve_files()
+        new_policies: list[Policy] = []
+        for f in files:
+            try:
+                policy = load_policy_from_yaml(f)
+                new_policies.append(policy)
+            except Exception:
+                logger.exception("Failed to load policy from %s", f)
+                # Keep existing policies on error
+                self._mtimes = self._get_current_mtimes()
+                return
+
+        # Atomically replace policies
+        self._guard._policies[:] = new_policies
+        self._mtimes = self._get_current_mtimes()
+
+        if self._on_reload:
+            try:
+                self._on_reload(new_policies)
+            except Exception:
+                logger.exception("on_reload callback raised an exception")
+
+        logger.info(
+            "Reloaded %d policy file(s): %s",
+            len(new_policies),
+            [p.name for p in new_policies],
+        )
+
+    def start(self) -> None:
+        """Start the watcher background thread.
+
+        Performs an initial reload, then polls for changes at the
+        configured interval. Safe to call multiple times (no-op if
+        already running).
+        """
+        if self.is_running:
+            return
+        self._stop_event.clear()
+        self.reload()
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            name="agentguard-policy-watcher",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the watcher background thread.
+
+        Blocks until the thread exits. Safe to call multiple times
+        (no-op if not running).
+        """
+        if not self.is_running:
+            return
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._poll_interval * 3)
+            self._thread = None
+
+    def _poll_loop(self) -> None:
+        """Background polling loop."""
+        while not self._stop_event.is_set():
+            self._stop_event.wait(self._poll_interval)
+            if self._stop_event.is_set():
+                break
+            if self.has_changes():
+                self.reload()
+
+    def __enter__(self) -> PolicyWatcher:
+        """Start the watcher as a context manager."""
+        self.start()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Stop the watcher on context exit."""
+        self.stop()

--- a/tests/unit/test_policy_watcher.py
+++ b/tests/unit/test_policy_watcher.py
@@ -1,0 +1,416 @@
+"""Tests for hot-reload policy file watcher (M12).
+
+Covers:
+- PolicyWatcher creation and configuration
+- File change detection via mtime polling
+- Policy reload on file change
+- Multiple file watching
+- New file detection
+- File deletion handling
+- Callback on reload
+- Thread start/stop lifecycle
+- Context manager usage
+- Error handling on reload (bad YAML)
+- Guard integration after reload
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from agentguard.policies.guard import Guard
+from agentguard.policies.watcher import PolicyWatcher
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_policy(path: Path, name: str, pattern: str = "rm -rf") -> None:
+    """Write a simple deny policy YAML file."""
+    path.write_text(
+        f"""\
+name: {name}
+rules:
+  - action: shell_command
+    severity: critical
+    deny:
+      - pattern: '{pattern}'
+""",
+        encoding="utf-8",
+    )
+
+
+# --- PolicyWatcher creation ---
+
+
+class TestPolicyWatcherCreation:
+    """Tests for PolicyWatcher initialization."""
+
+    def test_create_watcher_with_guard(self, tmp_path: Path) -> None:
+        guard = Guard()
+        watcher = PolicyWatcher(guard=guard, paths=[tmp_path])
+        assert watcher.guard is guard
+        assert watcher.poll_interval == 2.0
+
+    def test_custom_poll_interval(self, tmp_path: Path) -> None:
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[tmp_path],
+            poll_interval=0.5,
+        )
+        assert watcher.poll_interval == 0.5
+
+    def test_create_with_file_paths(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(guard=guard, paths=[policy_file])
+        assert len(watcher.paths) == 1
+
+    def test_create_with_directory_path(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path / "p1.yaml", "p1")
+        _write_policy(tmp_path / "p2.yaml", "p2")
+        guard = Guard()
+        watcher = PolicyWatcher(guard=guard, paths=[tmp_path])
+        assert len(watcher.paths) == 1
+
+
+# --- File change detection ---
+
+
+class TestFileChangeDetection:
+    """Tests for detecting file changes."""
+
+    def test_detects_file_modification(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test", pattern="rm -rf")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+
+        # Initial load
+        watcher.reload()
+        assert len(guard.policies) == 1
+        assert guard.policies[0].name == "test"
+
+        # Modify file
+        time.sleep(0.05)  # Ensure mtime changes
+        _write_policy(policy_file, "test-updated", pattern="DROP TABLE")
+
+        assert watcher.has_changes()
+
+    def test_no_changes_when_unmodified(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+
+        assert not watcher.has_changes()
+
+
+# --- Policy reload ---
+
+
+class TestPolicyReload:
+    """Tests for policy reloading."""
+
+    def test_reload_replaces_policies(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "v1", pattern="rm -rf")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.denied is True
+
+        # Update policy
+        _write_policy(policy_file, "v2", pattern="DROP TABLE")
+        watcher.reload()
+
+        # Old pattern no longer denied
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.allowed is True
+
+        # New pattern denied
+        decision = guard.check("shell_command", command="DROP TABLE users")
+        assert decision.denied is True
+
+    def test_reload_multiple_files(self, tmp_path: Path) -> None:
+        p1 = tmp_path / "p1.yaml"
+        p2 = tmp_path / "p2.yaml"
+        _write_policy(p1, "policy-1", pattern="rm -rf")
+        _write_policy(p2, "policy-2", pattern="DROP TABLE")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[p1, p2],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+
+        assert len(guard.policies) == 2
+        names = {p.name for p in guard.policies}
+        assert names == {"policy-1", "policy-2"}
+
+    def test_reload_from_directory(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path / "a.yaml", "alpha")
+        _write_policy(tmp_path / "b.yaml", "beta")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[tmp_path],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+
+        assert len(guard.policies) == 2
+
+    def test_reload_detects_new_file_in_directory(self, tmp_path: Path) -> None:
+        _write_policy(tmp_path / "existing.yaml", "existing")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[tmp_path],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+        assert len(guard.policies) == 1
+
+        # Add a new file
+        time.sleep(0.05)
+        _write_policy(tmp_path / "new.yaml", "new-policy")
+        watcher.reload()
+        assert len(guard.policies) == 2
+
+    def test_reload_handles_deleted_file(self, tmp_path: Path) -> None:
+        p1 = tmp_path / "p1.yaml"
+        p2 = tmp_path / "p2.yaml"
+        _write_policy(p1, "keep")
+        _write_policy(p2, "remove")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[tmp_path],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+        assert len(guard.policies) == 2
+
+        # Delete one file
+        p2.unlink()
+        watcher.reload()
+        assert len(guard.policies) == 1
+        assert guard.policies[0].name == "keep"
+
+    def test_reload_preserves_deny_handlers(self, tmp_path: Path) -> None:
+        """Deny handlers on Guard survive a policy reload."""
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        handler = MagicMock()
+        guard.on_deny(handler)
+
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+
+        decision = guard.check("shell_command", command="rm -rf /")
+        assert decision.denied is True
+        handler.assert_called_once()
+
+
+# --- Callbacks ---
+
+
+class TestReloadCallback:
+    """Tests for on_reload callback."""
+
+    def test_callback_called_on_reload(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        callback = MagicMock()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+            on_reload=callback,
+        )
+        watcher.reload()
+
+        callback.assert_called_once()
+        call_args = callback.call_args[0]
+        assert isinstance(call_args[0], list)  # list of policies
+        assert len(call_args[0]) == 1
+
+
+# --- Thread lifecycle ---
+
+
+class TestWatcherThread:
+    """Tests for watcher thread start/stop."""
+
+    def test_start_stop(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+
+        watcher.start()
+        assert watcher.is_running
+
+        watcher.stop()
+        assert not watcher.is_running
+
+    def test_context_manager(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+
+        with watcher:
+            assert watcher.is_running
+        assert not watcher.is_running
+
+    def test_auto_reload_on_change(self, tmp_path: Path) -> None:
+        """Watcher thread detects changes and reloads automatically."""
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "v1", pattern="rm -rf")
+        guard = Guard()
+        callback = MagicMock()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+            on_reload=callback,
+        )
+
+        with watcher:
+            # Wait for initial load
+            time.sleep(0.3)
+            assert len(guard.policies) == 1
+
+            # Modify file
+            _write_policy(policy_file, "v2", pattern="DROP TABLE")
+
+            # Wait for the watcher to detect and reload
+            time.sleep(0.5)
+
+        # After stop, check that reload happened
+        # The callback should have been called at least twice
+        # (initial + at least one change detection)
+        assert callback.call_count >= 2
+
+    def test_double_start_is_safe(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+
+        watcher.start()
+        watcher.start()  # Should not raise
+        assert watcher.is_running
+        watcher.stop()
+
+    def test_double_stop_is_safe(self, tmp_path: Path) -> None:
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+
+        watcher.start()
+        watcher.stop()
+        watcher.stop()  # Should not raise
+        assert not watcher.is_running
+
+
+# --- Error handling ---
+
+
+class TestErrorHandling:
+    """Tests for error handling during reload."""
+
+    def test_bad_yaml_does_not_crash(self, tmp_path: Path) -> None:
+        """Invalid YAML should log error but not crash watcher."""
+        policy_file = tmp_path / "policy.yaml"
+        _write_policy(policy_file, "test")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[policy_file],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+        assert len(guard.policies) == 1
+
+        # Write invalid YAML
+        policy_file.write_text("invalid: yaml: content: [", encoding="utf-8")
+
+        # Reload should not raise; policies should remain unchanged
+        watcher.reload()
+        assert len(guard.policies) == 1  # Previous policies kept
+
+    def test_missing_file_skipped(self, tmp_path: Path) -> None:
+        """A file path that doesn't exist is silently skipped."""
+        existing = tmp_path / "exists.yaml"
+        missing = tmp_path / "missing.yaml"
+        _write_policy(existing, "exists")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[existing, missing],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+        assert len(guard.policies) == 1
+        assert guard.policies[0].name == "exists"
+
+    def test_non_yaml_files_in_directory_ignored(self, tmp_path: Path) -> None:
+        """Only .yaml and .yml files should be loaded from directories."""
+        _write_policy(tmp_path / "good.yaml", "good")
+        (tmp_path / "readme.txt").write_text("not a policy", encoding="utf-8")
+        (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+        guard = Guard()
+        watcher = PolicyWatcher(
+            guard=guard,
+            paths=[tmp_path],
+            poll_interval=0.1,
+        )
+        watcher.reload()
+        assert len(guard.policies) == 1
+        assert guard.policies[0].name == "good"


### PR DESCRIPTION
## Summary

- Add `PolicyWatcher` class for monitoring YAML policy files and automatically reloading into a `Guard` on changes
- Thread-based file mtime polling with configurable interval (default 2s)
- First two tasks of M12 (NemoClaw Adaptations) milestone

## Design

`PolicyWatcher` monitors files and directories for policy changes using stdlib-only mtime polling:

```python
from agentguard.policies.guard import Guard
from agentguard.policies.watcher import PolicyWatcher

guard = Guard()

with PolicyWatcher(guard=guard, paths=["policies/"]):
    # Watcher polls for changes in background thread
    # Guard policies are automatically updated on file changes
    decision = guard.check("shell_command", command="rm -rf /")
```

### Features

| Feature | Description |
|---------|-------------|
| File watching | Individual files or directories (*.yaml, *.yml) |
| Change detection | mtime-based polling for adds, modifies, deletes |
| Atomic reload | Replaces all policies while preserving deny handlers |
| Error resilience | Bad YAML keeps previous policies, logs error |
| Callback | Optional `on_reload` callback with new policy list |
| Lifecycle | `start()`/`stop()`, context manager, idempotent |
| Zero deps | Uses only pathlib, threading from stdlib |

## Files Changed

- **New:** `src/agentguard/policies/watcher.py` — `PolicyWatcher` class
- **New:** `tests/unit/test_policy_watcher.py` — 21 tests covering creation, change detection, reload, callbacks, threading, and error handling

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.