### PR TITLE
feat: add SSE and streamable-http transport to MCP serve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentguard"
-version = "0.2.0"
+version = "0.3.0"
 description = "Safety and audit framework for autonomous AI agents"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/agentguard/cli.py
+++ b/src/agentguard/cli.py
@@ -564,6 +564,24 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Delete oldest rotated logs until total size is under this limit.",
     )
+    serve_parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "streamable-http"],
+        default="stdio",
+        help="MCP transport protocol (default: stdio). Use 'sse' or "
+        "'streamable-http' for persistent HTTP server mode.",
+    )
+    serve_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind to in sse/streamable-http mode (default: 127.0.0.1).",
+    )
+    serve_parser.add_argument(
+        "--port",
+        type=int,
+        default=8021,
+        help="Port to bind to in sse/streamable-http mode (default: 8021).",
+    )
 
     # --- report ---
     report_parser = subparsers.add_parser("report", help="Generate compliance reports.")
@@ -1640,7 +1658,11 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             rotation=rotation,
             retention=retention,
         )
-        app.run()
+        transport = getattr(args, "transport", "stdio")
+        if transport in ("sse", "streamable-http"):
+            app.settings.host = args.host
+            app.settings.port = args.port
+        app.run(transport=transport)
     except ImportError:
         print(
             "Error: MCP dependencies not installed. "

--- a/systemd/agentguard-mcp@.service
+++ b/systemd/agentguard-mcp@.service
@@ -1,0 +1,75 @@
+# AgentGuard MCP Server — systemd user service (SSE transport)
+#
+# Template unit. The instance name selects the protection preset:
+#
+#   systemctl --user start agentguard-mcp@permissive
+#   systemctl --user start agentguard-mcp@balanced
+#   systemctl --user start agentguard-mcp@strict
+#
+# Install:
+#   cp systemd/agentguard-mcp@.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now agentguard-mcp@permissive
+#
+# Configuration:
+#   ~/.config/agentguard/mcp.env    (environment overrides)
+#
+# Logs:
+#   journalctl --user -u agentguard-mcp@permissive -f
+#
+# Connect from opencode.json:
+#   "mcp": {
+#     "agentguard": {
+#       "type": "remote",
+#       "url": "http://127.0.0.1:8021/sse"
+#     }
+#   }
+
+[Unit]
+Description=AgentGuard MCP Server (%i)
+Documentation=https://github.com/Roboter-Schlafen-Nicht/agentguard
+After=network-online.target
+Wants=network-online.target
+
+# Rate-limit restarts: max 5 in 60s
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+
+# Defaults — override in ~/.config/agentguard/mcp.env
+Environment=AGENTGUARD_MCP_PORT=8021
+Environment=AGENTGUARD_MCP_HOST=127.0.0.1
+Environment=AGENTGUARD_ACTOR=opencode-mcp
+Environment=AGENTGUARD_AUDIT_DIR=%h/.local/share/agentguard/audit
+Environment=AGENTGUARD_BIN=/home/human/miniconda3/bin/agentguard
+
+# Load user overrides (file is optional, - prefix means no error if missing)
+EnvironmentFile=-%h/.config/agentguard/mcp.env
+
+ExecStartPre=/bin/mkdir -p ${AGENTGUARD_AUDIT_DIR}
+ExecStart=/bin/bash -c '\
+  PRESET="%i"; \
+  ARGS="--transport sse \
+        --host ${AGENTGUARD_MCP_HOST} \
+        --port ${AGENTGUARD_MCP_PORT} \
+        --audit-dir ${AGENTGUARD_AUDIT_DIR} \
+        --actor ${AGENTGUARD_ACTOR} \
+        --auto-discover"; \
+  if [ "$PRESET" = "builtins" ]; then \
+    exec ${AGENTGUARD_BIN} serve --builtins $ARGS; \
+  else \
+    exec ${AGENTGUARD_BIN} serve --preset $PRESET $ARGS; \
+  fi'
+
+# Restart on crash (not on manual stop)
+Restart=on-failure
+RestartSec=3
+
+# Security hardening (user service — limited options)
+NoNewPrivileges=yes
+PrivateTmp=yes
+
+[Install]
+WantedBy=default.target

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -908,3 +908,82 @@ class TestServeCommand:
         assert exit_code == 0
         call_kwargs = mock_create.call_args[1]
         assert call_kwargs["actor"] == "custom-bot"
+
+    def test_serve_default_transport_is_stdio(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default transport is stdio (backward-compatible)."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli("serve", "--builtins")
+        assert exit_code == 0
+        mock_app.run.assert_called_once_with(transport="stdio")
+
+    def test_serve_sse_transport(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--transport sse starts SSE server on specified host/port."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli(
+            "serve",
+            "--builtins",
+            "--transport",
+            "sse",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9876",
+        )
+        assert exit_code == 0
+        mock_app.run.assert_called_once_with(transport="sse")
+
+    def test_serve_streamable_http_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--transport streamable-http is accepted."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli(
+            "serve",
+            "--builtins",
+            "--transport",
+            "streamable-http",
+        )
+        assert exit_code == 0
+        mock_app.run.assert_called_once_with(transport="streamable-http")
+
+    def test_serve_sse_sets_host_port_on_app(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--host and --port are set on the FastMCP app settings."""
+        from unittest.mock import MagicMock
+
+        mock_app = MagicMock()
+        mock_app.settings = MagicMock()
+        mock_create = MagicMock(return_value=mock_app)
+        monkeypatch.setattr("agentguard.cli.create_server", mock_create)
+
+        exit_code, _, _ = _run_cli(
+            "serve",
+            "--builtins",
+            "--transport",
+            "sse",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9876",
+        )
+        assert exit_code == 0
+        assert mock_app.settings.host == "0.0.0.0"
+        assert mock_app.settings.port == 9876


### PR DESCRIPTION
## Summary

- Add `--transport`, `--host`, `--port` CLI args to `agentguard serve` supporting SSE and streamable-http transports alongside the default stdio
- Enables running AgentGuard as a persistent MCP server that survives long sessions without stdio pipe breakage
- Add systemd template unit (`agentguard-mcp@.service`) for running as a user service with instance-based preset selection (e.g. `agentguard-mcp@permissive`)
- Version bump 0.2.0 → 0.3.0