### PR TITLE
feat: add Anthropic Messages API format adapter

### DIFF
--- a/src/agentguard/proxy/providers/__init__.py
+++ b/src/agentguard/proxy/providers/__init__.py
@@ -81,9 +81,11 @@ class Provider(Protocol):
 
 def _build_registry() -> dict[str, Provider]:
     """Build the provider registry lazily."""
+    from agentguard.proxy.providers.anthropic import AnthropicProvider
     from agentguard.proxy.providers.openai import OpenAIProvider
 
     return {
+        "anthropic": AnthropicProvider(),
         "openai": OpenAIProvider(),
     }
 

--- a/src/agentguard/proxy/providers/anthropic.py
+++ b/src/agentguard/proxy/providers/anthropic.py
@@ -1,0 +1,238 @@
+"""Anthropic Messages API format adapter.
+
+Handles parsing and extraction for the Anthropic ``/v1/messages``
+format, supporting the Claude family of models.  The Anthropic format
+differs from OpenAI in several key ways:
+
+- System prompt is a top-level ``system`` field (not a message).
+- Content can be structured blocks (``text``, ``tool_use``, etc.).
+- Responses use a top-level ``content`` array (no ``choices``).
+- Streaming uses typed events (``content_block_delta``) instead of
+  ``choices[].delta``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class AnthropicProvider:
+    """Provider adapter for Anthropic's Messages API.
+
+    Parses request bodies (top-level system + messages array),
+    response bodies (top-level content array), and streaming SSE
+    deltas (content_block_delta events).
+    """
+
+    @property
+    def name(self) -> str:
+        """Provider identifier."""
+        return "anthropic"
+
+    def extract_request_params(
+        self, body: bytes, *, seen_count: int | None = None
+    ) -> dict[str, str]:
+        """Extract scannable parameters from an Anthropic request body.
+
+        Parses the JSON body and extracts:
+        - ``messages``: Concatenated content from all messages.
+        - ``system``: System prompt (top-level field).
+        - ``content``: All user/assistant message content concatenated.
+        - ``model``: Model name if present.
+
+        When ``seen_count`` is provided, only messages at index
+        ``seen_count`` and beyond are extracted (delta scanning).
+
+        Args:
+            body: Raw request body bytes.
+            seen_count: Number of messages already scanned.
+
+        Returns:
+            Dictionary of parameter keys to string values.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        data = self._parse_json(body, "request")
+
+        if not isinstance(data, dict):
+            return {}
+
+        params: dict[str, str] = {}
+
+        # Anthropic system prompt is a top-level field
+        system = data.get("system")
+        system_text = self._extract_system(system)
+        if system_text:
+            params["system"] = system_text
+
+        # Messages array
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            if seen_count is not None and seen_count > 0:
+                messages = messages[seen_count:]
+
+            all_content: list[str] = []
+
+            for msg in messages:
+                if not isinstance(msg, dict):
+                    continue
+                content = self._extract_content(msg.get("content"))
+                if content:
+                    all_content.append(content)
+
+            if all_content:
+                params["messages"] = "\n".join(all_content)
+                params["content"] = "\n".join(all_content)
+
+        model = data.get("model")
+        if isinstance(model, str) and model:
+            params["model"] = model
+
+        return params
+
+    def extract_response_params(self, body: bytes) -> dict[str, str]:
+        """Extract scannable parameters from an Anthropic response.
+
+        Parses the JSON body and extracts:
+        - ``content``: Generated text from content blocks.
+
+        Args:
+            body: Raw response body bytes.
+
+        Returns:
+            Dictionary of parameter keys to string values.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        data = self._parse_json(body, "response")
+
+        if not isinstance(data, dict):
+            return {}
+
+        params: dict[str, str] = {}
+
+        content = data.get("content")
+        if isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str) and text:
+                        parts.append(text)
+            if parts:
+                params["content"] = "\n".join(parts)
+
+        return params
+
+    def extract_stream_content(self, data_str: str) -> list[str]:
+        """Extract content from a streaming SSE data payload.
+
+        Handles the Anthropic streaming format where content arrives
+        in ``content_block_delta`` events with ``text_delta`` type.
+
+        Args:
+            data_str: The JSON string after ``data: `` prefix.
+
+        Returns:
+            List of content strings found (may be empty).
+        """
+        parts: list[str] = []
+
+        try:
+            data = json.loads(data_str)
+        except (json.JSONDecodeError, ValueError):
+            return parts
+
+        if not isinstance(data, dict):
+            return parts
+
+        # Only content_block_delta with text_delta carries content
+        if data.get("type") != "content_block_delta":
+            return parts
+
+        delta = data.get("delta")
+        if not isinstance(delta, dict):
+            return parts
+
+        if delta.get("type") != "text_delta":
+            return parts
+
+        text = delta.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+
+        return parts
+
+    @staticmethod
+    def _parse_json(body: bytes, context: str) -> Any:
+        """Parse JSON from body bytes.
+
+        Args:
+            body: Raw bytes.
+            context: Description for error messages.
+
+        Returns:
+            Parsed JSON value.
+
+        Raises:
+            ValueError: If the body is not valid JSON.
+        """
+        try:
+            return json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            msg = f"Invalid JSON {context} body: {e}"
+            raise ValueError(msg) from e
+
+    @staticmethod
+    def _extract_system(system: Any) -> str:
+        """Extract text from the top-level system field.
+
+        Handles both string and structured block formats.
+
+        Args:
+            system: System prompt — string, list of blocks, or None.
+
+        Returns:
+            Extracted text, or empty string.
+        """
+        if isinstance(system, str):
+            return system
+        if isinstance(system, list):
+            parts: list[str] = []
+            for block in system:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "\n".join(parts)
+        return ""
+
+    @staticmethod
+    def _extract_content(content: Any) -> str:
+        """Extract text from a message content field.
+
+        Handles string content and structured content blocks
+        (list of dicts with type/text).
+
+        Args:
+            content: Message content — string, list, or None.
+
+        Returns:
+            Extracted text as a string, or empty string.
+        """
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "\n".join(parts)
+        return ""

--- a/tests/unit/test_provider_anthropic.py
+++ b/tests/unit/test_provider_anthropic.py
@@ -1,0 +1,451 @@
+"""Tests for Anthropic API format provider adapter.
+
+Covers:
+- Provider name and protocol compliance
+- Request parameter extraction (system, messages, content, model)
+- Structured content blocks (text, tool_use, tool_result)
+- Delta scanning (seen_count)
+- Response parameter extraction
+- Streaming SSE content extraction (content_block_delta, message_stop)
+- Edge cases: empty bodies, malformed JSON, missing fields
+- Provider registry integration
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentguard.proxy.providers import Provider
+
+
+class TestAnthropicProviderProtocol:
+    """Verify AnthropicProvider satisfies the Provider protocol."""
+
+    def test_is_provider_instance(self) -> None:
+        from agentguard.proxy.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        assert isinstance(provider, Provider)
+
+    def test_name_is_anthropic(self) -> None:
+        from agentguard.proxy.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        assert provider.name == "anthropic"
+
+
+class TestExtractRequestParams:
+    """Tests for extract_request_params on Anthropic Messages API format."""
+
+    def _provider(self):
+        from agentguard.proxy.providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider()
+
+    def test_simple_user_message(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [
+                    {"role": "user", "content": "Hello, Claude!"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "messages" in params
+        assert "Hello, Claude!" in params["messages"]
+        assert "content" in params
+        assert "Hello, Claude!" in params["content"]
+        assert params["model"] == "claude-sonnet-4-20250514"
+
+    def test_system_prompt_as_string(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "system": "You are a helpful assistant.",
+                "messages": [
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert params["system"] == "You are a helpful assistant."
+        assert "system" not in params.get("content", "")
+
+    def test_system_prompt_as_blocks(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "system": [
+                    {"type": "text", "text": "You are a coding assistant."},
+                    {"type": "text", "text": "Be concise."},
+                ],
+                "messages": [
+                    {"role": "user", "content": "Help me"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "You are a coding assistant." in params["system"]
+        assert "Be concise." in params["system"]
+
+    def test_structured_content_blocks(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Analyze this code"},
+                            {"type": "text", "text": "def foo(): pass"},
+                        ],
+                    },
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "Analyze this code" in params["messages"]
+        assert "def foo(): pass" in params["messages"]
+
+    def test_multi_turn_conversation(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [
+                    {"role": "user", "content": "First message"},
+                    {"role": "assistant", "content": "Response"},
+                    {"role": "user", "content": "Second message"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "First message" in params["messages"]
+        assert "Response" in params["messages"]
+        assert "Second message" in params["messages"]
+
+    def test_delta_scanning_with_seen_count(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [
+                    {"role": "user", "content": "Old message"},
+                    {"role": "assistant", "content": "Old response"},
+                    {"role": "user", "content": "New message"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body, seen_count=2)
+        assert "Old message" not in params.get("messages", "")
+        assert "Old response" not in params.get("messages", "")
+        assert "New message" in params["messages"]
+
+    def test_seen_count_none_extracts_all(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [
+                    {"role": "user", "content": "First"},
+                    {"role": "user", "content": "Second"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "First" in params["messages"]
+        assert "Second" in params["messages"]
+
+    def test_tool_use_and_tool_result_blocks(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Let me check."},
+                            {
+                                "type": "tool_use",
+                                "id": "tool_1",
+                                "name": "calculator",
+                                "input": {"expr": "2+2"},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "tool_1",
+                                "content": "4",
+                            },
+                        ],
+                    },
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "Let me check." in params["messages"]
+
+    def test_empty_messages_array(self) -> None:
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "messages" not in params
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            self._provider().extract_request_params(b"not json")
+
+    def test_non_dict_body_returns_empty(self) -> None:
+        body = json.dumps([1, 2, 3]).encode()
+        params = self._provider().extract_request_params(body)
+        assert params == {}
+
+    def test_no_model_field(self) -> None:
+        body = json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        assert "model" not in params
+
+    def test_messages_key_includes_all_content(self) -> None:
+        """messages key should contain ALL message content."""
+        body = json.dumps(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "system": "Be helpful.",
+                "messages": [
+                    {"role": "user", "content": "User text"},
+                    {"role": "assistant", "content": "Assistant text"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_request_params(body)
+        # messages key should have message content (not system)
+        assert "User text" in params["messages"]
+        assert "Assistant text" in params["messages"]
+        # system should be separate
+        assert params["system"] == "Be helpful."
+
+
+class TestExtractResponseParams:
+    """Tests for extract_response_params on Anthropic response format."""
+
+    def _provider(self):
+        from agentguard.proxy.providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider()
+
+    def test_simple_text_response(self) -> None:
+        body = json.dumps(
+            {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Hello! How can I help?"},
+                ],
+                "stop_reason": "end_turn",
+            }
+        ).encode()
+        params = self._provider().extract_response_params(body)
+        assert params["content"] == "Hello! How can I help?"
+
+    def test_multi_block_response(self) -> None:
+        body = json.dumps(
+            {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Here is the code:"},
+                    {"type": "text", "text": "def foo(): pass"},
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_response_params(body)
+        assert "Here is the code:" in params["content"]
+        assert "def foo(): pass" in params["content"]
+
+    def test_tool_use_response(self) -> None:
+        body = json.dumps(
+            {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me look that up."},
+                    {
+                        "type": "tool_use",
+                        "id": "tool_1",
+                        "name": "search",
+                        "input": {"query": "test"},
+                    },
+                ],
+            }
+        ).encode()
+        params = self._provider().extract_response_params(body)
+        assert "Let me look that up." in params["content"]
+
+    def test_empty_content_array(self) -> None:
+        body = json.dumps(
+            {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+            }
+        ).encode()
+        params = self._provider().extract_response_params(body)
+        assert "content" not in params
+
+    def test_no_content_field(self) -> None:
+        body = json.dumps(
+            {
+                "id": "msg_123",
+                "type": "message",
+            }
+        ).encode()
+        params = self._provider().extract_response_params(body)
+        assert params == {}
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            self._provider().extract_response_params(b"bad json")
+
+    def test_non_dict_body_returns_empty(self) -> None:
+        body = json.dumps("just a string").encode()
+        params = self._provider().extract_response_params(body)
+        assert params == {}
+
+
+class TestExtractStreamContent:
+    """Tests for extract_stream_content on Anthropic streaming format."""
+
+    def _provider(self):
+        from agentguard.proxy.providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider()
+
+    def test_content_block_delta_text(self) -> None:
+        data = json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == ["Hello"]
+
+    def test_message_start_returns_empty(self) -> None:
+        data = json.dumps(
+            {
+                "type": "message_start",
+                "message": {"id": "msg_1", "type": "message"},
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == []
+
+    def test_content_block_start_returns_empty(self) -> None:
+        data = json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == []
+
+    def test_content_block_stop_returns_empty(self) -> None:
+        data = json.dumps(
+            {
+                "type": "content_block_stop",
+                "index": 0,
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == []
+
+    def test_message_stop_returns_empty(self) -> None:
+        data = json.dumps(
+            {
+                "type": "message_stop",
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == []
+
+    def test_message_delta_returns_empty(self) -> None:
+        data = json.dumps(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == []
+
+    def test_invalid_json_returns_empty(self) -> None:
+        parts = self._provider().extract_stream_content("not json")
+        assert parts == []
+
+    def test_non_dict_returns_empty(self) -> None:
+        parts = self._provider().extract_stream_content(json.dumps([1, 2]))
+        assert parts == []
+
+    def test_tool_use_delta_returns_empty(self) -> None:
+        data = json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": '{"key":',
+                },
+            }
+        )
+        parts = self._provider().extract_stream_content(data)
+        assert parts == []
+
+
+class TestRegistryIntegration:
+    """Test that Anthropic provider is registered properly."""
+
+    def test_anthropic_in_provider_list(self) -> None:
+        import agentguard.proxy.providers as mod
+        from agentguard.proxy.providers import list_providers
+
+        # Reset registry to pick up new provider
+        mod._registry = None
+        providers = list_providers()
+        assert "anthropic" in providers
+
+    def test_get_provider_returns_anthropic(self) -> None:
+        import agentguard.proxy.providers as mod
+        from agentguard.proxy.providers import get_provider
+
+        mod._registry = None
+        provider = get_provider("anthropic")
+        assert provider.name == "anthropic"
+
+    def test_detect_provider_by_name(self) -> None:
+        import agentguard.proxy.providers as mod
+        from agentguard.proxy.providers import detect_provider
+
+        mod._registry = None
+        provider = detect_provider(provider_name="anthropic")
+        assert provider.name == "anthropic"


### PR DESCRIPTION
## Summary

- Add `AnthropicProvider` for the Anthropic `/v1/messages` API format (Claude family)
- Implements the `Provider` protocol: request/response parsing and streaming content extraction
- Registered in provider registry alongside OpenAI — zero external dependencies

## Design

The Anthropic Messages API differs structurally from OpenAI:

| Feature | OpenAI | Anthropic |
|---------|--------|-----------|
| System prompt | `messages[{role: "system"}]` | Top-level `system` field |
| Response | `choices[].message.content` | Top-level `content[]` array |
| Streaming | `choices[].delta.content` | `content_block_delta` events |
| Content format | String or blocks | String or typed blocks |
| Stream end | `[DONE]` marker | `message_stop` event |

### Usage

```python
from agentguard.proxy.providers import get_provider, detect_provider

# Explicit lookup
provider = get_provider("anthropic")

# Or via detect_provider
provider = detect_provider(provider_name="anthropic")

# Use with proxy middleware
config = ProxyConfig(target="https://api.anthropic.com", provider="anthropic")
```

## Files Changed

- **New:** `src/agentguard/proxy/providers/anthropic.py` — AnthropicProvider class
- **Modified:** `src/agentguard/proxy/providers/__init__.py` — Registry entry
- **New:** `tests/unit/test_provider_anthropic.py` — 34 tests

## Testing

All tests pass locally across the full suite. mypy strict and ruff clean.