### PR TITLE
feat: add unified audit across proxy and MCP server

### DIFF
--- a/src/agentguard/audit/__init__.py
+++ b/src/agentguard/audit/__init__.py
@@ -6,17 +6,37 @@ from agentguard.audit.models import AuditEntry
 from agentguard.audit.report import CrossSessionReport, generate_cross_session_report
 from agentguard.audit.retention import RetentionConfig, enforce_retention
 from agentguard.audit.rotation import RotationConfig
+from agentguard.audit.unified import (
+    SOURCE_METADATA_KEY,
+    ActionType,
+    FilterDirection,
+    Source,
+    SourceAuditLog,
+    classify_direction,
+    default_audit_dir,
+    inject_source_metadata,
+    query_directory,
+)
 
 __all__ = [
     "CSV_COLUMNS",
+    "SOURCE_METADATA_KEY",
+    "ActionType",
     "AuditEntry",
     "AuditLog",
     "CrossSessionReport",
+    "FilterDirection",
     "RetentionConfig",
     "RotationConfig",
+    "Source",
+    "SourceAuditLog",
+    "classify_direction",
+    "default_audit_dir",
     "enforce_retention",
     "export_csv",
     "export_json",
     "export_sqlite",
     "generate_cross_session_report",
+    "inject_source_metadata",
+    "query_directory",
 ]

--- a/src/agentguard/audit/unified.py
+++ b/src/agentguard/audit/unified.py
@@ -1,0 +1,295 @@
+"""Unified audit across proxy and MCP server.
+
+Provides shared action type constants, source identification,
+filter direction classification, and cross-component querying
+so that audit entries from both the proxy and MCP server can be
+analyzed together.
+
+Public API:
+- ``ActionType`` — Enum of all known audit action types.
+- ``Source`` — Constants for component source identifiers.
+- ``SOURCE_METADATA_KEY`` — Metadata key used for source tracking.
+- ``FilterDirection`` — Enum for traffic direction classification.
+- ``classify_direction(action)`` — Map action to filter direction.
+- ``query_directory(...)`` — Query entries across all sessions.
+- ``default_audit_dir(...)`` — Resolve ``AGENTGUARD_AUDIT_DIR``.
+- ``inject_source_metadata(...)`` — Add source to metadata dict.
+- ``SourceAuditLog`` — AuditLog subclass that auto-injects source.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentguard.audit.log import AuditLog
+
+if TYPE_CHECKING:
+    from agentguard.audit.models import AuditEntry
+
+
+# ---------------------------------------------------------------------------
+# Action types
+# ---------------------------------------------------------------------------
+
+
+class ActionType(Enum):
+    """Known audit action types across all AgentGuard components.
+
+    Proxy actions record LLM API interactions.  MCP server actions
+    record tool execution events.
+    """
+
+    # Proxy actions
+    LLM_REQUEST = "llm_request"
+    LLM_RESPONSE = "llm_response"
+
+    # MCP server actions
+    SHELL_EXECUTE = "shell_execute"
+    FILE_READ = "file_read"
+    FILE_WRITE = "file_write"
+    FILE_EDIT = "file_edit"
+    FILE_GLOB = "file_glob"
+    FILE_GREP = "file_grep"
+    FILE_LIST = "file_list"
+    WEB_FETCH = "web_fetch_js"
+
+
+# ---------------------------------------------------------------------------
+# Source identification
+# ---------------------------------------------------------------------------
+
+SOURCE_METADATA_KEY: str = "source"
+"""Metadata key used to identify which component recorded an entry."""
+
+
+class Source:
+    """Constants for component source identifiers.
+
+    These values are stored under ``SOURCE_METADATA_KEY`` in the
+    entry metadata so that entries self-identify their origin.
+    """
+
+    PROXY: str = "proxy"
+    MCP_SERVER: str = "mcp-server"
+
+
+# ---------------------------------------------------------------------------
+# Filter direction
+# ---------------------------------------------------------------------------
+
+
+class FilterDirection(Enum):
+    """Traffic direction for audit entry classification.
+
+    - **OUTBOUND** — Agent → LLM (requests forwarded to the model).
+    - **INBOUND** — LLM → Agent (responses received from the model).
+    - **LATERAL** — Agent → OS/Tools (file ops, shell, web fetch).
+    """
+
+    OUTBOUND = "outbound"
+    INBOUND = "inbound"
+    LATERAL = "lateral"
+
+
+_DIRECTION_MAP: dict[str, FilterDirection] = {
+    ActionType.LLM_REQUEST.value: FilterDirection.OUTBOUND,
+    ActionType.LLM_RESPONSE.value: FilterDirection.INBOUND,
+}
+
+
+def classify_direction(action: str) -> FilterDirection:
+    """Classify an action type into a filter direction.
+
+    Args:
+        action: Action type string (e.g. ``"llm_request"``).
+
+    Returns:
+        The corresponding :class:`FilterDirection`.  Unknown actions
+        default to ``LATERAL``.
+    """
+    return _DIRECTION_MAP.get(action, FilterDirection.LATERAL)
+
+
+# ---------------------------------------------------------------------------
+# Cross-component querying
+# ---------------------------------------------------------------------------
+
+
+def query_directory(
+    audit_dir: str | Path,
+    *,
+    action: str | None = None,
+    actor: str | None = None,
+    result: str | None = None,
+    source: str | None = None,
+    direction: str | None = None,
+) -> list[AuditEntry]:
+    """Query audit entries across all sessions in a directory.
+
+    Loads every ``.jsonl`` file in *audit_dir* and filters entries
+    with AND-combined criteria.  Supports filtering by source
+    component and traffic direction in addition to the standard
+    action/actor/result filters.
+
+    Args:
+        audit_dir: Directory containing ``.jsonl`` audit files.
+        action: Filter by action type.
+        actor: Filter by actor identifier.
+        result: Filter by result string.
+        source: Filter by source component (e.g. ``"proxy"``).
+        direction: Filter by traffic direction
+            (``"outbound"``, ``"inbound"``, ``"lateral"``).
+
+    Returns:
+        List of matching :class:`AuditEntry` objects from all sessions.
+
+    Raises:
+        FileNotFoundError: If *audit_dir* does not exist.
+    """
+    dir_path = Path(audit_dir)
+    if not dir_path.is_dir():
+        msg = f"Audit directory not found: {dir_path}"
+        raise FileNotFoundError(msg)
+
+    logs = AuditLog.load_directory(audit_dir)
+    entries: list[AuditEntry] = []
+
+    for log in logs:
+        for entry in log.entries:
+            if action is not None and entry.action != action:
+                continue
+            if actor is not None and entry.actor != actor:
+                continue
+            if result is not None and entry.result != result:
+                continue
+            if source is not None:
+                entry_source = (entry.metadata or {}).get(SOURCE_METADATA_KEY)
+                if entry_source != source:
+                    continue
+            if direction is not None:
+                entry_direction = classify_direction(entry.action)
+                if entry_direction.value != direction:
+                    continue
+            entries.append(entry)
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Default audit directory
+# ---------------------------------------------------------------------------
+
+
+def default_audit_dir(fallback: str = "audit_logs") -> Path:
+    """Resolve the default audit directory.
+
+    Reads the ``AGENTGUARD_AUDIT_DIR`` environment variable.
+    Falls back to *fallback* if the variable is not set.
+
+    Args:
+        fallback: Default directory name when the env var is unset.
+
+    Returns:
+        Path to the audit directory.
+    """
+    env = os.environ.get("AGENTGUARD_AUDIT_DIR")
+    if env:
+        return Path(env)
+    return Path(fallback)
+
+
+# ---------------------------------------------------------------------------
+# Source metadata helper
+# ---------------------------------------------------------------------------
+
+
+def inject_source_metadata(
+    metadata: dict[str, str] | None,
+    source: str,
+) -> dict[str, str]:
+    """Add source identification to entry metadata.
+
+    Creates a new dict (never mutates the original) with the
+    ``SOURCE_METADATA_KEY`` set to *source*.  If the key already
+    exists in *metadata*, it is preserved (not overwritten).
+
+    Args:
+        metadata: Existing metadata dict, or None.
+        source: Source identifier (e.g. ``Source.PROXY``).
+
+    Returns:
+        New metadata dict with source included.
+    """
+    result = dict(metadata) if metadata else {}
+    if SOURCE_METADATA_KEY not in result:
+        result[SOURCE_METADATA_KEY] = source
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Source-aware audit log
+# ---------------------------------------------------------------------------
+
+
+class SourceAuditLog(AuditLog):
+    """AuditLog subclass that auto-injects source metadata.
+
+    Drop-in replacement for :class:`AuditLog` that automatically
+    adds ``source`` to the metadata of every recorded entry.  This
+    avoids modifying every ``record()`` call site in the proxy or
+    MCP server.
+
+    Usage::
+
+        log = SourceAuditLog("proxy-abc123", source=Source.PROXY)
+        log.record(action="llm_request", actor="agent",
+                   target="/v1/chat", result="allowed")
+        # Entry metadata will include {"source": "proxy"}
+    """
+
+    def __init__(self, session_id: str, *, source: str) -> None:
+        """Initialize a source-aware audit log.
+
+        Args:
+            session_id: Identifier for this agent session.
+            source: Source component identifier (e.g. ``Source.PROXY``).
+        """
+        super().__init__(session_id)
+        self._source = source
+
+    @property
+    def source(self) -> str:
+        """Return the source component identifier."""
+        return self._source
+
+    def record(
+        self,
+        action: str,
+        actor: str,
+        target: str,
+        result: str,
+        metadata: dict[str, str] | None = None,
+    ) -> AuditEntry:
+        """Record a new audit entry with source automatically injected.
+
+        Args:
+            action: Type of action.
+            actor: Agent identifier.
+            target: What the action targeted.
+            result: Outcome.
+            metadata: Optional additional data.
+
+        Returns:
+            The newly created AuditEntry with source in metadata.
+        """
+        enriched = inject_source_metadata(metadata, self._source)
+        return super().record(
+            action=action,
+            actor=actor,
+            target=target,
+            result=result,
+            metadata=enriched,
+        )

--- a/src/agentguard/mcp/server.py
+++ b/src/agentguard/mcp/server.py
@@ -20,11 +20,12 @@ from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
 
-from agentguard.audit.log import AuditLog
+from agentguard.audit.unified import Source, SourceAuditLog
 from agentguard.policies.builtins import load_all_builtins
 from agentguard.policies.guard import Guard
 
 if TYPE_CHECKING:
+    from agentguard.audit.log import AuditLog
     from agentguard.audit.retention import RetentionConfig
     from agentguard.audit.rotation import RotationConfig
 
@@ -83,7 +84,7 @@ def create_server(
         raise ValueError(msg)
     guard = Guard()
     session_id = f"ag-{uuid.uuid4().hex[:12]}"
-    audit_log = AuditLog(session_id)
+    audit_log: AuditLog = SourceAuditLog(session_id, source=Source.MCP_SERVER)
 
     # --- load policies ------------------------------------------------
     # Policy sources are additive: each enabled source appends its

--- a/src/agentguard/proxy/middleware.py
+++ b/src/agentguard/proxy/middleware.py
@@ -19,13 +19,14 @@ if TYPE_CHECKING:
     from starlette.requests import Request
     from starlette.responses import Response
 
+    from agentguard.audit.log import AuditLog
     from agentguard.proxy.compaction.engine import CompactionEngine
     from agentguard.proxy.config import ProxyConfig
     from agentguard.proxy.providers import Provider
     from agentguard.proxy.routing.classifier import DifficultyClassifier
     from agentguard.proxy.routing.router import Router
 
-from agentguard.audit.log import AuditLog
+from agentguard.audit.unified import Source, SourceAuditLog
 from agentguard.policies.guard import Guard
 from agentguard.proxy.outbound import estimate_tokens
 
@@ -70,7 +71,7 @@ class GuardMiddleware:
         self.provider = self._resolve_provider()
         self._auth_token: str | None = self._load_auth_token()
         self.session_id = f"proxy-{uuid.uuid4().hex[:12]}"
-        self.audit_log = AuditLog(self.session_id)
+        self.audit_log: AuditLog = SourceAuditLog(self.session_id, source=Source.PROXY)
         # Delta scanning: track how many messages have been scanned
         # per conversation, keyed by conversation fingerprint.
         self._seen_messages: dict[str, int] = {}

--- a/tests/unit/test_unified_audit.py
+++ b/tests/unit/test_unified_audit.py
@@ -1,0 +1,463 @@
+"""Tests for unified audit module.
+
+Covers:
+- ActionType enum and classification (proxy, mcp, all)
+- Source constants and metadata injection
+- FilterDirection classification (outbound, inbound, lateral)
+- query_directory for cross-session, cross-component querying
+- default_audit_dir environment variable convention
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentguard.audit.log import AuditLog
+
+# ---------------------------------------------------------------------------
+# ActionType
+# ---------------------------------------------------------------------------
+
+
+class TestActionType:
+    """Verify ActionType enum has correct values and classification."""
+
+    def test_proxy_action_types(self) -> None:
+        from agentguard.audit.unified import ActionType
+
+        assert ActionType.LLM_REQUEST.value == "llm_request"
+        assert ActionType.LLM_RESPONSE.value == "llm_response"
+
+    def test_mcp_action_types(self) -> None:
+        from agentguard.audit.unified import ActionType
+
+        assert ActionType.SHELL_EXECUTE.value == "shell_execute"
+        assert ActionType.FILE_READ.value == "file_read"
+        assert ActionType.FILE_WRITE.value == "file_write"
+        assert ActionType.FILE_EDIT.value == "file_edit"
+        assert ActionType.FILE_GLOB.value == "file_glob"
+        assert ActionType.FILE_GREP.value == "file_grep"
+        assert ActionType.FILE_LIST.value == "file_list"
+        assert ActionType.WEB_FETCH.value == "web_fetch_js"
+
+    def test_all_values_are_unique(self) -> None:
+        from agentguard.audit.unified import ActionType
+
+        values = [a.value for a in ActionType]
+        assert len(values) == len(set(values))
+
+
+# ---------------------------------------------------------------------------
+# Source constants
+# ---------------------------------------------------------------------------
+
+
+class TestSource:
+    """Verify Source constants."""
+
+    def test_source_proxy(self) -> None:
+        from agentguard.audit.unified import Source
+
+        assert Source.PROXY == "proxy"
+
+    def test_source_mcp(self) -> None:
+        from agentguard.audit.unified import Source
+
+        assert Source.MCP_SERVER == "mcp-server"
+
+    def test_source_metadata_key(self) -> None:
+        from agentguard.audit.unified import SOURCE_METADATA_KEY
+
+        assert SOURCE_METADATA_KEY == "source"
+
+
+# ---------------------------------------------------------------------------
+# FilterDirection
+# ---------------------------------------------------------------------------
+
+
+class TestFilterDirection:
+    """Verify FilterDirection enum and classify_direction function."""
+
+    def test_direction_values(self) -> None:
+        from agentguard.audit.unified import FilterDirection
+
+        assert FilterDirection.OUTBOUND.value == "outbound"
+        assert FilterDirection.INBOUND.value == "inbound"
+        assert FilterDirection.LATERAL.value == "lateral"
+
+    def test_classify_llm_request_as_outbound(self) -> None:
+        from agentguard.audit.unified import classify_direction
+
+        assert classify_direction("llm_request").value == "outbound"
+
+    def test_classify_llm_response_as_inbound(self) -> None:
+        from agentguard.audit.unified import classify_direction
+
+        assert classify_direction("llm_response").value == "inbound"
+
+    def test_classify_shell_execute_as_lateral(self) -> None:
+        from agentguard.audit.unified import classify_direction
+
+        assert classify_direction("shell_execute").value == "lateral"
+
+    def test_classify_file_ops_as_lateral(self) -> None:
+        from agentguard.audit.unified import classify_direction
+
+        for action in [
+            "file_read",
+            "file_write",
+            "file_edit",
+            "file_glob",
+            "file_grep",
+            "file_list",
+        ]:
+            assert classify_direction(action).value == "lateral"
+
+    def test_classify_web_fetch_as_lateral(self) -> None:
+        from agentguard.audit.unified import classify_direction
+
+        assert classify_direction("web_fetch_js").value == "lateral"
+
+    def test_classify_unknown_action_as_lateral(self) -> None:
+        from agentguard.audit.unified import classify_direction
+
+        assert classify_direction("custom_action").value == "lateral"
+
+
+# ---------------------------------------------------------------------------
+# query_directory
+# ---------------------------------------------------------------------------
+
+
+class TestQueryDirectory:
+    """Test cross-session, cross-component querying."""
+
+    def _make_log_file(
+        self,
+        tmp_path: Path,
+        session_id: str,
+        entries: list[dict[str, Any]],
+    ) -> Path:
+        """Create a JSONL audit log file with given entries."""
+        log = AuditLog(session_id)
+        for e in entries:
+            log.record(
+                action=e["action"],
+                actor=e.get("actor", "agent"),
+                target=e.get("target", ""),
+                result=e.get("result", "allowed"),
+                metadata=e.get("metadata"),
+            )
+        path = tmp_path / f"{session_id}.jsonl"
+        log.save(path)
+        return path
+
+    def test_query_all_entries(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        self._make_log_file(
+            tmp_path,
+            "proxy-abc123",
+            [
+                {"action": "llm_request", "metadata": {"source": "proxy"}},
+                {"action": "llm_response", "metadata": {"source": "proxy"}},
+            ],
+        )
+        self._make_log_file(
+            tmp_path,
+            "ag-def456",
+            [
+                {"action": "shell_execute", "metadata": {"source": "mcp-server"}},
+            ],
+        )
+        results = query_directory(tmp_path)
+        assert len(results) == 3
+
+    def test_query_filter_by_action(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        self._make_log_file(
+            tmp_path,
+            "proxy-abc",
+            [
+                {"action": "llm_request"},
+                {"action": "llm_response"},
+            ],
+        )
+        results = query_directory(tmp_path, action="llm_request")
+        assert len(results) == 1
+        assert results[0].action == "llm_request"
+
+    def test_query_filter_by_source(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        self._make_log_file(
+            tmp_path,
+            "proxy-abc",
+            [
+                {"action": "llm_request", "metadata": {"source": "proxy"}},
+            ],
+        )
+        self._make_log_file(
+            tmp_path,
+            "ag-def",
+            [
+                {"action": "shell_execute", "metadata": {"source": "mcp-server"}},
+            ],
+        )
+        results = query_directory(tmp_path, source="proxy")
+        assert len(results) == 1
+        assert results[0].action == "llm_request"
+
+    def test_query_filter_by_direction(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        self._make_log_file(
+            tmp_path,
+            "mixed-session",
+            [
+                {"action": "llm_request"},
+                {"action": "llm_response"},
+                {"action": "shell_execute"},
+                {"action": "file_write"},
+            ],
+        )
+        outbound = query_directory(tmp_path, direction="outbound")
+        assert len(outbound) == 1
+        assert outbound[0].action == "llm_request"
+
+        inbound = query_directory(tmp_path, direction="inbound")
+        assert len(inbound) == 1
+        assert inbound[0].action == "llm_response"
+
+        lateral = query_directory(tmp_path, direction="lateral")
+        assert len(lateral) == 2
+
+    def test_query_filter_by_result(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        self._make_log_file(
+            tmp_path,
+            "session-1",
+            [
+                {"action": "llm_request", "result": "allowed"},
+                {"action": "llm_request", "result": "denied"},
+            ],
+        )
+        denied = query_directory(tmp_path, result="denied")
+        assert len(denied) == 1
+        assert denied[0].result == "denied"
+
+    def test_query_combined_filters(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        self._make_log_file(
+            tmp_path,
+            "proxy-1",
+            [
+                {
+                    "action": "llm_request",
+                    "result": "denied",
+                    "metadata": {"source": "proxy"},
+                },
+                {
+                    "action": "llm_request",
+                    "result": "allowed",
+                    "metadata": {"source": "proxy"},
+                },
+            ],
+        )
+        self._make_log_file(
+            tmp_path,
+            "ag-1",
+            [
+                {
+                    "action": "shell_execute",
+                    "result": "denied",
+                    "metadata": {"source": "mcp-server"},
+                },
+            ],
+        )
+        results = query_directory(
+            tmp_path,
+            source="proxy",
+            result="denied",
+        )
+        assert len(results) == 1
+        assert results[0].action == "llm_request"
+        assert results[0].result == "denied"
+
+    def test_query_empty_directory(self, tmp_path: Path) -> None:
+        from agentguard.audit.unified import query_directory
+
+        results = query_directory(tmp_path)
+        assert results == []
+
+    def test_query_nonexistent_directory_raises(self) -> None:
+        from agentguard.audit.unified import query_directory
+
+        with pytest.raises(FileNotFoundError):
+            query_directory("/nonexistent/path/that/does/not/exist")
+
+
+# ---------------------------------------------------------------------------
+# default_audit_dir
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultAuditDir:
+    """Test AGENTGUARD_AUDIT_DIR convention."""
+
+    def test_returns_env_var_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from agentguard.audit.unified import default_audit_dir
+
+        monkeypatch.setenv("AGENTGUARD_AUDIT_DIR", "/custom/audit")
+        assert default_audit_dir() == Path("/custom/audit")
+
+    def test_returns_fallback_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from agentguard.audit.unified import default_audit_dir
+
+        monkeypatch.delenv("AGENTGUARD_AUDIT_DIR", raising=False)
+        result = default_audit_dir()
+        assert result == Path("audit_logs")
+
+    def test_fallback_can_be_customized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from agentguard.audit.unified import default_audit_dir
+
+        monkeypatch.delenv("AGENTGUARD_AUDIT_DIR", raising=False)
+        result = default_audit_dir(fallback="my_logs")
+        assert result == Path("my_logs")
+
+
+# ---------------------------------------------------------------------------
+# inject_source_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestInjectSourceMetadata:
+    """Test the source metadata injection helper."""
+
+    def test_inject_into_none_metadata(self) -> None:
+        from agentguard.audit.unified import inject_source_metadata
+
+        result = inject_source_metadata(None, "proxy")
+        assert result == {"source": "proxy"}
+
+    def test_inject_into_existing_metadata(self) -> None:
+        from agentguard.audit.unified import inject_source_metadata
+
+        meta = {"key": "value"}
+        result = inject_source_metadata(meta, "mcp-server")
+        assert result == {"key": "value", "source": "mcp-server"}
+
+    def test_does_not_overwrite_existing_source(self) -> None:
+        from agentguard.audit.unified import inject_source_metadata
+
+        meta = {"source": "custom"}
+        result = inject_source_metadata(meta, "proxy")
+        assert result["source"] == "custom"
+
+    def test_does_not_mutate_original(self) -> None:
+        from agentguard.audit.unified import inject_source_metadata
+
+        meta = {"key": "value"}
+        result = inject_source_metadata(meta, "proxy")
+        assert "source" not in meta
+        assert "source" in result
+
+
+# ---------------------------------------------------------------------------
+# SourceAuditLog
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAuditLog:
+    """Test SourceAuditLog auto-injection of source metadata."""
+
+    def test_record_injects_source(self) -> None:
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("proxy-test", source="proxy")
+        entry = log.record(
+            action="llm_request",
+            actor="agent",
+            target="/v1/chat",
+            result="allowed",
+        )
+        assert entry.metadata is not None
+        assert entry.metadata["source"] == "proxy"
+
+    def test_record_preserves_existing_metadata(self) -> None:
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("proxy-test", source="proxy")
+        entry = log.record(
+            action="llm_request",
+            actor="agent",
+            target="/v1/chat",
+            result="allowed",
+            metadata={"model": "gpt-4", "token_estimate": "100"},
+        )
+        assert entry.metadata is not None
+        assert entry.metadata["source"] == "proxy"
+        assert entry.metadata["model"] == "gpt-4"
+        assert entry.metadata["token_estimate"] == "100"
+
+    def test_record_does_not_overwrite_explicit_source(self) -> None:
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("proxy-test", source="proxy")
+        entry = log.record(
+            action="llm_request",
+            actor="agent",
+            target="/v1/chat",
+            result="allowed",
+            metadata={"source": "custom-override"},
+        )
+        assert entry.metadata is not None
+        assert entry.metadata["source"] == "custom-override"
+
+    def test_source_property(self) -> None:
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("ag-test", source="mcp-server")
+        assert log.source == "mcp-server"
+
+    def test_is_subclass_of_audit_log(self) -> None:
+        from agentguard.audit.log import AuditLog
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("test", source="proxy")
+        assert isinstance(log, AuditLog)
+
+    def test_entries_are_hash_chained(self) -> None:
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("test", source="proxy")
+        log.record(action="a", actor="agent", target="t", result="allowed")
+        log.record(action="b", actor="agent", target="t", result="allowed")
+        assert log.verify()
+        assert log.entries[1].previous_hash == log.entries[0].entry_hash
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        from agentguard.audit.log import AuditLog
+        from agentguard.audit.unified import SourceAuditLog
+
+        log = SourceAuditLog("proxy-round", source="proxy")
+        log.record(
+            action="llm_request",
+            actor="agent",
+            target="/v1/chat",
+            result="allowed",
+        )
+        path = tmp_path / "proxy-round.jsonl"
+        log.save(path)
+
+        loaded = AuditLog.load(path, "proxy-round")
+        assert len(loaded.entries) == 1
+        assert loaded.entries[0].metadata is not None
+        assert loaded.entries[0].metadata["source"] == "proxy"


### PR DESCRIPTION
## Summary

- Add `agentguard.audit.unified` module for cross-component audit infrastructure
- Wire `SourceAuditLog` into both proxy middleware and MCP server for automatic source tracking
- Export all new types from `agentguard.audit.__init__`

## Design

Both the proxy and MCP server already use the same `AuditLog` and `AuditEntry` types, but lacked:

1. **Source identification** — No way to tell which component generated an entry
2. **Cross-component querying** — `AuditLog.query()` only searches within a single session
3. **Action type constants** — Action strings scattered across codebase
4. **Traffic direction classification** — No outbound/inbound/lateral grouping

### New API

| API | Purpose |
|-----|---------|
| `ActionType` | Enum of all known action types (proxy + MCP) |
| `Source` | Constants: `PROXY`, `MCP_SERVER` |
| `FilterDirection` | Enum: `OUTBOUND`, `INBOUND`, `LATERAL` |
| `classify_direction()` | Map action type to filter direction |
| `query_directory()` | Cross-session querying with source/direction filters |
| `default_audit_dir()` | `AGENTGUARD_AUDIT_DIR` env var convention |
| `inject_source_metadata()` | Non-mutating source metadata injection |
| `SourceAuditLog` | AuditLog subclass with auto source injection |

### Integration

`SourceAuditLog` subclasses `AuditLog` and overrides `record()` to inject source metadata transparently. The proxy and MCP server constructors now use `SourceAuditLog` instead of `AuditLog` — zero changes needed at call sites.

```python
# Proxy middleware (automatic)
self.audit_log = SourceAuditLog(session_id, source=Source.PROXY)

# MCP server (automatic)
audit_log = SourceAuditLog(session_id, source=Source.MCP_SERVER)

# Cross-component querying
from agentguard.audit.unified import query_directory
denied = query_directory("audit_logs/", source="proxy", result="denied")
lateral = query_directory("audit_logs/", direction="lateral")
```

## Files Changed

- **New:** `src/agentguard/audit/unified.py` — Unified audit module
- **Modified:** `src/agentguard/audit/__init__.py` — New exports
- **Modified:** `src/agentguard/proxy/middleware.py` — SourceAuditLog integration
- **Modified:** `src/agentguard/mcp/server.py` — SourceAuditLog integration
- **New:** `tests/unit/test_unified_audit.py` — 35 tests

## Testing

All tests pass locally. mypy strict and ruff clean.