### PR TITLE
fix: update stale docstring/test name and narrow parser return types

### DIFF
--- a/src/agentguard/compliance/eu_ai_act.py
+++ b/src/agentguard/compliance/eu_ai_act.py
@@ -29,10 +29,11 @@ if TYPE_CHECKING:
 class EUAIActReportGenerator:
     """Generate EU AI Act compliance reports from audit logs.
 
-    Analyzes an AuditLog against four key articles of the EU AI Act
+    Analyzes an AuditLog against five key articles of the EU AI Act
     (Regulation 2024/1689) that are most relevant to autonomous AI
     agents:
 
+    - Art. 5/9: Persona safety and risk scoring
     - Art. 9: Risk management (are risks being detected and mitigated?)
     - Art. 12: Logging (are agent actions being recorded?)
     - Art. 13: Transparency (are agents identifiable?)

--- a/src/agentguard/policies/loader.py
+++ b/src/agentguard/policies/loader.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 from datetime import date, time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -24,6 +24,11 @@ from agentguard.policies.models import (
     ScanTarget,
     Severity,
 )
+
+if TYPE_CHECKING:
+    from agentguard.policies.approval import ApprovalPolicy
+    from agentguard.policies.domain_allowlist import DomainAllowlist
+    from agentguard.policies.fs_allowlist import FilesystemAllowlist
 
 
 def load_policy_from_string(yaml_str: str) -> Policy:
@@ -103,7 +108,7 @@ def _parse_policy(data: dict[str, Any]) -> Policy:
     )
 
 
-def _parse_domain_allowlist(data: dict[str, Any]) -> Policy:
+def _parse_domain_allowlist(data: dict[str, Any]) -> DomainAllowlist:
     """Parse a domain_allowlist policy from a YAML dict.
 
     Expected fields:
@@ -131,7 +136,7 @@ def _parse_domain_allowlist(data: dict[str, Any]) -> Policy:
     )
 
 
-def _parse_fs_allowlist(data: dict[str, Any]) -> Policy:
+def _parse_fs_allowlist(data: dict[str, Any]) -> FilesystemAllowlist:
     """Parse a fs_allowlist policy from a YAML dict.
 
     Expected fields:
@@ -159,7 +164,7 @@ def _parse_fs_allowlist(data: dict[str, Any]) -> Policy:
     )
 
 
-def _parse_approval_policy(data: dict[str, Any]) -> Policy:
+def _parse_approval_policy(data: dict[str, Any]) -> ApprovalPolicy:
     """Parse an approval policy from a YAML dict.
 
     Expected fields:

--- a/tests/unit/test_eu_ai_act.py
+++ b/tests/unit/test_eu_ai_act.py
@@ -49,7 +49,7 @@ class TestEUAIActReportGenerator:
         assert report.framework == "EU AI Act"
         assert report.session_id == "test-session"
 
-    def test_report_has_four_sections(self) -> None:
+    def test_report_has_five_sections(self) -> None:
         log = _make_log([{"action": "file_read", "result": "allowed"}])
         generator = EUAIActReportGenerator()
         report = generator.generate(log)


### PR DESCRIPTION
## Summary

- Fix stale docstring and test name in EU AI Act compliance module
- Narrow YAML parser return types for better type specificity

## Changes

- `eu_ai_act.py`: Update docstring from "four key articles" to "five key articles", add Art. 5/9 to the list (Closes #335)
- `test_eu_ai_act.py`: Rename `test_report_has_four_sections` to `test_report_has_five_sections` (Closes #336)
- `loader.py`: Narrow return types of `_parse_domain_allowlist` → `DomainAllowlist`, `_parse_fs_allowlist` → `FilesystemAllowlist`, `_parse_approval_policy` → `ApprovalPolicy` (Closes #318, #322, #325)

All existing tests pass unchanged.