### PR TITLE
feat: add persona safety section to EU AI Act compliance report

### DIFF
--- a/src/agentguard/compliance/eu_ai_act.py
+++ b/src/agentguard/compliance/eu_ai_act.py
@@ -63,6 +63,7 @@ class EUAIActReportGenerator:
             self._assess_art12(audit_log),
             self._assess_art13(audit_log),
             self._assess_art14(audit_log),
+            self._assess_persona_safety(audit_log),
         ]
 
         return ComplianceReport(
@@ -336,6 +337,145 @@ class EUAIActReportGenerator:
         return ReportSection(
             article="Art. 14",
             title="Human Oversight",
+            status=status,
+            findings=findings,
+        )
+
+    def _assess_persona_safety(
+        self,
+        audit_log: AuditLog,
+    ) -> ReportSection:
+        """Assess persona safety and behavioral drift.
+
+        Evaluates whether the AI agent's behavior stays within
+        expected boundaries, using heuristic risk scoring to
+        detect behavioral drift patterns that may indicate the
+        agent is operating outside its intended persona or role.
+
+        Maps to EU AI Act Art. 5 (prohibited practices) and Art. 9
+        (risk management) — ensuring the AI system does not exhibit
+        manipulative, deceptive, or uncontrolled behavior.
+
+        Args:
+            audit_log: The audit log to analyze.
+
+        Returns:
+            A ReportSection with persona safety findings.
+        """
+        from agentguard.audit.risk import (
+            ConversationRiskScorer,
+            RiskLevel,
+        )
+
+        entries = audit_log.entries
+
+        if not entries:
+            return ReportSection(
+                article="Art. 5/9",
+                title="Persona Safety",
+                status=SectionStatus.NOT_ASSESSED,
+                findings=[
+                    Finding(
+                        severity=FindingSeverity.INFO,
+                        article="Art. 5/9",
+                        description=(
+                            "No audit entries available for persona safety assessment."
+                        ),
+                    ),
+                ],
+            )
+
+        scorer = ConversationRiskScorer()
+        risk_score = scorer.score(entries)
+
+        findings: list[Finding] = []
+
+        # Always report the drift probability
+        findings.append(
+            Finding(
+                severity=FindingSeverity.INFO,
+                article="Art. 5/9",
+                description=(
+                    f"Behavioral drift probability: "
+                    f"{risk_score.probability:.2f} "
+                    f"(risk level: {risk_score.level.value})"
+                ),
+                evidence=(
+                    f"Analyzed {len(entries)} audit entries. "
+                    f"Detected {len(risk_score.signals)} risk signal(s)."
+                ),
+            ),
+        )
+
+        # Report individual signals
+        for signal in risk_score.signals:
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.INFO,
+                    article="Art. 5/9",
+                    description=(f"Risk signal: {signal.signal_type.value}"),
+                    evidence=signal.description,
+                ),
+            )
+
+        # Determine status and add severity-appropriate findings
+        if risk_score.level == RiskLevel.CRITICAL:
+            status = SectionStatus.FAIL
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.VIOLATION,
+                    article="Art. 5/9",
+                    description=(
+                        "Critical behavioral drift detected. "
+                        "Agent may be operating outside intended "
+                        "persona boundaries."
+                    ),
+                    evidence=(
+                        f"Drift probability {risk_score.probability:.2f} "
+                        f"exceeds critical threshold (0.75)."
+                    ),
+                ),
+            )
+        elif risk_score.level == RiskLevel.HIGH:
+            status = SectionStatus.FAIL
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.VIOLATION,
+                    article="Art. 5/9",
+                    description=(
+                        "High behavioral drift detected. "
+                        "Agent actions show significant deviation "
+                        "from expected patterns."
+                    ),
+                    evidence=(
+                        f"Drift probability {risk_score.probability:.2f} "
+                        f"exceeds high threshold (0.50)."
+                    ),
+                ),
+            )
+        elif risk_score.level == RiskLevel.MEDIUM:
+            status = SectionStatus.WARN
+            findings.append(
+                Finding(
+                    severity=FindingSeverity.WARNING,
+                    article="Art. 5/9",
+                    description=(
+                        "Moderate behavioral drift detected. "
+                        "Some agent actions deviate from expected "
+                        "patterns."
+                    ),
+                    evidence=(
+                        f"Drift probability {risk_score.probability:.2f} "
+                        f"exceeds medium threshold (0.25)."
+                    ),
+                ),
+            )
+        else:
+            status = SectionStatus.PASS
+
+        return ReportSection(
+            article="Art. 5/9",
+            title="Persona Safety",
             status=status,
             findings=findings,
         )

--- a/tests/unit/test_eu_ai_act.py
+++ b/tests/unit/test_eu_ai_act.py
@@ -53,12 +53,13 @@ class TestEUAIActReportGenerator:
         log = _make_log([{"action": "file_read", "result": "allowed"}])
         generator = EUAIActReportGenerator()
         report = generator.generate(log)
-        assert len(report.sections) == 4
+        assert len(report.sections) == 5
         articles = [s.article for s in report.sections]
         assert "Art. 9" in articles
         assert "Art. 12" in articles
         assert "Art. 13" in articles
         assert "Art. 14" in articles
+        assert "Art. 5/9" in articles
 
     def test_report_generated_at_is_set(self) -> None:
         log = _make_log([{"action": "file_read", "result": "allowed"}])
@@ -344,8 +345,8 @@ class TestEdgeCases:
         )
         generator = EUAIActReportGenerator()
         report = generator.generate(log)
-        # Should produce a valid report with all 4 sections
-        assert len(report.sections) == 4
+        # Should produce a valid report with all 5 sections
+        assert len(report.sections) == 5
         # Should have both info and warning findings
         all_findings = [f for s in report.sections for f in s.findings]
         severities = {f.severity for f in all_findings}

--- a/tests/unit/test_persona_compliance.py
+++ b/tests/unit/test_persona_compliance.py
@@ -1,0 +1,170 @@
+"""Tests for persona safety section in EU AI Act compliance report (M14).
+
+Covers:
+- Persona safety section appears in report when enabled
+- Low/medium/high/critical risk score produce appropriate findings
+- Empty audit log produces NOT_ASSESSED
+- Integration with ConversationRiskScorer
+- Metadata-enriched entries are analyzed
+- Findings use correct severity levels
+- Report backward compatibility (existing 4 sections unchanged)
+"""
+
+from __future__ import annotations
+
+from agentguard.audit.log import AuditLog
+from agentguard.compliance.eu_ai_act import EUAIActReportGenerator
+from agentguard.compliance.models import (
+    FindingSeverity,
+    SectionStatus,
+)
+
+
+def _make_log(
+    entries: list[dict[str, str | dict[str, str] | None]],
+    session_id: str = "test-session",
+) -> AuditLog:
+    """Helper to create an AuditLog with preset entries."""
+    log = AuditLog(session_id=session_id)
+    for entry_data in entries:
+        log.record(
+            action=str(entry_data.get("action", "test")),
+            actor=str(entry_data.get("actor", "agent")),
+            target=str(entry_data.get("target", "target")),
+            result=str(entry_data.get("result", "allowed")),
+            metadata=entry_data.get("metadata"),  # type: ignore[arg-type]
+        )
+    return log
+
+
+class TestPersonaSafetySection:
+    """Tests for the persona safety compliance section."""
+
+    def test_section_present_in_report(self) -> None:
+        log = _make_log([{"result": "allowed"}])
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        articles = [s.article for s in report.sections]
+        assert "Art. 5/9" in articles
+
+    def test_report_has_five_sections(self) -> None:
+        log = _make_log([{"result": "allowed"}])
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        assert len(report.sections) == 5
+
+    def test_empty_log_not_assessed(self) -> None:
+        log = _make_log([])
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        assert section.status == SectionStatus.NOT_ASSESSED
+
+    def test_all_allowed_low_risk_passes(self) -> None:
+        log = _make_log([{"result": "allowed"} for _ in range(10)])
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        assert section.status == SectionStatus.PASS
+        info_findings = [
+            f for f in section.findings if f.severity == FindingSeverity.INFO
+        ]
+        assert len(info_findings) >= 1
+
+    def test_high_deny_rate_produces_warning(self) -> None:
+        entries: list[dict[str, str | dict[str, str] | None]] = [
+            {"result": "denied"} for _ in range(8)
+        ] + [{"result": "allowed"} for _ in range(2)]
+        log = _make_log(entries)
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        assert section.status in (SectionStatus.WARN, SectionStatus.FAIL)
+
+    def test_critical_risk_produces_violation(self) -> None:
+        """Repeated denials on sensitive targets with escalation."""
+        entries: list[dict[str, str | dict[str, str] | None]] = [
+            {
+                "action": "file_write",
+                "target": "/etc/passwd",
+                "result": "denied",
+                "metadata": {"severity": "low"},
+            },
+            {
+                "action": "file_write",
+                "target": "/etc/passwd",
+                "result": "denied",
+                "metadata": {"severity": "medium"},
+            },
+            {
+                "action": "file_write",
+                "target": "/etc/shadow",
+                "result": "denied",
+                "metadata": {"severity": "high"},
+            },
+            {
+                "action": "file_write",
+                "target": "/etc/shadow",
+                "result": "denied",
+                "metadata": {"severity": "critical"},
+            },
+            {
+                "action": "file_read",
+                "target": "/.ssh/id_rsa",
+                "result": "denied",
+                "metadata": {"severity": "critical"},
+            },
+        ]
+        log = _make_log(entries)
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        assert section.status == SectionStatus.FAIL
+        violations = [
+            f for f in section.findings if f.severity == FindingSeverity.VIOLATION
+        ]
+        assert len(violations) >= 1
+
+    def test_finding_includes_drift_probability(self) -> None:
+        entries: list[dict[str, str | dict[str, str] | None]] = [
+            {"result": "denied"} for _ in range(8)
+        ] + [{"result": "allowed"} for _ in range(2)]
+        log = _make_log(entries)
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        # At least one finding should mention drift probability
+        all_text = " ".join(
+            (f.description or "") + " " + (f.evidence or "") for f in section.findings
+        )
+        assert "drift" in all_text.lower() or "risk" in all_text.lower()
+
+    def test_section_title(self) -> None:
+        log = _make_log([{"result": "allowed"}])
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        assert "persona" in section.title.lower() or "safety" in section.title.lower()
+
+    def test_mixed_results_produces_findings(self) -> None:
+        entries: list[dict[str, str | dict[str, str] | None]] = (
+            [{"result": "allowed"} for _ in range(5)]
+            + [{"result": "denied"} for _ in range(3)]
+            + [{"result": "error"} for _ in range(2)]
+        )
+        log = _make_log(entries)
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        section = next(s for s in report.sections if s.article == "Art. 5/9")
+        assert len(section.findings) >= 1
+
+    def test_backward_compatibility_existing_sections(self) -> None:
+        """Existing 4 sections should still be present and unchanged."""
+        log = _make_log([{"result": "allowed"}])
+        gen = EUAIActReportGenerator()
+        report = gen.generate(log)
+        articles = [s.article for s in report.sections]
+        assert "Art. 9" in articles
+        assert "Art. 12" in articles
+        assert "Art. 13" in articles
+        assert "Art. 14" in articles


### PR DESCRIPTION
## Summary

- Add Art. 5/9 Persona Safety section to `EUAIActReportGenerator` integrating `ConversationRiskScorer`
- Maps behavioral drift risk levels to compliance findings (VIOLATION/WARNING/INFO)
- Backward-compatible: existing 4 sections unchanged, new section appended

## Design

The persona safety section leverages the conversation risk scoring engine (from PR #329) to assess behavioral drift within the EU AI Act compliance framework:

```python
generator = EUAIActReportGenerator()
report = generator.generate(audit_log)

# New Art. 5/9 section alongside existing Art. 9/12/13/14
persona_section = next(s for s in report.sections if s.article == "Art. 5/9")
# persona_section.status -> PASS | WARN | FAIL | NOT_ASSESSED
# persona_section.findings -> [Finding(drift probability, signals, ...)]
```

### Risk Level to Compliance Mapping

| Risk Level | Drift Probability | Section Status | Finding Severity |
|-----------|------------------|---------------|-----------------|
| LOW | [0.0, 0.25) | PASS | INFO |
| MEDIUM | [0.25, 0.50) | WARN | WARNING |
| HIGH | [0.50, 0.75) | FAIL | VIOLATION |
| CRITICAL | [0.75, 1.0] | FAIL | VIOLATION |

Each finding includes the drift probability and evidence from individual risk signals.

## Files Changed

- **Modified:** `src/agentguard/compliance/eu_ai_act.py` — Added `_assess_persona_safety()` method and wired it into `generate()`
- **New:** `tests/unit/test_persona_compliance.py` — 10 tests for the new section
- **Modified:** `tests/unit/test_eu_ai_act.py` — Updated 2 existing tests for new section count (4 → 5)

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.