### PR TITLE
feat: add domain allowlist policy type with presets

### DIFF
--- a/src/agentguard/policies/domain_allowlist.py
+++ b/src/agentguard/policies/domain_allowlist.py
@@ -1,0 +1,263 @@
+"""Domain allowlist policy type.
+
+Provides a policy that allows actions only when the target domain
+is in an allowlist. Supports exact domains, wildcard subdomains
+(``*.example.com``), and built-in presets for popular services.
+
+Usage::
+
+    from agentguard.policies.domain_allowlist import DomainAllowlist
+    from agentguard.policies.guard import Guard
+
+    policy = DomainAllowlist(
+        name="web-access",
+        domains=["api.github.com"],
+        presets=["google"],
+        action_kind="web_request",
+    )
+    guard = Guard(policies=[policy])
+    decision = guard.check("web_request", url="https://api.github.com/repos")
+
+YAML format::
+
+    name: web-access
+    type: domain_allowlist
+    action: web_request
+    domains:
+      - api.github.com
+      - "*.internal.corp"
+    presets:
+      - github
+      - google
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+from agentguard.policies.models import Action, Context, Decision, Policy, Severity
+
+logger = logging.getLogger(__name__)
+
+#: Built-in domain presets for popular services.
+PRESETS: dict[str, list[str]] = {
+    "github": [
+        "github.com",
+        "*.github.com",
+        "api.github.com",
+        "raw.githubusercontent.com",
+        "*.githubusercontent.com",
+    ],
+    "google": [
+        "google.com",
+        "*.google.com",
+        "googleapis.com",
+        "*.googleapis.com",
+    ],
+    "openai": [
+        "api.openai.com",
+        "openai.com",
+    ],
+    "anthropic": [
+        "api.anthropic.com",
+        "anthropic.com",
+    ],
+    "pypi": [
+        "pypi.org",
+        "files.pythonhosted.org",
+        "*.pythonhosted.org",
+    ],
+    "npm": [
+        "registry.npmjs.org",
+        "npmjs.com",
+        "*.npmjs.com",
+    ],
+    "docker": [
+        "docker.io",
+        "*.docker.io",
+        "registry-1.docker.io",
+        "hub.docker.com",
+    ],
+}
+
+
+class DomainAllowlist(Policy):
+    """Policy that allows actions only for whitelisted domains.
+
+    Checks ``url`` and ``domain`` parameters in actions against an
+    allowlist of domains. Supports exact match and wildcard
+    subdomains (``*.example.com``).
+
+    Args:
+        name: Policy name.
+        domains: List of allowed domain patterns.
+        presets: List of preset names to include.
+        action_kind: The action kind this policy applies to
+            (default: ``web_request``).
+        description: Optional description.
+
+    Raises:
+        ValueError: If neither domains nor presets are provided,
+            or if an unknown preset is referenced.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        domains: list[str] | None = None,
+        presets: list[str] | None = None,
+        action_kind: str = "web_request",
+        description: str | None = None,
+    ) -> None:
+        if not domains and not presets:
+            msg = "At least one of domains or presets must be provided"
+            raise ValueError(msg)
+
+        # Validate presets
+        if presets:
+            for preset in presets:
+                if preset not in PRESETS:
+                    msg = f"Unknown preset: {preset!r}"
+                    raise ValueError(msg)
+
+        # Build the full domain set
+        all_domains: list[str] = []
+        if domains:
+            all_domains.extend(domains)
+        if presets:
+            for preset in presets:
+                all_domains.extend(PRESETS[preset])
+
+        # Normalize: lowercase, deduplicate
+        self._exact_domains: set[str] = set()
+        self._wildcard_suffixes: set[str] = set()
+        for d in all_domains:
+            d_lower = d.lower()
+            if d_lower.startswith("*."):
+                # *.example.com -> match any .example.com suffix
+                self._wildcard_suffixes.add(d_lower[1:])
+            else:
+                self._exact_domains.add(d_lower)
+
+        self._action_kind = action_kind
+
+        # Initialize the parent Policy with no rules
+        # (we override evaluate() entirely)
+        super().__init__(
+            name=name,
+            rules=[],
+            description=description,
+        )
+
+    def evaluate(
+        self,
+        action: Action,
+        context: Context | None = None,
+    ) -> Decision:
+        """Evaluate an action against the domain allowlist.
+
+        Checks ``url`` and ``domain`` params. If the action kind
+        doesn't match, the action is allowed (pass-through).
+
+        Args:
+            action: The action to check.
+            context: Unused (present for API compatibility).
+
+        Returns:
+            Allow if domain is in allowlist, deny otherwise.
+        """
+        if action.kind != self._action_kind:
+            return Decision(allowed=True)
+
+        # Try to extract domain from params
+        domain = self._extract_domain(action)
+        if domain is None:
+            # No domain info found — deny by default
+            return Decision(
+                allowed=False,
+                denied_by=self.name,
+                reason=(f"No domain found in action params (policy: {self.name})"),
+                severity=Severity.HIGH,
+            )
+
+        return self.evaluate_domain(domain)
+
+    def evaluate_domain(self, domain: str) -> Decision:
+        """Check a domain string against the allowlist.
+
+        Args:
+            domain: The domain to check.
+
+        Returns:
+            Allow if domain is in allowlist, deny otherwise.
+        """
+        domain_lower = domain.lower()
+
+        # Exact match
+        if domain_lower in self._exact_domains:
+            return Decision(allowed=True)
+
+        # Wildcard match: check if domain ends with any wildcard suffix
+        for suffix in self._wildcard_suffixes:
+            if domain_lower.endswith(suffix):
+                return Decision(allowed=True)
+
+        return Decision(
+            allowed=False,
+            denied_by=self.name,
+            reason=(f"Domain {domain!r} not in allowlist (policy: {self.name})"),
+            severity=Severity.HIGH,
+        )
+
+    def evaluate_url(self, url: str) -> Decision:
+        """Check a URL against the domain allowlist.
+
+        Parses the URL to extract the hostname and checks it.
+
+        Args:
+            url: The URL to check.
+
+        Returns:
+            Allow if the URL's domain is in allowlist, deny otherwise.
+        """
+        domain = self._parse_domain_from_url(url)
+        if domain is None:
+            return Decision(
+                allowed=False,
+                denied_by=self.name,
+                reason=(
+                    f"Could not parse domain from URL {url!r} (policy: {self.name})"
+                ),
+                severity=Severity.HIGH,
+            )
+        return self.evaluate_domain(domain)
+
+    def _extract_domain(self, action: Action) -> str | None:
+        """Extract domain from action params.
+
+        Checks ``domain`` param first, then tries to parse ``url``.
+        """
+        # Direct domain param
+        domain = action.params.get("domain")
+        if isinstance(domain, str) and domain:
+            return domain
+
+        # URL param
+        url = action.params.get("url")
+        if isinstance(url, str) and url:
+            return self._parse_domain_from_url(url)
+
+        return None
+
+    @staticmethod
+    def _parse_domain_from_url(url: str) -> str | None:
+        """Parse hostname from a URL string."""
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname
+            if hostname:
+                return hostname
+        except Exception:
+            pass
+        return None

--- a/src/agentguard/policies/loader.py
+++ b/src/agentguard/policies/loader.py
@@ -69,10 +69,19 @@ def load_policy_from_yaml(path: str | Path) -> Policy:
 
 
 def _parse_policy(data: dict[str, Any]) -> Policy:
-    """Parse and validate a policy dict."""
+    """Parse and validate a policy dict.
+
+    If the policy has a ``type`` field, dispatches to the
+    appropriate specialized parser. Otherwise parses as a
+    standard deny-rule policy.
+    """
     if "name" not in data:
         msg = "Policy must have a 'name' field"
         raise ValueError(msg)
+
+    policy_type = data.get("type")
+    if policy_type == "domain_allowlist":
+        return _parse_domain_allowlist(data)
 
     if "rules" not in data or not data["rules"]:
         msg = "Policy must have a non-empty 'rules' field"
@@ -87,6 +96,34 @@ def _parse_policy(data: dict[str, Any]) -> Policy:
         rules=rules,
         version=version,
         changelog=changelog,
+    )
+
+
+def _parse_domain_allowlist(data: dict[str, Any]) -> Policy:
+    """Parse a domain_allowlist policy from a YAML dict.
+
+    Expected fields:
+    - name (required)
+    - action (optional, default "web_request")
+    - domains (optional, list of domain strings)
+    - presets (optional, list of preset names)
+    - description (optional)
+
+    At least one of domains or presets must be provided.
+    """
+    from agentguard.policies.domain_allowlist import DomainAllowlist
+
+    domains = data.get("domains")
+    presets = data.get("presets")
+    action_kind = data.get("action", "web_request")
+    description = data.get("description")
+
+    return DomainAllowlist(
+        name=data["name"],
+        domains=domains,
+        presets=presets,
+        action_kind=action_kind,
+        description=description,
     )
 
 

--- a/tests/unit/test_domain_allowlist.py
+++ b/tests/unit/test_domain_allowlist.py
@@ -1,0 +1,330 @@
+"""Tests for domain allowlist policy type (M12).
+
+Covers:
+- DomainAllowlist creation and configuration
+- Exact domain matching
+- Wildcard subdomain matching (*.example.com)
+- Preset loading (github, google, etc.)
+- URL parsing to extract domain
+- Deny for unlisted domains
+- Allow for listed domains
+- Multiple domains
+- Guard integration
+- YAML loading of domain allowlist policies
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentguard.policies.domain_allowlist import (
+    PRESETS,
+    DomainAllowlist,
+)
+from agentguard.policies.guard import Guard
+from agentguard.policies.loader import load_policy_from_string
+
+# --- DomainAllowlist creation ---
+
+
+class TestDomainAllowlistCreation:
+    """Tests for DomainAllowlist initialization."""
+
+    def test_create_with_domains(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com", "api.example.com"],
+        )
+        assert al.name == "test"
+
+    def test_create_with_wildcard(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["*.example.com"],
+        )
+        assert al.name == "test"
+
+    def test_create_with_preset(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            presets=["github"],
+        )
+        assert al.name == "test"
+
+    def test_empty_domains_and_presets_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"domains.*presets"):
+            DomainAllowlist(name="test")
+
+    def test_unknown_preset_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown_preset"):
+            DomainAllowlist(name="test", presets=["unknown_preset"])
+
+
+# --- Domain matching ---
+
+
+class TestDomainMatching:
+    """Tests for domain allowlist matching."""
+
+    def test_exact_domain_allowed(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_domain("example.com")
+        assert decision.allowed is True
+
+    def test_unlisted_domain_denied(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_domain("evil.com")
+        assert decision.denied is True
+        assert decision.denied_by == "test"
+
+    def test_wildcard_matches_subdomain(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["*.example.com"],
+        )
+        decision = al.evaluate_domain("api.example.com")
+        assert decision.allowed is True
+
+    def test_wildcard_matches_nested_subdomain(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["*.example.com"],
+        )
+        decision = al.evaluate_domain("v2.api.example.com")
+        assert decision.allowed is True
+
+    def test_wildcard_does_not_match_root(self) -> None:
+        """*.example.com should NOT match example.com itself."""
+        al = DomainAllowlist(
+            name="test",
+            domains=["*.example.com"],
+        )
+        decision = al.evaluate_domain("example.com")
+        assert decision.denied is True
+
+    def test_both_root_and_wildcard(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com", "*.example.com"],
+        )
+        assert al.evaluate_domain("example.com").allowed is True
+        assert al.evaluate_domain("api.example.com").allowed is True
+
+    def test_case_insensitive(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["Example.COM"],
+        )
+        assert al.evaluate_domain("example.com").allowed is True
+        assert al.evaluate_domain("EXAMPLE.COM").allowed is True
+
+    def test_multiple_domains(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["github.com", "api.github.com", "pypi.org"],
+        )
+        assert al.evaluate_domain("github.com").allowed is True
+        assert al.evaluate_domain("api.github.com").allowed is True
+        assert al.evaluate_domain("pypi.org").allowed is True
+        assert al.evaluate_domain("evil.com").denied is True
+
+
+# --- URL parsing ---
+
+
+class TestURLParsing:
+    """Tests for extracting domains from URLs."""
+
+    def test_extract_domain_from_https_url(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_url("https://example.com/path")
+        assert decision.allowed is True
+
+    def test_extract_domain_from_http_url(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_url("http://example.com/page")
+        assert decision.allowed is True
+
+    def test_url_with_port(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_url("https://example.com:8080/api")
+        assert decision.allowed is True
+
+    def test_url_with_auth(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_url("https://user:pass@example.com/path")
+        assert decision.allowed is True
+
+    def test_invalid_url_denied(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["example.com"],
+        )
+        decision = al.evaluate_url("not-a-url")
+        assert decision.denied is True
+
+
+# --- Presets ---
+
+
+class TestPresets:
+    """Tests for built-in domain presets."""
+
+    def test_github_preset_exists(self) -> None:
+        assert "github" in PRESETS
+
+    def test_google_preset_exists(self) -> None:
+        assert "google" in PRESETS
+
+    def test_preset_domains_are_lists(self) -> None:
+        for name, domains in PRESETS.items():
+            assert isinstance(domains, list), f"Preset '{name}' is not a list"
+            assert len(domains) > 0, f"Preset '{name}' is empty"
+
+    def test_github_preset_includes_expected_domains(self) -> None:
+        al = DomainAllowlist(name="test", presets=["github"])
+        assert al.evaluate_domain("github.com").allowed is True
+        assert al.evaluate_domain("api.github.com").allowed is True
+
+    def test_combined_presets_and_domains(self) -> None:
+        al = DomainAllowlist(
+            name="test",
+            domains=["custom.internal.com"],
+            presets=["github"],
+        )
+        assert al.evaluate_domain("github.com").allowed is True
+        assert al.evaluate_domain("custom.internal.com").allowed is True
+        assert al.evaluate_domain("evil.com").denied is True
+
+
+# --- Guard integration via evaluate() ---
+
+
+class TestGuardIntegration:
+    """Tests for DomainAllowlist as a Policy in Guard."""
+
+    def test_domain_policy_in_guard(self) -> None:
+        al = DomainAllowlist(
+            name="domain-guard",
+            domains=["safe.com"],
+            action_kind="web_request",
+        )
+        guard = Guard(policies=[al])
+
+        # Allowed domain
+        decision = guard.check("web_request", url="https://safe.com/api")
+        assert decision.allowed is True
+
+        # Denied domain
+        decision = guard.check("web_request", url="https://evil.com/steal")
+        assert decision.denied is True
+        assert decision.denied_by == "domain-guard"
+
+    def test_non_matching_action_kind_passes(self) -> None:
+        """DomainAllowlist only applies to its configured action kind."""
+        al = DomainAllowlist(
+            name="domain-guard",
+            domains=["safe.com"],
+            action_kind="web_request",
+        )
+        guard = Guard(policies=[al])
+
+        # Different action kind should pass
+        decision = guard.check("shell_command", command="echo hello")
+        assert decision.allowed is True
+
+    def test_action_with_domain_param(self) -> None:
+        """Support checking 'domain' param directly."""
+        al = DomainAllowlist(
+            name="domain-guard",
+            domains=["api.example.com"],
+            action_kind="api_call",
+        )
+        guard = Guard(policies=[al])
+
+        decision = guard.check("api_call", domain="api.example.com")
+        assert decision.allowed is True
+
+        decision = guard.check("api_call", domain="evil.com")
+        assert decision.denied is True
+
+
+# --- YAML loading ---
+
+
+class TestYAMLLoading:
+    """Tests for loading domain allowlist from YAML."""
+
+    def test_load_domain_allowlist_from_yaml(self) -> None:
+        yaml_str = """
+name: web-access
+type: domain_allowlist
+action: web_request
+domains:
+  - example.com
+  - "*.example.com"
+  - api.github.com
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert isinstance(policy, DomainAllowlist)
+        assert policy.name == "web-access"
+
+    def test_load_with_presets(self) -> None:
+        yaml_str = """
+name: with-presets
+type: domain_allowlist
+action: web_request
+presets:
+  - github
+  - google
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert isinstance(policy, DomainAllowlist)
+
+    def test_load_with_domains_and_presets(self) -> None:
+        yaml_str = """
+name: combined
+type: domain_allowlist
+action: web_request
+domains:
+  - custom.internal.com
+presets:
+  - github
+"""
+        policy = load_policy_from_string(yaml_str)
+        assert isinstance(policy, DomainAllowlist)
+
+    def test_yaml_domain_allowlist_in_guard(self) -> None:
+        yaml_str = """
+name: web-guard
+type: domain_allowlist
+action: web_request
+domains:
+  - safe.example.com
+"""
+        guard = Guard()
+        guard.load_policy_string(yaml_str)
+
+        decision = guard.check("web_request", url="https://safe.example.com/api")
+        assert decision.allowed is True
+
+        decision = guard.check("web_request", url="https://evil.com/steal")
+        assert decision.denied is True


### PR DESCRIPTION
## Summary

- Add `DomainAllowlist` policy type that restricts actions to whitelisted domains
- Support exact match, wildcard subdomains (`*.example.com`), and built-in presets for popular services
- YAML loader extended to support `type: domain_allowlist` policies

## Design

`DomainAllowlist` extends `Policy` and integrates directly with `Guard.check()`:

```yaml
name: web-access
type: domain_allowlist
action: web_request
domains:
  - api.internal.corp
  - "*.internal.corp"
presets:
  - github
  - google
```

```python
guard = Guard()
guard.load_policy_string(yaml_str)
decision = guard.check("web_request", url="https://api.github.com/repos")
```

### Features

| Feature | Description |
|---------|-------------|
| Exact match | `example.com` matches only `example.com` |
| Wildcard | `*.example.com` matches any subdomain |
| Presets | github, google, openai, anthropic, pypi, npm, docker |
| URL parsing | Extracts hostname from `url` param via `urlparse` |
| Domain param | Also checks `domain` param directly |
| Case insensitive | All matching is case-insensitive |
| Default deny | Unknown domains are denied |

### Presets

Presets reduce boilerplate for common integrations. Each preset defines a list of domains and wildcard patterns for a service.

## Files Changed

- **New:** `src/agentguard/policies/domain_allowlist.py` — `DomainAllowlist` class and `PRESETS` dict
- **Modified:** `src/agentguard/policies/loader.py` — dispatch on `type: domain_allowlist` in YAML parser
- **New:** `tests/unit/test_domain_allowlist.py` — 30 tests covering creation, matching, URLs, presets, Guard integration, and YAML loading

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.